### PR TITLE
Add page showing conviction match details

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -34,6 +34,7 @@
 
 // Custom styles
 @import 'partials/addresses';
+@import 'partials/buttons';
 @import 'partials/dates';
 @import 'partials/pagination';
 @import 'partials/people';

--- a/app/assets/stylesheets/partials/_buttons.scss
+++ b/app/assets/stylesheets/partials/_buttons.scss
@@ -1,0 +1,3 @@
+.button-warning {
+  @include button($red);
+}

--- a/app/controllers/convictions_controller.rb
+++ b/app/controllers/convictions_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class ConvictionsController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    reg_identifier = params[:transient_registration_reg_identifier]
+    @transient_registration = WasteCarriersEngine::TransientRegistration.where(reg_identifier: reg_identifier).first
+  end
+end

--- a/app/helpers/convictions_helper.rb
+++ b/app/helpers/convictions_helper.rb
@@ -16,6 +16,11 @@ module ConvictionsHelper
     @transient_registration.key_person_has_matching_or_unknown_conviction?
   end
 
+  def people_to_show
+    people = @transient_registration.key_people.select(&:conviction_check_required?)
+    people
+  end
+
   private
 
   def unknown_people_convictions?

--- a/app/helpers/convictions_helper.rb
+++ b/app/helpers/convictions_helper.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module ConvictionsHelper
+  def declared_convictions
+    return "unknown" unless @transient_registration.declared_convictions.present?
+    @transient_registration.declared_convictions == "yes"
+  end
+
+  def business_convictions
+    return "unknown" unless @transient_registration.conviction_search_result.present?
+    @transient_registration.business_has_matching_or_unknown_conviction?
+  end
+
+  def people_convictions
+    return "unknown" if unknown_people_convictions?
+    @transient_registration.key_person_has_matching_or_unknown_conviction?
+  end
+
+  private
+
+  def unknown_people_convictions?
+    return true unless @transient_registration.key_people.present?
+
+    # Check to see if any conviction_search_results are present
+    conviction_search_results = @transient_registration.key_people.map(&:conviction_search_result).compact
+    conviction_search_results.count.zero?
+  end
+end

--- a/app/helpers/convictions_helper.rb
+++ b/app/helpers/convictions_helper.rb
@@ -16,9 +16,12 @@ module ConvictionsHelper
     @transient_registration.key_person_has_matching_or_unknown_conviction?
   end
 
-  def people_to_show
-    people = @transient_registration.key_people.select(&:conviction_check_required?)
-    people
+  def people_with_matches
+    @transient_registration.key_people.select(&:conviction_check_required?)
+  end
+
+  def relevant_people_without_matches
+    @transient_registration.relevant_people - people_with_matches
   end
 
   private

--- a/app/views/convictions/index.html.erb
+++ b/app/views/convictions/index.html.erb
@@ -23,6 +23,9 @@
     <p>
       <%= t(".business_convictions.#{business_convictions}") %>
     </p>
+    <% if business_convictions == true %>
+      <%= render("shared/conviction_search_result", conviction_search_result: @transient_registration.conviction_search_result) %>
+    <% end %>
 
     <h2 class="heading-medium">
       <%= t(".people_convictions.heading") %>
@@ -30,5 +33,11 @@
     <p>
       <%= t(".people_convictions.#{people_convictions}") %>
     </p>
+    <% if people_convictions == true %>
+      <% people_to_show.each do |person| %>
+        <h3 class="heading-small"><%= person.first_name %> <%= person.last_name %></h3>
+        <%= render("shared/conviction_search_result", conviction_search_result: person.conviction_search_result) %>
+      <% end %>
+    <% end %>
   </div>
 </div>

