### PR TITLE
Integrate the project with Codeclimate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
-language: ruby
+env:
+  global:
+    - CC_TEST_REPORTER_ID=9db6462028452d95a747379abb11cd1f15f52499e7327904c50896883fffc2e8
+
+anguage: ruby
 rvm: 2.4.2
 cache: bundler
 
@@ -16,7 +20,18 @@ before_script:
   # Set up Mongo databases
   - mongo waste-carriers-test --eval 'db.createUser({user:"mongoUser", pwd:"password1234", roles:["readWrite", "dbAdmin", "userAdmin"]})'
   - mongo waste-carriers-users-test --eval 'db.createUser({user:"mongoUser", pwd:"password1234", roles:["readWrite", "dbAdmin", "userAdmin"]})'
+  # Setup to support the CodeClimate test coverage submission
+  # As per CodeClimate's documentation, they suggest only running
+  # ./cc-test-reporter commands on travis-ci push builds only. Hence we wrap all
+  # the codeclimate test coverage related commands in a check that tests if we
+  # are in a pull request or not.
+  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter; fi
+  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then chmod +x ./cc-test-reporter; fi
+  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then ./cc-test-reporter before-build; fi
   # Run rubocop. Its installed as a dependency (hence no install step) as this
   # allows projects to control the version they are using (rather than getting)
   # surprise build failures.
   - bundle exec rubocop
+
+after_script:
+  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT; fi


### PR DESCRIPTION
Integration with [Codeclimate](https://codeclimate.com/) allows us to monitor the quality of our code, plus the level of test coverage automatically as part of a CI chain.

This change adds the necessary configuration to allow this to happen.