### PR TITLE
Set up users for the back office

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -3,8 +3,8 @@
 class Ability
   include CanCan::Ability
 
-  def initialize(user)
-    can :read, WasteCarriersEngine::Registration, account_email: user.email
-    can :manage, WasteCarriersEngine::TransientRegistration, account_email: user.email
+  def initialize(_user)
+    can :read, WasteCarriersEngine::Registration
+    can :manage, WasteCarriersEngine::TransientRegistration
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User
   include Mongoid::Document
 
   # Use the User database
-  store_in client: "users", collection: "users"
+  store_in client: "users", collection: "back_office_users"
 
   devise :database_authenticatable,
          :lockable,

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,14 +1,7 @@
 # frozen_string_literal: true
 
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
-#
-# Examples:
-#
-#   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
-#   Mayor.create(name: 'Emanuel', city: cities.first)
-
-# User.find_or_create_by(
-#   email: "test@example.com",
-#   password: ENV["WCR_TEST_USER_PASSWORD"] || "Secret123"
-# )
+User.find_or_create_by(
+  email: "bo-user@waste-exemplar.gov.uk",
+  password: ENV["WCRS_DEFAULT_PASSWORD"] || "Secret123",
+  confirmed_at: Time.new(2015, 1, 1)
+)

--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :registration, class: WasteCarriersEngine::Registration do
+  end
+end

--- a/spec/factories/transient_registration.rb
+++ b/spec/factories/transient_registration.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :transient_registration, class: WasteCarriersEngine::TransientRegistration do
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "cancan/matchers"
 require "rails_helper"
 
 RSpec.describe User, type: :model do
@@ -49,6 +50,51 @@ RSpec.describe User, type: :model do
 
       it "should not be valid" do
         expect(user).to_not be_valid
+      end
+    end
+  end
+
+  describe "abilities" do
+    subject(:ability) { Ability.new(user) }
+    let(:user) { build(:user) }
+
+    context "when the user owns a registration" do
+      let(:registration) { build(:registration, account_email: user.email) }
+
+      it "should be able to read it" do
+        should be_able_to(:read, registration)
+      end
+
+      it "should not able to manage it" do
+        should_not be_able_to(:manage, registration)
+      end
+    end
+
+    context "when the user does not own a registration" do
+      let(:registration) { build(:registration, account_email: "foo@test.com") }
+
+      it "should be able to read it" do
+        should be_able_to(:read, registration)
+      end
+
+      it "should not able to manage it" do
+        should_not be_able_to(:manage, registration)
+      end
+    end
+
+    context "when the user owns a transient_registration" do
+      let(:transient_registration) { build(:transient_registration, account_email: user.email) }
+
+      it "should be able to manage it" do
+        should be_able_to(:manage, transient_registration)
+      end
+    end
+
+    context "when the user does not own a transient_registration" do
+      let(:transient_registration) { build(:transient_registration, account_email: "foo@test.com") }
+
+      it "should be able to manage it" do
+        should be_able_to(:manage, transient_registration)
       end
     end
   end


### PR DESCRIPTION
Back office users should be held in a different collection to front office users.

They also need the ability to renew registrations which belong to other users.

We should also provide a back office user seed for testing purposes.

---

Note that there's also a PR for the vagrant box to add scripts for back office seeding.