--- a/app/views/convictions/index.html.erb
+++ b/app/views/convictions/index.html.erb
@@ -1,3 +1,34 @@
-<h1 class="heading-large">
-  <%= t(".heading", reg_identifier: @transient_registration.reg_identifier) %>
-</h1>
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render("waste_carriers_engine/shared/back", back_path: transient_registration_path(@transient_registration.reg_identifier)) %>
+
+    <h1 class="heading-large">
+      <%= t(".heading", reg_identifier: @transient_registration.reg_identifier) %>
+    </h1>
+
+    <div class="panel">
+      <%= t(".required.#{@transient_registration.conviction_check_required?}") %>
+    </div>
+
+    <h2 class="heading-medium">
+      <%= t(".declared_convictions.heading") %>
+    </h2>
+    <p>
+      <%= t(".declared_convictions.#{declared_convictions}") %>
+    </p>
+
+    <h2 class="heading-medium">
+      <%= t(".business_convictions.heading") %>
+    </h2>
+    <p>
+      <%= t(".business_convictions.#{business_convictions}") %>
+    </p>
+
+    <h2 class="heading-medium">
+      <%= t(".people_convictions.heading") %>
+    </h2>
+    <p>
+      <%= t(".people_convictions.#{people_convictions}") %>
+    </p>
+  </div>
+</div>

--- a/app/views/convictions/index.html.erb
+++ b/app/views/convictions/index.html.erb
@@ -1,0 +1,3 @@
+<h1 class="heading-large">
+  <%= t(".heading", reg_identifier: @transient_registration.reg_identifier) %>
+</h1>

--- a/app/views/convictions/index.html.erb
+++ b/app/views/convictions/index.html.erb
@@ -33,6 +33,7 @@
     <p>
       <%= t(".people_convictions.#{people_convictions}") %>
     </p>
+
     <% if people_convictions == true %>
       <% people_with_matches.each do |person| %>
         <h3 class="heading-small">
@@ -46,7 +47,7 @@
       <% end %>
     <% end %>
 
-      <% if relevant_people_without_matches.present? %>
+    <% if relevant_people_without_matches.present? %>
       <h2 class="heading-medium">
         <%= t(".unmatched_people.heading") %>
       </h2>
@@ -60,6 +61,20 @@
           </tbody>
         </table>
       <% end %>
+    <% end %>
+
+    <% if @transient_registration.conviction_check_required? %>
+      <h2 class="heading-medium">
+        <%= t(".approve_or_reject.heading") %>
+      </h2>
+      <p>
+        <%= t(".approve_or_reject.paragraph_1") %>
+      </p>
+      <p>
+        <%= t(".approve_or_reject.paragraph_2") %>
+      </p>
+      <%= link_to t(".approve_or_reject.buttons.approve"), "#", class: "button" %>
+      <%= link_to t(".approve_or_reject.buttons.reject"), "#", class: "button-warning" %>
     <% end %>
   </div>
 </div>

--- a/app/views/convictions/index.html.erb
+++ b/app/views/convictions/index.html.erb
@@ -24,7 +24,7 @@
       <%= t(".business_convictions.#{business_convictions}") %>
     </p>
     <% if business_convictions == true %>
-      <%= render("shared/conviction_search_result", conviction_search_result: @transient_registration.conviction_search_result) %>
+      <%= render("shared/conviction_search_result", conviction_search_result: @transient_registration.conviction_search_result, person: nil) %>
     <% end %>
 
     <h2 class="heading-medium">
@@ -34,9 +34,31 @@
       <%= t(".people_convictions.#{people_convictions}") %>
     </p>
     <% if people_convictions == true %>
