### PR TITLE
Add branch to WCR renewals Gemfile entry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,8 @@ gem "passenger", "~> 5.0", ">= 5.0.30", require: "phusion_passenger/rack_handler
 
 # Use the waste carriers engine for the user journey
 gem "waste_carriers_engine",
-    git: "https://github.com/DEFRA/waste-carriers-renewals"
+    git: "https://github.com/DEFRA/waste-carriers-renewals",
+    branch: "master"
 
 # Allows us to automatically generate the change log from the tags, issues,
 # labels and pull requests on GitHub. Added as a dependency so all dev's have

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-renewals
-  revision: ced04a041e0c53c779f01f456ca0c34524a61ed6
+  revision: d0281f2880808ae704d2bf514a140ee90ab03eee
+  branch: master
   specs:
     waste_carriers_engine (0.0.1)
       aasm (~> 4.12)


### PR DESCRIPTION
Now that the project is an engine and which we reference in the front-office and back-office apps when developing locally we often need to make changes to this project, which we want to see in the apps when run.

To support this we can use a feature in bundler to tell it that a gem is actually stored locally, rather than always pulling from the original source; `bundle config --local local.my_gem`.

However this option is only supported if a branch has also been defined in the entry. We also believe its useful to specify the branch in the gemfile, so other developers can be clear on what is being referenced in the source repo.

N.B. For more details on local gem config see

https://cruikshanks.co.uk/blog/local-gems-for-local-projects/
https://rossta.net/blog/how-to-specify-local-ruby-gems-in-your-gemfile.html