### PR TITLE
Change seed email

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 User.find_or_create_by(
-  email: "bo-user@waste-exemplar.gov.uk",
+  email: "bo-user@wcr.gov.uk",
   password: ENV["WCRS_DEFAULT_PASSWORD"] || "Secret123",
   confirmed_at: Time.new(2015, 1, 1)
 )


### PR DESCRIPTION
We now seed at @wcr.gov.uk instead of @waste-exemplar.gov.uk.