-      <% people_to_show.each do |person| %>
-        <h3 class="heading-small"><%= person.first_name %> <%= person.last_name %></h3>
-        <%= render("shared/conviction_search_result", conviction_search_result: person.conviction_search_result) %>
+      <% people_with_matches.each do |person| %>
+        <h3 class="heading-small">
+          <% if person.person_type == "KEY" %>
+            <%= t(".people_convictions.person_heading.#{@transient_registration.business_type}") %>
+          <% else %>
+            <%= t(".people_convictions.person_heading.relevant") %>
+          <% end %>
+        </h3>
+        <%= render("shared/conviction_search_result", conviction_search_result: person.conviction_search_result, person: person) %>
+      <% end %>
+    <% end %>
+
+      <% if relevant_people_without_matches.present? %>
+      <h2 class="heading-medium">
+        <%= t(".unmatched_people.heading") %>
+      </h2>
+      <p>
+        <%= t(".unmatched_people.paragraph") %>
+      </p>
+      <% relevant_people_without_matches.each do |person| %>
+        <table>
+          <tbody>
+            <%= render("shared/person_table_rows", person: person) %>
+          </tbody>
+        </table>
       <% end %>
     <% end %>
   </div>

--- a/app/views/shared/_conviction_search_result.html.erb
+++ b/app/views/shared/_conviction_search_result.html.erb
@@ -1,11 +1,14 @@
 <table>
   <tbody>
+    <% if person.present? %>
+      <%= render("shared/person_table_rows", person: person) %>
+    <% end %>
     <tr>
       <td>
         <%= t(".match_result") %>
       </td>
       <td>
-        <%= conviction_search_result.match_result.downcase %>
+        <%= conviction_search_result.match_result.titleize %>
       </td>
     </tr>
     <tr>
@@ -45,7 +48,7 @@
         <%= t(".confirmed") %>
       </td>
       <td>
-        <%= conviction_search_result.confirmed %>
+        <%= conviction_search_result.confirmed.titleize %>
       </td>
     </tr>
   </tbody>

--- a/app/views/shared/_conviction_search_result.html.erb
+++ b/app/views/shared/_conviction_search_result.html.erb
@@ -1,0 +1,52 @@
+<table>
+  <tbody>
+    <tr>
+      <td>
+        <%= t(".match_result") %>
+      </td>
+      <td>
+        <%= conviction_search_result.match_result.downcase %>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <%= t(".matching_system") %>
+      </td>
+      <td>
+        <%= conviction_search_result.matching_system %>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <%= t(".reference") %>
+      </td>
+      <td>
+        <%= conviction_search_result.reference %>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <%= t(".matched_name") %>
+      </td>
+      <td>
+        <%= conviction_search_result.matched_name %>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <%= t(".searched_at") %>
+      </td>
+      <td>
+        <%= conviction_search_result.searched_at.in_time_zone("London").strftime("%A %e %B %Y at %l:%M%P") %>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <%= t(".confirmed") %>
+      </td>
+      <td>
+        <%= conviction_search_result.confirmed %>
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/app/views/shared/_person_table_rows.html.erb
+++ b/app/views/shared/_person_table_rows.html.erb
@@ -1,0 +1,26 @@
+<tr>
+  <td>
+    <%= t(".name") %>
+  </td>
+  <td>
+    <%= person.first_name %> <%= person.last_name %>
+  </td>
+</tr>
+<% if person.position.present? %>
+<tr>
+  <td>
+    <%= t(".position") %>
+  </td>
+  <td>
+      <%= person.position %>
+  </td>
+</tr>
+<% end %>
+<tr>
+  <td>
+    <%= t(".dob") %>
+  </td>
+  <td>
+    <%= person.dob.to_date %>
+  </td>
+</tr>

--- a/app/views/transient_registrations/show.html.erb
+++ b/app/views/transient_registrations/show.html.erb
@@ -196,22 +196,7 @@
           <%= t(".person_information.heading.#{@transient_registration.business_type}") %>
         </caption>
         <tbody>
-          <tr>
-            <td>
-              <%= t(".person_information.labels.name") %>
-            </td>
-            <td>
-              <%= person.first_name %> <%= person.last_name %>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <%= t(".person_information.labels.dob") %>
-            </td>
-            <td>
-              <%= person.dob.to_date %>
-            </td>
-          </tr>
+          <%= render("shared/person_table_rows", person: person) %>
           <tr>
             <td>
               <%= t(".person_information.labels.conviction_search_result") %>
