### PR TITLE
Move dashboard to /bo

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,9 @@
 Rails.application.routes.draw do
   mount WasteCarriersEngine::Engine => "/bo"
 
-  resource :dashboards, only: :index
+  get "/bo" => "dashboards#index"
 
-  root "dashboards#index"
+  root "waste_carriers_engine/registrations#index"
 
   devise_for :users, path: "/bo/users", path_names: { sign_in: "sign_in", sign_out: "sign_out" }
 end

--- a/spec/requests/dashboards_spec.rb
+++ b/spec/requests/dashboards_spec.rb
@@ -3,14 +3,14 @@
 require "rails_helper"
 
 RSpec.describe "Dashboards", type: :request do
-  describe "root" do
+  describe "/bo" do
     it "renders the index template" do
-      get "/"
+      get "/bo"
       expect(response).to render_template(:index)
     end
 
     it "returns a 200 response" do
-      get "/"
+      get "/bo"
       expect(response).to have_http_status(200)
     end
   end


### PR DESCRIPTION
This follows on from https://github.com/DEFRA/waste-carriers-back-office/pull/48

We need to mount the dashboard at /bo so our routing for different applications can be easily configured.

The temporary registrations list page then becomes the root, as this is useful for local testing but won't be accessible in production.