### PR TITLE
Set link for header title to be /bo

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,7 @@
   <div class="header-proposition">
     <div class="content">
       <nav id="proposition-menu">
-        <%= link_to t(:global_proposition_header), "/", id: "proposition-name" %>
+        <%= link_to t(:global_proposition_header), bo_path, id: "proposition-name" %>
       </nav>
     </div>
   </div>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-440

In test was spotted that the one thing that still pointed to route (and therefore if clicked would send the user to the frontend app in production) was the link embedded in the title in the header.

This change fixes that.