### PR TITLE
Set the host in application config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# Environment variables for the waste-carriers-backoffice.
+# Environment variables for the waste-carriers-back-office.
 #
 # Many of these variables have suitable defaults built-in to the application,
 # but we list them here for completeness and ease-of-editing.

--- a/config/application.rb
+++ b/config/application.rb
@@ -75,8 +75,10 @@ module WasteCarriersBackOffice
     # Paths
     config.wcrs_renewals_url = ENV["WCRS_RENEWALS_DOMAIN"] || "http://localhost:3002"
     config.wcrs_frontend_url = ENV["WCRS_FRONTEND_DOMAIN"] || "http://localhost:3000"
+    config.wcrs_back_office_url = ENV["WCRS_BACK_OFFICE_DOMAIN"] || "http://localhost:8001"
     config.wcrs_services_url = ENV["WCRS_SERVICES_DOMAIN"] || "http://localhost:8003"
     config.os_places_service_url = ENV["WCRS_OS_PLACES_DOMAIN"] || "http://localhost:8005"
+    config.host = config.wcrs_back_office_url
 
     # Fees
     config.renewal_charge = ENV["WCRS_RENEWAL_CHARGE"].to_i


### PR DESCRIPTION
This is to improve the way we generate WorldPay success and failure URLs in the engine. See https://github.com/DEFRA/waste-carriers-renewals/pull/231