### PR TITLE
Configure secure headers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,8 @@ gem "govuk_admin_template", "~> 6.6"
 # Sticking with version 3 for now as 4 doesn't support Rails 4
 gem "simple_form", "~> 3.5.1"
 
+gem "secure_headers", "~> 5.0"
+
 # Use the waste carriers engine for the user journey
 gem "waste_carriers_engine",
     git: "https://github.com/DEFRA/waste-carriers-renewals",

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -274,6 +274,8 @@ GEM
     sdoc (0.4.2)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
+    secure_headers (5.0.5)
+      useragent (>= 0.15.0)
     simple_form (3.5.1)
       actionpack (> 4, < 5.2)
       activemodel (> 4, < 5.2)
@@ -308,6 +310,7 @@ GEM
     unf_ext (0.0.7.5)
     unicode-display_width (1.4.0)
     unicode_utils (1.4.0)
+    useragent (0.16.10)
     validates_email_format_of (1.6.3)
       i18n
     warden (1.2.7)
@@ -342,6 +345,7 @@ DEPENDENCIES
   rubocop
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
+  secure_headers (~> 5.0)
   simple_form (~> 3.5.1)
   simplecov
   spring

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -1,0 +1,47 @@
+require "secure_headers"
+
+# A CSP is delivered via a HTTP response header, much like HSTS, and defines
+# approved sources of content that the browser may load. It can be an
+# effective countermeasure to Cross Site Scripting (XSS) attacks and is
+# also widely supported and usually easily deployed.
+# https://scotthelme.co.uk/content-security-policy-an-introduction/
+#
+# See the following for reference on CSP
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
+#
+# See the following for reference on secure_headers and its configuration
+# https://github.com/twitter/secureheaders#configuration
+#
+# This is based on our CSP config for pafs_core
+# https://github.com/DEFRA/pafs_core
+
+SecureHeaders::Configuration.default do |config|
+  # Specifically here we are saying
+  # - scripts can only come from the service or Google, however we permit
+  #   unsafe-inlinescripts (Google to support analytics)
+  # - images can only come from the service and Google (GA because it sends
+  #   the data to the Analytics server via a list of parameters attached to
+  #   a single-pixel image request)
+  # - fonts can only come from the service, or via the data: scheme
+  # - send any violation reports to a service we have setup for CSP
+  # - for all other items their soiurce must be the service (default-src)
+  #
+  # The following were used for reference
+  # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src
+  # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/font-src
+  #
+  # We have to use single quotes here, even though it's against style - double doesn't work
+  config.csp = {
+    default_src: %w('self'),
+    font_src: %w('self' data:),
+    img_src: %w('self' www.google-analytics.com),
+    object_src: %w('self'),
+    script_src: %w('self' 'unsafe-inline' www.googletagmanager.com www.google-analytics.com),
+    style_src: %w('self'),
+    report_uri: %w(https://environmentagency.report-uri.io/r/default/csp/enforce)
+  }
+
+  config.x_content_type_options = "nosniff"
+  config.x_frame_options = "SAMEORIGIN"
+  config.x_xss_protection = "1; mode=block"
+end


### PR DESCRIPTION
Install and configure the secure_headers gem. This currently uses the same configuration as waste-carriers-front-office.