@@ -236,30 +221,7 @@
           <%= t(".person_information.heading.relevant") %>
         </caption>
         <tbody>
-          <tr>
-            <td>
-              <%= t(".person_information.labels.name") %>
-            </td>
-            <td>
-              <%= person.first_name %> <%= person.last_name %>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <%= t(".person_information.labels.position") %>
-            </td>
-            <td>
-              <%= person.position %>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <%= t(".person_information.labels.dob") %>
-            </td>
-            <td>
-              <%= person.dob.to_date %>
-            </td>
-          </tr>
+          <%= render("shared/person_table_rows", person: person) %>
           <tr>
             <td>
               <%= t(".person_information.labels.conviction_search_result") %>

--- a/app/views/transient_registrations/show.html.erb
+++ b/app/views/transient_registrations/show.html.erb
@@ -1,9 +1,11 @@
-<h1 class="heading-large">
-  <%= t(".heading", reg_identifier: @transient_registration.reg_identifier) %>
-</h1>
-
 <div class="grid-row">
   <div class="column-two-thirds">
+    <%= render("waste_carriers_engine/shared/back", back_path: bo_path) %>
+
+    <h1 class="heading-large">
+      <%= t(".heading", reg_identifier: @transient_registration.reg_identifier) %>
+    </h1>
+
     <% if @transient_registration.renewal_application_submitted? %>
       <div class="panel">
         <h2 class="heading-medium">
@@ -14,7 +16,7 @@
             <%= t(".status.messages.pending_payment_and_convictions_check") %>
           </p>
           <%= link_to t(".status.actions.payment_button"), "#", class: 'button' %>
-          <%= link_to t(".status.actions.convictions_check_button"), "#", class: 'button' %>
+          <%= link_to t(".status.actions.convictions_check_button"), transient_registration_convictions_path(@transient_registration.reg_identifier), class: 'button' %>
         <% elsif @transient_registration.pending_payment? %>
           <p>
             <%= t(".status.messages.pending_payment") %>
@@ -24,7 +26,7 @@
           <p>
             <%= t(".status.messages.pending_convictions_check") %>
           </p>
-          <%= link_to t(".status.actions.convictions_check_button"), "#", class: 'button' %>
+          <%= link_to t(".status.actions.convictions_check_button"), transient_registration_convictions_path(@transient_registration.reg_identifier), class: 'button' %>
         <% end %>
       </div>
     <% else %>

--- a/config/locales/convictions.en.yml
+++ b/config/locales/convictions.en.yml
@@ -13,11 +13,20 @@ en:
         unknown: "Unknown – the user has not answered this question yet."
       business_convictions:
         heading: Business conviction matches
-        "true": "Yes – there is a conviction match for the business."
-        "false": "No – there is no conviction match for the business."
+        "true": "There is a possible conviction match for the business:"
+        "false": "There is no conviction match for the business."
         unknown: "Unknown – the automated conviction checks have not run yet. This may be because the renewal application is still in progress."
       people_convictions:
         heading: People conviction matches
-        "true": "Yes – there is a conviction match for at least one person."
-        "false": "No – there are no conviction matches for people."
+        "true": "There are possible conviction matches for the following people:"
+        "false": "There are no conviction matches for people."
         unknown: "Unknown – the automated conviction checks have not run yet. This may be because the renewal application is still in progress."
+
+  shared:
+    conviction_search_result:
+      match_result: "Match result"
+      matching_system: "Matching system"
+      reference: "Reference"
+      matched_name: "Matched name"
+      searched_at: "Searched at"
+      confirmed: "Confirmed"

--- a/config/locales/convictions.en.yml
+++ b/config/locales/convictions.en.yml
@@ -3,3 +3,21 @@ en:
     index:
       title: "Conviction details"
       heading: "Conviction information for %{reg_identifier}"
