### PR TITLE
 Improve list of transient regs on dashboard

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,9 @@ gem "secure_headers", "~> 5.0"
 gem "govuk_elements_rails", "~> 3.1"
 gem "govuk_template", "~> 0.23"
 
+gem "kaminari", "~> 1.1"
+gem "kaminari-mongoid", "~> 1.0"
+
 # Use the waste carriers engine for the user journey
 gem "waste_carriers_engine",
     git: "https://github.com/DEFRA/waste-carriers-renewals",

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,6 +152,21 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (1.8.6)
+    kaminari (1.1.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.1.1)
+      kaminari-activerecord (= 1.1.1)
+      kaminari-core (= 1.1.1)
+    kaminari-actionview (1.1.1)
+      actionview
+      kaminari-core (= 1.1.1)
+    kaminari-activerecord (1.1.1)
+      activerecord
+      kaminari-core (= 1.1.1)
+    kaminari-core (1.1.1)
+    kaminari-mongoid (1.0.1)
+      kaminari-core (~> 1.0)
+      mongoid
     loofah (2.2.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -337,6 +352,8 @@ DEPENDENCIES
   govuk_template (~> 0.23)
   jbuilder (~> 2.0)
   jquery-rails
+  kaminari (~> 1.1)
+  kaminari-mongoid (~> 1.0)
   mongoid (~> 5.2.0)
   passenger (~> 5.0, >= 5.0.30)
   rails (= 4.2.10)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -36,6 +36,7 @@
 @import 'partials/addresses';
 @import 'partials/dates';
 @import 'partials/people';
+@import 'partials/tags';
 
 main {
   max-width: 1080px;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -35,6 +35,7 @@
 // Custom styles
 @import 'partials/addresses';
 @import 'partials/dates';
+@import 'partials/pagination';
 @import 'partials/people';
 @import 'partials/tags';
 

--- a/app/assets/stylesheets/partials/_pagination.scss
+++ b/app/assets/stylesheets/partials/_pagination.scss
@@ -1,0 +1,65 @@
+// Cribbed from https://home-office-digital-patterns.herokuapp.com/components/pagination
+.pagination .pagination_list-items {
+
+  li {
+    display: inline-block;
+    a {
+      // @extend .bold-small;
+      color: $govuk-blue;
+      display: inline-block;
+      padding: 15px 5px 10px 5px;
+      margin-right: 15px;
+      text-decoration: none;
+
+      &:focus {
+        outline: 0;
+      }
+    }
+    &.active a,
+    &.active a:hover {
+      color: $govuk-blue;
+      -webkit-box-shadow: inset 0px -5px 0px 0px $govuk-blue;
+      -moz-box-shadow: inset 0px -5px 0px 0px $govuk-blue;
+      box-shadow: inset 0px -5px 0px 0px $govuk-blue;
+    }
+  }
+}
+
+.pagination {
+  padding: 0;
+}
+.pagination__item {
+  display: inline-block;
+  list-style: none;
+}
+.pagination__link {
+  display: block;
+  padding: 5px 10px;
+  text-decoration: none;
+
+  &:hover, &:focus {
+    background: $highlight-colour;
+    outline: 3px solid $focus-colour;
+  }
+
+  &.current {
+    color: $text-colour;
+    font-weight: 700;
+    border: none;
+    pointer-events: none;
+    cursor: default;
+
+    &:hover, &:focus {
+      color: $text-colour;
+      background: none;
+    }
+  }
+}
+
+.pagination__summary {
+  padding: 15px 0;
+
+  @media (min-width: 642px) {
+    float: right;
+  }
+}

--- a/app/assets/stylesheets/partials/_tags.scss
+++ b/app/assets/stylesheets/partials/_tags.scss
@@ -1,0 +1,28 @@
+// Taken from https://dwp-design-examples.herokuapp.com/example/tags
+@import 'colours';
+
+.app-c-tag {
+  background-color: $govuk-blue;
+  color: $white;
+  display: inline-block;
+  font-family: 'nta', Arial, sans-serif;
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: 1px;
+  line-height: 1.25;
+  padding: 5px 8px 0;
+  text-decoration: none;
+  text-transform: uppercase;
+}
+
+.app-c-tag--success {
+  background-color: $grass-green;
+}
+
+.app-c-tag--warning {
+  background-color: $brown;
+}
+
+.app-c-tag--danger {
+  background-color: $mellow-red;
+}

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -4,6 +4,7 @@ class DashboardsController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @transient_registrations = WasteCarriersEngine::TransientRegistration.all.page params[:page]
+    @transient_registrations = WasteCarriersEngine::TransientRegistration.order_by(:"metaData.last_modified".desc)
+                                                                         .page params[:page]
   end
 end

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -4,6 +4,6 @@ class DashboardsController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @transient_registrations = WasteCarriersEngine::TransientRegistration.all
+    @transient_registrations = WasteCarriersEngine::TransientRegistration.all.page params[:page]
   end
 end

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -4,7 +4,7 @@ class DashboardsController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @transient_registrations = WasteCarriersEngine::TransientRegistration.order_by(:"metaData.last_modified".desc)
+    @transient_registrations = WasteCarriersEngine::TransientRegistration.order_by("metaData.lastModified": :desc)
                                                                          .page params[:page]
   end
 end

--- a/app/helpers/transient_registrations_helper.rb
+++ b/app/helpers/transient_registrations_helper.rb
@@ -3,9 +3,9 @@
 module TransientRegistrationsHelper
   # Note that this is the application to renew, not a completed renewal. It just means that the user has submitted
   # all the required information through the forms, either through digital or assisted digital.
-  def renewal_application_submitted?
+  def renewal_application_submitted?(transient_registration)
     not_in_progress_states = %w[renewal_received_form renewal_complete_form]
-    not_in_progress_states.include?(@transient_registration.workflow_state)
+    not_in_progress_states.include?(transient_registration.workflow_state)
   end
 
   def show_translation_or_filler(attribute)

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -14,6 +14,8 @@
           <tr>
             <th><%= t(".results.th.reg_identifier") %></th>
             <th><%= t(".results.th.company_name") %></th>
+            <th><%= t(".results.th.status") %></th>
+            <th><%= t(".results.th.last_modified") %></th>
             <th><%= t(".results.th.actions") %></th>
           </tr>
         </thead>
@@ -25,6 +27,27 @@
               </td>
               <td>
                 <%= transient_registration.company_name %>
+              </td>
+              <td>
+                <% if renewal_application_submitted?(transient_registration) %>
+                    <% if transient_registration.finance_details.balance.positive? %>
+                      <strong class="app-c-tag app-c-tag--success">
+                        <%= t(".results.statuses.pending_payment") %>
+                      </strong>
+                    <% end %>
+                    <% if transient_registration.conviction_check_required? %>
+                      <strong class="app-c-tag app-c-tag--warning">
+                        <%= t(".results.statuses.pending_convictions_check") %>
+                      </strong>
+                    <% end %>
+                <% else %>
+                  <strong class="app-c-tag">
+                    <%= t(".results.statuses.in_progress") %>
+                  </strong>
+                <% end %>
+              </td>
+              <td>
+                <%= transient_registration.metaData.last_modified.strftime("%H:%M %d/%m/%Y") %>
               </td>
               <td>
                 <%= link_to t(".results.details_button"), transient_registration_path(transient_registration.reg_identifier), class: 'button' %>

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -57,7 +57,7 @@
         </tbody>
       </table>
     <% end %>
-
-    <%= paginate @transient_registrations %>
   </div>
 </div>
+
+<%= paginate @transient_registrations %>

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -60,4 +60,13 @@
   </div>
 </div>
 
-<%= paginate @transient_registrations %>
+<div class="grid-row">
+  <div class="column-full">
+    <nav role="navigation" class="pagination" aria-label="Pagination">
+      <div class="pagination__summary">
+        <%= page_entries_info @transient_registrations, entry_name: "item" %>
+      </div>
+      <%= paginate @transient_registrations %>
+    </nav>
+  </div>
+</div>

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -57,5 +57,7 @@
         </tbody>
       </table>
     <% end %>
+
+    <%= paginate @transient_registrations %>
   </div>
 </div>

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,9 @@
+<li class="pagination__item">
+  <%= link_to_unless current_page.first?, raw(t("views.pagination.first")),
+                                          url,
+                                          {
+                                            remote: remote,
+                                            class: "pagination__link",
+                                            "aria-label": "First page"
+                                          } %>
+</li>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,3 @@
+<li class="disabled">
+  <%= content_tag :a, raw(t("views.pagination.truncate")) %>
+</li>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,9 @@
+<li class="pagination__item">
+  <%= link_to_unless current_page.last?, raw(t("views.pagination.last")),
+                                         url,
+                                         {
+                                           remote: remote,
+                                           class: "pagination__link",
+                                           "aria-label": "Last page"
+                                          } %>
+</li>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,10 @@
+<li class="pagination__item">
+  <%= link_to_unless current_page.last?, raw(t("views.pagination.next")),
+                                         url,
+                                         {
+                                           rel: "next",
+                                           remote: remote,
+                                           class: "pagination__link",
+                                           "aria-label": "Next page"
+                                          } %>
+</li>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,24 @@
+<% if page.current? %>
+  <li class="active pagination__item">
+    <%= content_tag :a,
+                    page,
+                    {
+                      remote: remote,
+                      rel: (page.next? ? "next" : (page.prev? ? "prev" : nil)),
+                      class: "pagination__link current",
+                      "aria-current": "true",
+                      "aria-label": "Page #{page}, current page"
+                    } %>
+  </li>
+<% else %>
+  <li class="pagination__item">
+    <%= link_to page,
+                url,
+                {
+                  remote: remote,
+                  rel: (page.next? ? "next" : (page.prev? ? "prev" : nil)),
+                  class: "pagination__link",
+                  "aria-label": "Page #{page}"
+                } %>
+  </li>
+<% end %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,22 +1,15 @@
 <%= paginator.render do %>
-<div class="grid-row">
-  <div class="column-full">
-    <nav role="navigation" class="pagination" aria-label="Pagination">
-      <div class="pagination__summary">Showing ??? &ndash; ??? of ??? results</div>
-      <ul class="pagination_list-items">
-        <%= first_page_tag unless current_page.first? %>
-        <%= prev_page_tag unless current_page.first? %>
-        <% each_page do |page| %>
-          <% if page.left_outer? || page.right_outer? || page.inside_window? %>
-            <%= page_tag page %>
-          <% elsif !page.was_truncated? %>
-            <%= gap_tag %>
-          <% end %>
-        <% end %>
-        <%= next_page_tag unless current_page.last? %>
-        <%= last_page_tag unless current_page.last? %>
-      </ul>
-    </nav>
-  </div>
-</div>
+  <ul class="pagination_list-items">
+    <%= first_page_tag unless current_page.first? %>
+    <%= prev_page_tag unless current_page.first? %>
+    <% each_page do |page| %>
+      <% if page.left_outer? || page.right_outer? || page.inside_window? %>
+        <%= page_tag page %>
+      <% elsif !page.was_truncated? %>
+        <%= gap_tag %>
+      <% end %>
+    <% end %>
+    <%= next_page_tag unless current_page.last? %>
+    <%= last_page_tag unless current_page.last? %>
+  </ul>
 <% end %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,22 @@
+<%= paginator.render do %>
+<div class="grid-row">
+  <div class="column-full">
+    <nav role="navigation" class="pagination" aria-label="Pagination">
+      <div class="pagination__summary">Showing ??? &ndash; ??? of ??? results</div>
+      <ul class="pagination_list-items">
+        <%= first_page_tag unless current_page.first? %>
+        <%= prev_page_tag unless current_page.first? %>
+        <% each_page do |page| %>
+          <% if page.left_outer? || page.right_outer? || page.inside_window? %>
+            <%= page_tag page %>
+          <% elsif !page.was_truncated? %>
+            <%= gap_tag %>
+          <% end %>
+        <% end %>
+        <%= next_page_tag unless current_page.last? %>
+        <%= last_page_tag unless current_page.last? %>
+      </ul>
+    </nav>
+  </div>
+</div>
+<% end %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,10 @@
+<li class="pagination__item">
+  <%= link_to_unless current_page.first?, raw(t("views.pagination.previous")),
+                                          url,
+                                          {
+                                            rel: "prev",
+                                            remote: remote,
+                                            class: "pagination__link",
+                                            "aria-label": "Previous page"
+                                           } %>
+</li>

--- a/app/views/transient_registrations/show.html.erb
+++ b/app/views/transient_registrations/show.html.erb
@@ -4,7 +4,7 @@
 
 <div class="grid-row">
   <div class="column-two-thirds">
-    <% if renewal_application_submitted? %>
+    <% if renewal_application_submitted?(@transient_registration) %>
       <div class="panel">
         <h2 class="heading-medium">
           <%= t(".status.headings.submitted") %>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  config.default_per_page = 20
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.params_on_first_page = false
+end

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -3,7 +3,7 @@
 Kaminari.configure do |config|
   config.default_per_page = 20
   # config.max_per_page = nil
-  # config.window = 4
+  config.window = 2
   # config.outer_window = 0
   # config.left = 0
   # config.right = 0

--- a/config/locales/dashboard.en.yml
+++ b/config/locales/dashboard.en.yml
@@ -5,7 +5,13 @@ en:
       heading: "Renewals dashboard"
       results:
         th:
-          reg_identifier: "Registration number"
+          reg_identifier: "Registration"
           company_name: "Company name"
+          last_modified: "Last modified"
+          status: "Status"
           actions: "Actions"
-        details_button: "See details"
+        statuses:
+          in_progress: "application in progress"
+          pending_payment: "pending payment"
+          pending_convictions_check: "pending convictions"
+        details_button: "Details"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,3 +25,13 @@ en:
   layouts:
     application:
       feedback_url: https://www.gov.uk/done/waste-carrier-or-broker-registration
+  # Kaminari overrides
+  helpers:
+    page_entries_info:
+      one_page:
+        display_entries:
+          zero: "No results found"
+          one: "Displaying 1 result"
+          other: "Displaying all %{count} results"
+      more_pages:
+        display_entries: "Showing %{first} &ndash; %{last} of %{total} results"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,30 +1,10 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t 'hello'
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t('hello') %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# To learn more, please read the Rails Internationalization guide
-# available at http://guides.rubyonrails.org/i18n.html.
-
 en:
   global_proposition_header: Waste carriers back office
   please_wait_html: "Please wait&hellip;"
   layouts:
     application:
       feedback_url: https://www.gov.uk/done/waste-carrier-or-broker-registration
+
   # Kaminari overrides
   helpers:
     page_entries_info:

--- a/spec/helpers/transient_registrations_helper_spec.rb
+++ b/spec/helpers/transient_registrations_helper_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe WasteCarriersEngine::ApplicationHelper, type: :helper do
   describe "#renewal_application_submitted?" do
     context "when the workflow_state is not a completed one" do
       it "returns false" do
-        expect(helper.renewal_application_submitted?).to eq(false)
+        expect(helper.renewal_application_submitted?(transient_registration)).to eq(false)
       end
     end
 
@@ -22,7 +22,7 @@ RSpec.describe WasteCarriersEngine::ApplicationHelper, type: :helper do
       end
 
       it "returns true" do
-        expect(helper.renewal_application_submitted?).to eq(true)
+        expect(helper.renewal_application_submitted?(transient_registration)).to eq(true)
       end
     end
 
@@ -32,7 +32,7 @@ RSpec.describe WasteCarriersEngine::ApplicationHelper, type: :helper do
       end
 
       it "returns true" do
-        expect(helper.renewal_application_submitted?).to eq(true)
+        expect(helper.renewal_application_submitted?(transient_registration)).to eq(true)
       end
     end
   end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-374

Another PR in a multi-stage story. This set of commits will:

- order the transient_registrations so the most recently modified are first
- display the results in a more useful and useable format
- implement pagination so the list of results doesn't get too long

Search will be coming in a separate PR.