### PR TITLE
Set secret_key_base when run under prod & rake

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -33,8 +33,12 @@ module EntityMatchingService
     # assets:precompile is being run and therefore programmtically set the
     # secret key, stopping devise from erroring.
     # https://stackoverflow.com/a/15767148/6117745
-    if Rails.env.production? && File.basename($0) == "rake"
-      config.secret_key_base = "iamonlyherefordeviseduringassetcompilation"
+    def apply_dummy_secret_key?
+      return false unless Rails.env.production?
+      return false unless File.basename($0) == "rake"
+      return false unless config.secret_key_base.blank?
+
+      true
     end
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
@@ -103,5 +107,7 @@ module EntityMatchingService
     config.generators do |g|
       g.orm :mongoid
     end
+
+    config.secret_key_base = "iamonlyherefordevisewhenraketasksarecalled" if apply_dummy_secret_key?
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -21,6 +21,22 @@ module EntityMatchingService
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
 
+    # We have an issue when deploying to our environments in that when
+    # Capistrano runs the deploy:assets:precompile step (specifically bundle
+    # exec rake assets:precompile) it does so having set RAILS_ENV to production.
+    # However we have no default value for the SECRET_KEY in production, and
+    # when the command runs an env var with the value has not been set. This
+    # causes Devise to throw an error which prevents the task from completing.
+    # We have found the simplest solution to the problem is to add this logic
+    # which determines if we are running in production and if the originating
+    # call was made from rake. If that's the case we can assume a task like
+    # assets:precompile is being run and therefore programmtically set the
+    # secret key, stopping devise from erroring.
+    # https://stackoverflow.com/a/15767148/6117745
+    if Rails.env.production? && File.basename($0) == "rake"
+      config.secret_key_base = "iamonlyherefordeviseduringassetcompilation"
+    end
+
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
     config.time_zone = "UTC"


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-133
https://eaflood.atlassian.net/browse/WC-161

This change resolves an issue that has arisen when we come to try and deploy the project in our environments (not local dev).

We are using [Capistrano](https://github.com/capistrano/capistrano) to deploy the project onto our servers, and the [Capistrano-rails](https://github.com/capistrano/rails) plugin which handles rails specific tasks. The issue in our case is asset compilation.

When Capistrano is run its from the context of a Jenkins instance, and it is making an ssh call to the target instances. In this case the command its running is `$HOME/.rbenv/bin/rbenv exec bundle exec rake assets:precompile`. Run in local dev that is fine, but when run in our environment we get an error

```
Caused by:
Devise.secret_key was not set. Please add the following to your Devise initializer:

  config.secret_key =                                                                                  'db3e8d64661d4adcba523726556e95489c64c90f2d273e7f67f68b879cd875f3170ff5b33f8e143d8a969c2154c0acb49ca2a4867a095d31d47a4cbb698e21a6'
```

Essentially calling this command is starting an instance of rails, and Devise is throwing an issue because it cannot identify a SECRET_KEY to use. This is correct in the context of our environments, because the env vars that configure the app and include a SECRET_KEY do not exist in the shell session being run when `assets:precompile` is called. It exists in local dev because we have a default key when the app is run in development and test modes. We don't have a default when its run in production mode.

Looking into solutions they essentially fall into 3

- **Update your deployment to ensure a SECRET_KEY exists.** This is not practical in our case. We don't want to create one process for this value, and another for all the other env vars and apps we deploy, and we have no scope to change the way we do deployments.
- **Create your own custom Capistrano task to handle asset compilation.** Using this we could then alter the command to be `SECRET_KEY=foo $HOME/.rbenv/bin/rbenv exec bundle exec rake assets: precompile`. However it then means we are maintaining our own custom task for something that is pretty much a standard of Capistrano rails deployments, and its on us to ensure its plugged into the correct  step of the deployment, plus be aware of any changes in how asset compilation is done.
- **Set a default SECRET_KEY for production.** Convention is to not have a default, and definitely never to check the key into your repo. However this is the simplest solution to the problem, and means we do not have to try and change how apps are deployed.

So based on this we're implementing option 3. We initially looked at setting a default value in `secrets.yml` and then aborting if it was used in production mode. However on reflection that was foolish because with no SECRET_KEY_BASE env var and always running in production, we would always end up calling abort even when trying to compile the assets.

So instead we found a solution based on being able to tell

- we are running in production
- we were started by rake

If this is the situation, logic in `config/application.rb` sets `config.secret_key_base` to a dummy value. This stops Devise from erroring and allows the asset compilation to complete.