+      required:
+        "true": "This renewal requires a conviction check before it can be approved."
+        "false": "This renewal does not require a conviction check before it can be approved."
+      declared_convictions:
+        heading: "Declared convictions"
+        "true": "Yes – the user declared there were relevant convictions."
+        "false": "No – the user said there were no relevant convictions to declare."
+        unknown: "Unknown – the user has not answered this question yet."
+      business_convictions:
+        heading: Business conviction matches
+        "true": "Yes – there is a conviction match for the business."
+        "false": "No – there is no conviction match for the business."
+        unknown: "Unknown – the automated conviction checks have not run yet. This may be because the renewal application is still in progress."
+      people_convictions:
+        heading: People conviction matches
+        "true": "Yes – there is a conviction match for at least one person."
+        "false": "No – there are no conviction matches for people."
+        unknown: "Unknown – the automated conviction checks have not run yet. This may be because the renewal application is still in progress."

--- a/config/locales/convictions.en.yml
+++ b/config/locales/convictions.en.yml
@@ -1,0 +1,5 @@
+en:
+  convictions:
+    index:
+      title: "Conviction details"
+      heading: "Conviction information for %{reg_identifier}"

--- a/config/locales/convictions.en.yml
+++ b/config/locales/convictions.en.yml
@@ -12,14 +12,14 @@ en:
         "false": "No – the user said there were no relevant convictions to declare."
         unknown: "Unknown – the user has not answered this question yet."
       business_convictions:
-        heading: Business conviction matches
-        "true": "There is a possible conviction match for the business:"
-        "false": "There is no conviction match for the business."
+        heading: Matching convictions for the business
+        "true": "There is a possible matching conviction for the business:"
+        "false": "No matching convictions were found for the business."
         unknown: "Unknown – the automated conviction checks have not run yet. This may be because the renewal application is still in progress."
       people_convictions:
-        heading: People with conviction matches
-        "true": "There are possible conviction matches for the following people:"
-        "false": "There are no conviction matches for people."
+        heading: People with matching convictions
+        "true": "There are possible matching convictions for the following people:"
+        "false": "No matching convictions were found for people."
         unknown: "Unknown – the automated conviction checks have not run yet. This may be because the renewal application is still in progress."
         person_heading:
           localAuthority: "Chief executive"
@@ -30,5 +30,5 @@ en:
           soleTrader: "Business owner"
           relevant: "Employee"
       unmatched_people:
-        heading: People without conviction matches
+        heading: Relevant people without matching convictions
         paragraph: "The following people were declared to have relevant convictions, but no matches were found:"

--- a/config/locales/convictions.en.yml
+++ b/config/locales/convictions.en.yml
@@ -32,3 +32,10 @@ en:
       unmatched_people:
         heading: Relevant people without matching convictions
         paragraph: "The following people were declared to have relevant convictions, but no matches were found:"
+      approve_or_reject:
+        heading: "Approve or reject this renewal"
+        paragraph_1: "You can approve or reject this renewal based on this conviction information."
+        paragraph_2: "If the renewal hasn't been paid for yet, it won't be renewed until payment is received and processed."
+        buttons:
+          approve: "Approve"
+          reject: "Reject"

--- a/config/locales/convictions.en.yml
+++ b/config/locales/convictions.en.yml
@@ -17,16 +17,18 @@ en:
         "false": "There is no conviction match for the business."
         unknown: "Unknown – the automated conviction checks have not run yet. This may be because the renewal application is still in progress."
       people_convictions:
-        heading: People conviction matches
+        heading: People with conviction matches
         "true": "There are possible conviction matches for the following people:"
         "false": "There are no conviction matches for people."
         unknown: "Unknown – the automated conviction checks have not run yet. This may be because the renewal application is still in progress."
