### PR TITLE
Add specific page titles to template

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,4 +7,6 @@
   /bo
 <% end %>
 
+<% content_for :page_title, title %>
+
 <%= render template: 'layouts/govuk_admin_template' %>


### PR DESCRIPTION
Each page in the form should have a working title attribute. This title is set in the engine.