### PR TITLE
Sync dev and test secret keys across WCR service

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -11,10 +11,10 @@
 # if you're sharing your code publicly.
 
 development:
-  secret_key_base: 795bb39d72d2ccfe9b1d033c8bc5380f21daca0fc61e2ed9bc75481799ef8ea926e8b15d24dfc9c0dd23c5662c7e712c8535d8b431cd78d3ef25ad16afcf0e74
+  secret_key_base: 71ea996f1ac55f87a94b50feb9fab21ca967c76db775d9fe1c778239574bf9a0ad5138e431837d2eb23ee70e49f0aa2771c03f3b35de3d8d165a4669ac398d09
 
 test:
-  secret_key_base: 461c07a73cc5ce47f8408295abc0f46ebf8992e8866db223ee66643e11b341a015e38f5ff61207cea564f29f946f90f462be580383f7058970d0d1ae0984c102
+  secret_key_base: d01c13394bdd899925685e0a860cdb68116421e4f53bde1d28ebad428334703d3713982d85c4be68b295e50a7155087ae140b47fc90d6155b69783c156a82800
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.


### PR DESCRIPTION
In order for authentication to work across the apps the secret keys used need to be the same.

Currently this project is out of sync with the others so this change ensures the DEV and TEST secret keys are the same as in other projects.