-
-  shared:
-    conviction_search_result:
-      match_result: "Match result"
-      matching_system: "Matching system"
-      reference: "Reference"
-      matched_name: "Matched name"
-      searched_at: "Searched at"
-      confirmed: "Confirmed"
+        person_heading:
+          localAuthority: "Chief executive"
+          limitedCompany: "Company director"
+          limitedLiabilityPartnership: "Member"
+          overseas: "Business owner"
+          partnership: "Partner"
+          soleTrader: "Business owner"
+          relevant: "Employee"
+      unmatched_people:
+        heading: People without conviction matches
+        paragraph: "The following people were declared to have relevant convictions, but no matches were found:"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,6 +4,18 @@ en:
   layouts:
     application:
       feedback_url: https://www.gov.uk/done/waste-carrier-or-broker-registration
+  shared:
+    conviction_search_result:
+      match_result: "Match result"
+      matching_system: "Matching system"
+      reference: "Reference"
+      matched_name: "Matched name"
+      searched_at: "Searched at"
+      confirmed: "Confirmed"
+    person_table_rows:
+      name: "Name"
+      position: "Position"
+      dob: "Date of birth"
 
   # Kaminari overrides
   helpers:

--- a/config/locales/transient_registrations.en.yml
+++ b/config/locales/transient_registrations.en.yml
@@ -50,9 +50,6 @@ en:
           soleTrader: "Business owner details"
           relevant: "Person with a relevant conviction"
         labels:
-          name: "Name"
-          position: "Position"
-          dob: "Date of birth"
           conviction_search_result: "Matching convictions found?"
       conviction_heading: "Convictions"
       conviction_information:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,10 @@ Rails.application.routes.draw do
             only: :show,
             param: :reg_identifier,
             path: "/bo/transient-registrations",
-            path_names: { show: "/:reg_identifier" }
+            path_names: { show: "/:reg_identifier" } do
+              resources :convictions,
+                        only: :index
+            end
 
   mount WasteCarriersEngine::Engine => "/bo"
 end

--- a/spec/factories/key_person.rb
+++ b/spec/factories/key_person.rb
@@ -2,6 +2,14 @@
 
 FactoryBot.define do
   factory :key_person, class: WasteCarriersEngine::KeyPerson do
+    trait :main do
+      person_type { "KEY" }
+    end
+
+    trait :relevant do
+      person_type { "RELEVANT" }
+    end
+
     trait :requires_conviction_check do
       conviction_search_result { build(:conviction_search_result, :match_result_yes) }
     end

--- a/spec/helpers/convictions_helper_spec.rb
+++ b/spec/helpers/convictions_helper_spec.rb
@@ -141,4 +141,64 @@ RSpec.describe ConvictionsHelper, type: :helper do
       end
     end
   end
+
+  describe "#people_to_show" do
+    context "when there are no key people" do
+      before do
+        transient_registration.key_people = []
+      end
+
+      it "returns an empty array" do
+        expect(helper.people_to_show).to eq([])
+      end
+    end
+
+    context "when there is a key person" do
+      let(:person) { build(:key_person) }
+
+      before do
+        transient_registration.key_people = [person]
+      end
+
+      context "when a person has no conviction search result" do
+        before do
+          person.conviction_search_result = nil
+        end
+
+        it "returns an empty array" do
+          expect(helper.people_to_show).to eq([])
+        end
+      end
+
+      context "when a conviction search result is NO" do
+        before do
+          person.conviction_search_result = build(:conviction_search_result, :match_result_no)
+        end
+
+        it "returns an empty array" do
+          expect(helper.people_to_show).to eq([])
+        end
+      end
+
+      context "when a conviction search result is YES" do
+        before do
+          person.conviction_search_result = build(:conviction_search_result, :match_result_yes)
+        end
+
+        it "includes the person in the array" do
+          expect(helper.people_to_show).to eq([person])
+        end
+      end
+
+      context "when a conviction search result is UNKNOWN" do
+        before do
+          person.conviction_search_result = build(:conviction_search_result, :match_result_unknown)
+        end
+
+        it "includes the person in the array" do
+          expect(helper.people_to_show).to eq([person])
+        end
+      end
+    end
+  end
 end

