### PR TITLE
Fix changelog generator breaking deploy to heroku

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,17 @@ gem "passenger", "~> 5.0", ">= 5.0.30", require: "phusion_passenger/rack_handler
 gem "waste_carriers_engine",
     git: "https://github.com/DEFRA/waste-carriers-renewals"
 
+# Allows us to automatically generate the change log from the tags, issues,
+# labels and pull requests on GitHub. Added as a dependency so all dev's have
+# access to it to generate a log, and so they are using the same version.
+# New dev's should first create GitHub personal app token and add it to their
+# ~/.bash_profile (or equivalent)
+# https://github.com/skywinder/github-changelog-generator#github-token
+# Then simply run `bundle exec rake changelog` to update CHANGELOG.md
+# Should be in the :development group however when it is it breaks deployment
+# to Heroku. Hence moved outside group till we can understand why.
+gem "github_changelog_generator", require: false
+
 group :development, :test do
   # Call "byebug" anywhere in the code to stop execution and get a debugger console
   gem "byebug"
@@ -61,14 +72,6 @@ group :development, :test do
 end
 
 group :development do
-  # Allows us to automatically generate the change log from the tags, issues,
-  # labels and pull requests on GitHub. Added as a dependency so all dev's have
-  # access to it to generate a log, and so they are using the same version.
-  # New dev's should first create GitHub personal app token and add it to their
-  # ~/.bash_profile (or equivalent)
-  # https://github.com/skywinder/github-changelog-generator#github-token
-  # Then simply run `bundle exec rake changelog` to update CHANGELOG.md
-  gem "github_changelog_generator"
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem "spring"
   # Access an IRB console on exception pages or by using <%= console %> in views


### PR DESCRIPTION
When attempting to deploy the app to Heroku we started getting this error

```bash
/app/tmp/buildpacks/f6d48d8a14fccbb19c0c0402fca224929d18e9ee042b3e204bc5992612e990d3b3a0fb1f9627b1a3bae11e9fa20dffc96e136bd734a2f3cf92a0d05bedd42cfe/lib/language_pack/helpers/rake_runner.rb:106:in `load_rake_tasks!': Could not detect rake tasks (LanguagePack::Helpers::RakeRunner::CannotLoadRakefileError)
ensure you can run `$ bundle exec rake -P` against your app
and using the production group of your Gemfile.
rake aborted!
LoadError: cannot load such file -- github_changelog_generator/task
```

We believe its because Heroku starts the app in Production mode, and has no environment loaded when running `bundle exec rake -P`.