### PR TITLE
Let user continue to renewal after logging in

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,8 +15,14 @@ class ApplicationController < ActionController::Base
     redirect_to bo_path
   end
 
-  def after_sign_in_path_for(*)
-    bo_path
+  # We need to handle users coming to the app via /bo/renew/CBDU12345 that are
+  # first required to sign in, and those that just come straight to the sign in
+  # page. In the first case we need to redirect them back to /bo/renew/CBDU12345
+  # after sign in, which we're able to do thanks to a handy helper method in
+  # Devise which stores the previous url. In the second case we redirect them to
+  # our dashboard.
+  def after_sign_in_path_for(resource)
+    stored_location_for(resource) || bo_path
   end
 
   def after_sign_out_path_for(*)

--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -7,5 +7,10 @@ FactoryBot.define do
     addresses { [build(:address), build(:address)] }
 
     metaData { build(:metaData) }
+
+    trait :expires_soon do
+      metaData { build(:metaData, status: :ACTIVE) }
+      expires_on { 2.months.from_now }
+    end
   end
 end

--- a/spec/requests/routes_spec.rb
+++ b/spec/requests/routes_spec.rb
@@ -4,14 +4,61 @@ require "rails_helper"
 
 RSpec.describe "Root", type: :request do
   describe "GET /" do
-    it "renders the dashboards index template" do
+    it "redirects to /bo" do
       get "/"
       expect(response).to redirect_to(bo_path)
     end
 
-    it "returns a 200 response" do
+    it "returns a 302 (redirect) response" do
       get "/"
       expect(response).to have_http_status(302)
+    end
+  end
+
+  describe "GET /bo/renew/[registration number]" do
+    context "when the user is not signed in" do
+      let(:registration) { create(:registration, reg_identifier: "CBDU12345") }
+      it "returns a 200 response" do
+        get "/bo/renew/CBDU12345"
+        expect(response).to have_http_status(302)
+      end
+
+      it "redirects the user to the sign in page" do
+        get "/bo/renew/CBDU12345"
+        expect(response).to redirect_to(new_user_session_path)
+      end
+
+      it "redirects the user to the renewal start page after sign in" do
+        user = create(:user)
+        reg_identifier = create(:registration, :expires_soon, account_email: user.email).reg_identifier
+        renew_path = "/bo/renew/#{reg_identifier}"
+
+        get renew_path
+        post user_session_path, user: { email: user.email, password: user.password }
+        expect(response).to redirect_to(renew_path)
+      end
+    end
+
+    context "when the user is signed in" do
+      let(:user) { create(:user) }
+      # We have to force invocation of creating the registration because we
+      # don't directly reference it in our test, which means it doesn't get
+      # created and the test fails.
+      let!(:registration) { create(:registration, :expires_soon, account_email: user.email) }
+
+      before(:each) do
+        sign_in(user)
+      end
+
+      it "returns a 200 response" do
+        get "/bo/renew/#{registration.reg_identifier}"
+        expect(response).to have_http_status(200)
+      end
+
+      it "redirects the user to the renewal start page" do
+        get "/bo/renew/#{registration.reg_identifier}"
+        expect(response.body).to include("You are about to renew your registration")
+      end
     end
   end
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-448

If a user who isn't logged into the back office attempts to access a renewal, eg at /bo/renew/CBDU1234, they will be asked to log in. However, once they log in, they get redirected to the dashboard instead of the renewal.

This commit fixes this issue by adding the more complex path behaviour from the waste-carriers-front-office, so after logging in, users should be redirected to the resource they originally requested.