--- a/spec/helpers/convictions_helper_spec.rb
+++ b/spec/helpers/convictions_helper_spec.rb
@@ -142,14 +142,14 @@ RSpec.describe ConvictionsHelper, type: :helper do
     end
   end
 
-  describe "#people_to_show" do
+  describe "#people_with_matches" do
     context "when there are no key people" do
       before do
         transient_registration.key_people = []
       end
 
       it "returns an empty array" do
-        expect(helper.people_to_show).to eq([])
+        expect(helper.people_with_matches).to eq([])
       end
     end
 
@@ -166,7 +166,7 @@ RSpec.describe ConvictionsHelper, type: :helper do
         end
 
         it "returns an empty array" do
-          expect(helper.people_to_show).to eq([])
+          expect(helper.people_with_matches).to eq([])
         end
       end
 
@@ -176,7 +176,7 @@ RSpec.describe ConvictionsHelper, type: :helper do
         end
 
         it "returns an empty array" do
-          expect(helper.people_to_show).to eq([])
+          expect(helper.people_with_matches).to eq([])
         end
       end
 
@@ -186,7 +186,7 @@ RSpec.describe ConvictionsHelper, type: :helper do
         end
 
         it "includes the person in the array" do
-          expect(helper.people_to_show).to eq([person])
+          expect(helper.people_with_matches).to eq([person])
         end
       end
 
@@ -196,7 +196,67 @@ RSpec.describe ConvictionsHelper, type: :helper do
         end
 
         it "includes the person in the array" do
-          expect(helper.people_to_show).to eq([person])
+          expect(helper.people_with_matches).to eq([person])
+        end
+      end
+    end
+  end
+
+  describe "#relevant_people_without_matches" do
+    context "when there are no relevant people" do
+      before do
+        transient_registration.key_people = []
+      end
+
+      it "returns an empty array" do
+        expect(helper.relevant_people_without_matches).to eq([])
+      end
+    end
+
+    context "when there is a relevant person" do
+      let(:person) { build(:key_person, :relevant) }
+
+      before do
+        transient_registration.key_people = [person]
+      end
+
+      context "when a person has no conviction search result" do
+        before do
+          person.conviction_search_result = nil
+        end
+
+        it "includes the person in the array" do
+          expect(helper.relevant_people_without_matches).to eq([person])
+        end
+      end
+
+      context "when a conviction search result is NO" do
+        before do
+          person.conviction_search_result = build(:conviction_search_result, :match_result_no)
+        end
+
+        it "includes the person in the array" do
+          expect(helper.relevant_people_without_matches).to eq([person])
+        end
+      end
+
+      context "when a conviction search result is YES" do
+        before do
+          person.conviction_search_result = build(:conviction_search_result, :match_result_yes)
+        end
+
+        it "returns an empty array" do
+          expect(helper.relevant_people_without_matches).to eq([])
+        end
+      end
+
+      context "when a conviction search result is UNKNOWN" do
+        before do
+          person.conviction_search_result = build(:conviction_search_result, :match_result_unknown)
+        end
+
+        it "returns an empty array" do
+          expect(helper.relevant_people_without_matches).to eq([])
         end
       end
     end

