### PR TITLE
Standardise environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,10 +29,8 @@ WCRS_TEST_USERSDB_PASSWORD="password1234"
 WCRS_TEST_REGSDB_URL1="localhost:27017"
 
 # Errbit config
-WCRS_BACKOFFICE_USE_AIRBRAKE=true
+WCRS_USE_AIRBRAKE=true
 WCRS_BACKOFFICE_AIRBRAKE_HOST='https://my-errbit-instance.com'
-# This must be a positive integer to validate
-WCRS_BACKOFFICE_AIRBRAKE_PROJECT_ID=1
 WCRS_BACKOFFICE_AIRBRAKE_PROJECT_KEY=longvaluefullofnumbersandlettersinlowercase
 
 # Only required when running the app in production. A default is used in

--- a/.env.example
+++ b/.env.example
@@ -30,7 +30,7 @@ WCRS_TEST_REGSDB_URL1="localhost:27017"
 
 # Errbit config
 WCRS_USE_AIRBRAKE=true
-WCRS_BACKOFFICE_AIRBRAKE_HOST='https://my-errbit-instance.com'
+WCRS_AIRBRAKE_URL='https://my-errbit-instance.com'
 WCRS_BACKOFFICE_AIRBRAKE_PROJECT_KEY=longvaluefullofnumbersandlettersinlowercase
 
 # Only required when running the app in production. A default is used in

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ env:
   global:
     - CC_TEST_REPORTER_ID=9db6462028452d95a747379abb11cd1f15f52499e7327904c50896883fffc2e8
 
-anguage: ruby
+language: ruby
 rvm: 2.4.2
 cache: bundler
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -34,13 +34,14 @@ module EntityMatchingService
     # API specification and provide the gem, but we choose instead to send
     # notifications to an instance of Errbit we manage ourselves
     # (cause its free!)
-    config.airbrake_on = ENV["WCRS_BACKOFFICE_USE_AIRBRAKE"] == "true" ? true : false
+    config.airbrake_on = ENV["WCRS_USE_AIRBRAKE"] == "true" ? true : false
     config.airbrake_host = ENV["WCRS_BACKOFFICE_AIRBRAKE_HOST"]
     # Even though we may not want to enable airbrake, its initializer requires
-    # a value for project ID and key else it errors. So to simplify local
-    # development we default these values to save having to set anything in the
-    # .env file.
-    config.airbrake_id = ENV["WCRS_BACKOFFICE_AIRBRAKE_PROJECT_ID"] || 1
+    # a value for project ID and key else it errors.
+    # Furthermore Errbit (which we send the exceptions to) doesn't make use of
+    # the project ID, but it still has to be set to a positive integer or
+    # Airbrake errors. Hence we just set it to 1.
+    config.airbrake_id = 1
     config.airbrake_key = ENV["WCRS_BACKOFFICE_AIRBRAKE_PROJECT_KEY"] || "dummy"
 
     config.generators do |g|

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,7 +35,7 @@ module EntityMatchingService
     # notifications to an instance of Errbit we manage ourselves
     # (cause its free!)
     config.airbrake_on = ENV["WCRS_USE_AIRBRAKE"] == "true" ? true : false
-    config.airbrake_host = ENV["WCRS_BACKOFFICE_AIRBRAKE_HOST"]
+    config.airbrake_host = ENV["WCRS_AIRBRAKE_URL"]
     # Even though we may not want to enable airbrake, its initializer requires
     # a value for project ID and key else it errors.
     # Furthermore Errbit (which we send the exceptions to) doesn't make use of


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-281

To remove any confusion and help standardise usage of environment variables across Waste Carriers the changes here are to bring the project inline with the other apps, and to help remove duplication where possible.