### PR TITLE
Fix header link on pages using engine

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,7 @@
   <div class="header-proposition">
     <div class="content">
       <nav id="proposition-menu">
-        <%= link_to t(:global_proposition_header), bo_path, id: "proposition-name" %>
+        <%= link_to t(:global_proposition_header), main_app.bo_path, id: "proposition-name" %>
       </nav>
     </div>
   </div>


### PR DESCRIPTION
When the app loaded a form from the engine, it tried to find the `bo_path` helper in the engine. However, this is part of the main app. Specifying `main_app.bo_path` solves this problem.