--- a/spec/helpers/convictions_helper_spec.rb
+++ b/spec/helpers/convictions_helper_spec.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ConvictionsHelper, type: :helper do
+  let(:transient_registration) { build(:transient_registration) }
+
+  before do
+    assign(:transient_registration, transient_registration)
+  end
+
+  describe "#declared_convictions" do
+    context "when the value is not present" do
+      before do
+        transient_registration.declared_convictions = nil
+      end
+
+      it "returns 'unknown'" do
+        expect(helper.declared_convictions).to eq("unknown")
+      end
+    end
+
+    context "when the value is 'yes'" do
+      before do
+        transient_registration.declared_convictions = "yes"
+      end
+
+      it "returns true" do
+        expect(helper.declared_convictions).to eq(true)
+      end
+    end
+
+    context "when the value is 'no'" do
+      before do
+        transient_registration.declared_convictions = "no"
+      end
+
+      it "returns false" do
+        expect(helper.declared_convictions).to eq(false)
+      end
+    end
+  end
+
+  describe "#business_convictions" do
+    context "when the conviction_search_result is not present" do
+      before do
+        transient_registration.conviction_search_result = nil
+      end
+
+      it "returns 'unknown'" do
+        expect(helper.business_convictions).to eq("unknown")
+      end
+    end
+
+    context "when the conviction_search_result is positive" do
+      before do
+        transient_registration.conviction_search_result = build(:conviction_search_result, :match_result_yes)
+      end
+
+      it "returns true" do
+        expect(helper.business_convictions).to eq(true)
+      end
+    end
+
+    context "when the conviction_search_result is unknown" do
+      before do
+        transient_registration.conviction_search_result = build(:conviction_search_result, :match_result_unknown)
+      end
+
+      it "returns true" do
+        expect(helper.business_convictions).to eq(true)
+      end
+    end
+
+    context "when the conviction_search_result is negative" do
+      before do
+        transient_registration.conviction_search_result = build(:conviction_search_result, :match_result_no)
+      end
+
+      it "returns false" do
+        expect(helper.business_convictions).to eq(false)
+      end
+    end
+  end
+
+  describe "#people_convictions" do
+    context "when there are no key people" do
+      before do
+        transient_registration.key_people = nil
+      end
+
+      it "returns 'unknown'" do
+        expect(helper.people_convictions).to eq("unknown")
+      end
+    end
+
+    context "when there is a key person" do
+      let(:person) { build(:key_person) }
+      before do
+        transient_registration.key_people = [person]
+      end
+
+      context "when the conviction_search_result is not present" do
+        before do
+          person.conviction_search_result = nil
+        end
+
+        it "returns 'unknown'" do
+          expect(helper.people_convictions).to eq("unknown")
+        end
+      end
+
+      context "when the conviction_search_result is positive" do
+        before do
+          person.conviction_search_result = build(:conviction_search_result, :match_result_yes)
+        end
+
+        it "returns true" do
+          expect(helper.people_convictions).to eq(true)
+        end
+      end
+
+      context "when the conviction_search_result is unknown" do
+        before do
+          person.conviction_search_result = build(:conviction_search_result, :match_result_unknown)
+        end
+
+        it "returns true" do
+          expect(helper.people_convictions).to eq(true)
+        end
+      end
+
+      context "when the conviction_search_result is negative" do
+        before do
+          person.conviction_search_result = build(:conviction_search_result, :match_result_no)
+        end
+
+        it "returns false" do
+          expect(helper.people_convictions).to eq(false)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/convictions_spec.rb
+++ b/spec/requests/convictions_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Convictions", type: :request do
+  let(:transient_registration) { create(:transient_registration, workflow_state: "tier_check_form") }
+
+  describe "/bo/transient-registrations/:reg_identifier/convictions" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      it "renders the index template" do
+        get "/bo/transient-registrations/#{transient_registration.reg_identifier}/convictions"
+        expect(response).to render_template(:index)
+      end
+
+      it "returns a 200 response" do
+        get "/bo/transient-registrations/#{transient_registration.reg_identifier}/convictions"
+        expect(response).to have_http_status(200)
+      end
+
+      it "includes the reg identifier" do
+        get "/bo/transient-registrations/#{transient_registration.reg_identifier}/convictions"
+        expect(response.body).to include(transient_registration.reg_identifier)
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-376

This page should display whether the user has declared convictions, and also the details of any conviction matches. The back office users should be able to access it from the transient registration details page.
