### PR TITLE
Swap example port for port used in Vagrant env

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Check out [.env.example](/.env.example) for details of what you need in your `.e
 
 Simply start the app using `bundle exec rails s`. If you are in an environment with other Rails apps running you might find the default port of 3000 is in use and so get an error.
 
-If that's the case use `bundle exec rails s -p 3010` swapping `3010` for whatever port you want to use.
+If that's the case use `bundle exec rails s -p 8001` swapping `8001` for whatever port you want to use.
 
 ## Testing the app
 


### PR DESCRIPTION
The Defra development team have a vagrant build for the waste carriers service which uses the port 8001 for the back office.

To keep things consistent for those less familiar with the project internally, this changes tweaks the port number in the README example to use 8001 as well.