### PR TITLE
Back office users can select which type of payment they want to add

### DIFF
--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -2,6 +2,7 @@
 
 class PaymentsController < ApplicationController
   before_action :authenticate_user!
+  before_action :define_payment_types
 
   def new
     find_transient_registration(params[:transient_registration_reg_identifier])
@@ -9,11 +10,39 @@ class PaymentsController < ApplicationController
 
   def create
     find_transient_registration(params[:payment_form][:reg_identifier])
+
+    payment_type = params[:payment_form][:payment_type]
+
+    if valid_payment_type?(payment_type)
+      # redirect_to payment_path(payment_type)
+    else
+      render :new
+    end
   end
 
   private
 
+  def define_payment_types
+    @payment_types = payment_types
+  end
+
   def find_transient_registration(reg_identifier)
     @transient_registration = WasteCarriersEngine::TransientRegistration.where(reg_identifier: reg_identifier).first
+  end
+
+  def payment_types
+    %w[cash
+       cheque
+       postal_order
+       transfer
+       worldpay_missed]
+  end
+
+  def valid_payment_type?(payment_type)
+    payment_types.include?(payment_type)
+  end
+
+  def payment_path(payment_type)
+    public_send("transient_registration_#{payment_type}_payment_forms_path(@transient_registration.reg_identifier)")
   end
 end

--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class PaymentsController < ApplicationController
+  before_action :authenticate_user!
+
+  def new
+    find_transient_registration(params[:transient_registration_reg_identifier])
+  end
+
+  def create
+    find_transient_registration(params[:payment_form][:reg_identifier])
+  end
+
+  private
+
+  def find_transient_registration(reg_identifier)
+    @transient_registration = WasteCarriersEngine::TransientRegistration.where(reg_identifier: reg_identifier).first
+  end
+end

--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -14,7 +14,7 @@ class PaymentsController < ApplicationController
     payment_type = params[:payment_form][:payment_type]
 
     if valid_payment_type?(payment_type)
-      # redirect_to payment_path(payment_type)
+      redirect_to payment_path(payment_type)
     else
       render :new
     end
@@ -43,6 +43,6 @@ class PaymentsController < ApplicationController
   end
 
   def payment_path(payment_type)
-    public_send("transient_registration_#{payment_type}_payment_forms_path(@transient_registration.reg_identifier)")
+    public_send("new_transient_registration_#{payment_type}_payment_form_path")
   end
 end

--- a/app/controllers/transfer_payment_forms_controller.rb
+++ b/app/controllers/transfer_payment_forms_controller.rb
@@ -18,6 +18,6 @@ class TransferPaymentFormsController < AdminFormsController
   end
 
   def authorize_action(transient_registration)
-    authorize! :record_electronic_transfer_payment, transient_registration
+    authorize! :record_transfer_payment, transient_registration
   end
 end

--- a/app/helpers/payments_helper.rb
+++ b/app/helpers/payments_helper.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module PaymentsHelper
+  # We use this to iterate over each valid payment type to check abilities. For example, `can :record_cash_payment`
+  def record_payment_of_type(payment_type)
+    "record_#{payment_type}_payment".to_sym
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -27,11 +27,11 @@ class Ability
   end
 
   def permissions_for_finance_user
-    can :record_electronic_transfer_payment, WasteCarriersEngine::TransientRegistration
+    can :record_transfer_payment, WasteCarriersEngine::TransientRegistration
   end
 
   def permissions_for_finance_admin_user
-    can :record_worldpay_payment, WasteCarriersEngine::TransientRegistration
+    can :record_worldpay_missed_payment, WasteCarriersEngine::TransientRegistration
   end
 
   def permissions_for_agency_super_user

--- a/app/views/payments/new.html.erb
+++ b/app/views/payments/new.html.erb
@@ -13,30 +13,12 @@
             <%= t(".heading") %>
           </legend>
 
-          <div class="multiple-choice">
-            <%= f.radio_button :payment_type, 'transfer' %>
-            <%= f.label :payment_type, t(".options.transfer"), value: 'transfer' %>
-          </div>
-
-          <div class="multiple-choice">
-            <%= f.radio_button :payment_type, 'cash' %>
-            <%= f.label :payment_type, t(".options.cash"), value: 'cash' %>
-          </div>
-
-          <div class="multiple-choice">
-            <%= f.radio_button :payment_type, 'cheque' %>
-            <%= f.label :payment_type, t(".options.cheque"), value: 'cheque' %>
-          </div>
-
-          <div class="multiple-choice">
-            <%= f.radio_button :payment_type, 'postal_order' %>
-            <%= f.label :payment_type, t(".options.postal_order"), value: 'postal_order' %>
-          </div>
-
-          <div class="multiple-choice">
-            <%= f.radio_button :payment_type, 'worldpay_missed' %>
-            <%= f.label :payment_type, t(".options.worldpay_missed"), value: 'worldpay_missed' %>
-          </div>
+          <% @payment_types.each do |type| %>
+            <div class="multiple-choice">
+              <%= f.radio_button :payment_type, type %>
+              <%= f.label :payment_type, t(".options.#{type}"), value: type %>
+            </div>
+          <% end %>
         </fieldset>
       </div>
 

--- a/app/views/payments/new.html.erb
+++ b/app/views/payments/new.html.erb
@@ -15,8 +15,15 @@
 
           <% @payment_types.each do |type| %>
             <div class="multiple-choice">
-              <%= f.radio_button :payment_type, type %>
-              <%= f.label :payment_type, t(".options.#{type}"), value: type %>
+              <%= f.radio_button :payment_type,
+                                 type,
+                                 disabled: !(can? record_payment_of_type(type), @transient_registration) %>
+              <%= f.label :payment_type, value: type do %>
+                <%= t(".options.#{type}") %>
+                <% if !(can? record_payment_of_type(type), @transient_registration)%>
+                  <%= t(".no_permission") %>
+                <% end %>
+              <% end %>
             </div>
           <% end %>
         </fieldset>

--- a/app/views/payments/new.html.erb
+++ b/app/views/payments/new.html.erb
@@ -1,0 +1,49 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render("waste_carriers_engine/shared/back", back_path: transient_registration_path(@transient_registration.reg_identifier)) %>
+
+    <%= form_for(:payment_form, url: transient_registration_payments_path) do |f| %>
+      <h1 class="heading-large">
+        <%= t(".heading") %>
+      </h1>
+
+      <div class="form-group">
+        <fieldset id="payment_type">
+          <legend class="visuallyhidden">
+            <%= t(".heading") %>
+          </legend>
+
+          <div class="multiple-choice">
+            <%= f.radio_button :payment_type, 'transfer' %>
+            <%= f.label :payment_type, t(".options.transfer"), value: 'transfer' %>
+          </div>
+
+          <div class="multiple-choice">
+            <%= f.radio_button :payment_type, 'cash' %>
+            <%= f.label :payment_type, t(".options.cash"), value: 'cash' %>
+          </div>
+
+          <div class="multiple-choice">
+            <%= f.radio_button :payment_type, 'cheque' %>
+            <%= f.label :payment_type, t(".options.cheque"), value: 'cheque' %>
+          </div>
+
+          <div class="multiple-choice">
+            <%= f.radio_button :payment_type, 'postal_order' %>
+            <%= f.label :payment_type, t(".options.postal_order"), value: 'postal_order' %>
+          </div>
+
+          <div class="multiple-choice">
+            <%= f.radio_button :payment_type, 'worldpay_missed' %>
+            <%= f.label :payment_type, t(".options.worldpay_missed"), value: 'worldpay_missed' %>
+          </div>
+        </fieldset>
+      </div>
+
+      <%= f.hidden_field :reg_identifier, value: @transient_registration.reg_identifier %>
+      <div class="form-group">
+        <%= f.submit t(".submit_button"), class: "button" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/transient_registrations/show.html.erb
+++ b/app/views/transient_registrations/show.html.erb
@@ -372,7 +372,7 @@
               <%= t(".order_information.labels.payment_method") %>
             </td>
             <td>
-              <%= order.payment_method %>
+              <%= order.payment_method.titleize %>
             </td>
           </tr>
           <% if order.world_pay_status.present? %>
@@ -426,7 +426,7 @@
               <%= t(".payment_information.labels.payment_type") %>
             </td>
             <td>
-              <%= payment.payment_type %>
+              <%= t(".attributes.finance_details.payment.payment_type.#{payment.payment_type}") %>
             </td>
           </tr>
           <tr>

--- a/app/views/transient_registrations/show.html.erb
+++ b/app/views/transient_registrations/show.html.erb
@@ -15,13 +15,13 @@
           <p>
             <%= t(".status.messages.pending_payment_and_convictions_check") %>
           </p>
-          <%= link_to t(".status.actions.payment_button"), transient_registration_transfer_payment_forms_path(@transient_registration.reg_identifier), class: 'button' %>
+          <%= link_to t(".status.actions.payment_button"), transient_registration_payments_path(@transient_registration.reg_identifier), class: 'button' %>
           <%= link_to t(".status.actions.convictions_check_button"), transient_registration_convictions_path(@transient_registration.reg_identifier), class: 'button' %>
         <% elsif @transient_registration.pending_payment? %>
           <p>
             <%= t(".status.messages.pending_payment") %>
           </p>
-          <%= link_to t(".status.actions.payment_button"), transient_registration_transfer_payment_forms_path(@transient_registration.reg_identifier), class: 'button' %>
+          <%= link_to t(".status.actions.payment_button"), transient_registration_payments_path(@transient_registration.reg_identifier), class: 'button' %>
         <% elsif @transient_registration.pending_manual_conviction_check? %>
           <p>
             <%= t(".status.messages.pending_convictions_check") %>

--- a/config/locales/payments.en.yml
+++ b/config/locales/payments.en.yml
@@ -2,11 +2,12 @@ en:
   payments:
     new:
       title: "Add a payment"
-      heading: "Add a payment"
+      heading: "How was this payment made?"
       options:
         transfer: "Bank transfer"
         cash: "Cash"
         cheque: "Cheque"
         postal_order: "Postal order"
         worldpay_missed: "Missed WorldPay payment"
+      no_permission: " – your account can't add this type of payment"
       submit_button: "Add payment details"

--- a/config/locales/payments.en.yml
+++ b/config/locales/payments.en.yml
@@ -1,0 +1,12 @@
+en:
+  payments:
+    new:
+      title: "Add a payment"
+      heading: "Add a payment"
+      options:
+        transfer: "Bank transfer"
+        cash: "Cash"
+        cheque: "Cheque"
+        postal_order: "Postal order"
+        worldpay_missed: "Missed WorldPay payment"
+      submit_button: "Add payment details"

--- a/config/locales/transient_registrations.en.yml
+++ b/config/locales/transient_registrations.en.yml
@@ -114,6 +114,15 @@ en:
           other: "Other"
         declaration:
           "1": "Yes"
+        finance_details:
+          payment:
+            payment_type:
+              CASH: "Cash"
+              CHEQUE: "Cheque"
+              POSTALORDER: "Postal order"
+              BANKTRANSFER: "Bank transfer"
+              WORLDPAY: "WorldPay"
+              WORLDPAY_MISSED: "WorldPay (manually added)"
         key_people:
           number_of_people_with_matching_convictions:
             zero: "No"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,10 @@ Rails.application.routes.draw do
                         only: [:new, :create],
                         path: "convictions/reject",
                         path_names: { new: "" }
+
+              resources :payments,
+                        only: [:new, :create],
+                        path_names: { new: "" }
             end
 
   mount WasteCarriersEngine::Engine => "/bo"

--- a/spec/helpers/payments_helper_spec.rb
+++ b/spec/helpers/payments_helper_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PaymentsHelper, type: :helper do
+  let(:transient_registration) { build(:transient_registration) }
+
+  before do
+    assign(:transient_registration, transient_registration)
+  end
+
+  describe "#record_payment_of_type" do
+    context "when a payment_type is provided" do
+      it "returns a correctly_named symbol" do
+        expect(helper.record_payment_of_type("cash")).to eq(:record_cash_payment)
+      end
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -79,12 +79,12 @@ RSpec.describe User, type: :model do
         should be_able_to(:record_postal_order_payment, transient_registration)
       end
 
-      it "should not be able to record an electronic transfer payment" do
-        should_not be_able_to(:record_electronic_transfer_payment, transient_registration)
+      it "should not be able to record a transfer payment" do
+        should_not be_able_to(:record_transfer_payment, transient_registration)
       end
 
       it "should not be able to record a worldpay payment" do
-        should_not be_able_to(:record_worldpay_payment, transient_registration)
+        should_not be_able_to(:record_worldpay_missed_payment, transient_registration)
       end
 
       it "should be able to review convictions" do
@@ -127,12 +127,12 @@ RSpec.describe User, type: :model do
         should be_able_to(:record_postal_order_payment, transient_registration)
       end
 
-      it "should not be able to record an electronic transfer payment" do
-        should_not be_able_to(:record_electronic_transfer_payment, transient_registration)
+      it "should not be able to record a transfer payment" do
+        should_not be_able_to(:record_transfer_payment, transient_registration)
       end
 
       it "should not be able to record a worldpay payment" do
-        should_not be_able_to(:record_worldpay_payment, transient_registration)
+        should_not be_able_to(:record_worldpay_missed_payment, transient_registration)
       end
 
       it "should be able to review convictions" do
@@ -175,12 +175,12 @@ RSpec.describe User, type: :model do
         should_not be_able_to(:record_postal_order_payment, transient_registration)
       end
 
-      it "should be able to record an electronic transfer payment" do
-        should be_able_to(:record_electronic_transfer_payment, transient_registration)
+      it "should be able to record a transfer payment" do
+        should be_able_to(:record_transfer_payment, transient_registration)
       end
 
       it "should not be able to record a worldpay payment" do
-        should_not be_able_to(:record_worldpay_payment, transient_registration)
+        should_not be_able_to(:record_worldpay_missed_payment, transient_registration)
       end
 
       it "should not be able to review convictions" do
@@ -223,12 +223,12 @@ RSpec.describe User, type: :model do
         should_not be_able_to(:record_postal_order_payment, transient_registration)
       end
 
-      it "should not be able to record an electronic transfer payment" do
-        should_not be_able_to(:record_electronic_transfer_payment, transient_registration)
+      it "should not be able to record a transfer payment" do
+        should_not be_able_to(:record_transfer_payment, transient_registration)
       end
 
       it "should be able to record a worldpay payment" do
-        should be_able_to(:record_worldpay_payment, transient_registration)
+        should be_able_to(:record_worldpay_missed_payment, transient_registration)
       end
 
       it "should not be able to review convictions" do
@@ -271,12 +271,12 @@ RSpec.describe User, type: :model do
         should_not be_able_to(:record_postal_order_payment, transient_registration)
       end
 
-      it "should not be able to record an electronic transfer payment" do
-        should_not be_able_to(:record_electronic_transfer_payment, transient_registration)
+      it "should not be able to record a transfer payment" do
+        should_not be_able_to(:record_transfer_payment, transient_registration)
       end
 
       it "should not be able to record a worldpay payment" do
-        should_not be_able_to(:record_worldpay_payment, transient_registration)
+        should_not be_able_to(:record_worldpay_missed_payment, transient_registration)
       end
 
       it "should not be able to review convictions" do
@@ -319,12 +319,12 @@ RSpec.describe User, type: :model do
         should_not be_able_to(:record_postal_order_payment, transient_registration)
       end
 
-      it "should not be able to record an electronic transfer payment" do
-        should_not be_able_to(:record_electronic_transfer_payment, transient_registration)
+      it "should not be able to record a transfer payment" do
+        should_not be_able_to(:record_transfer_payment, transient_registration)
       end
 
       it "should not be able to record a worldpay payment" do
-        should_not be_able_to(:record_worldpay_payment, transient_registration)
+        should_not be_able_to(:record_worldpay_missed_payment, transient_registration)
       end
 
       it "should not be able to review convictions" do

--- a/spec/requests/payments_spec.rb
+++ b/spec/requests/payments_spec.rb
@@ -38,10 +38,10 @@ RSpec.describe "Payments", type: :request do
         }
       end
 
-      # it "redirects to the requested payment type" do
-      #   post "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments", payment_form: params
-      #   expect(response).to redirect_to(transient_registration_transfer_payment_form_path(transient_registration.reg_identifier))
-      # end
+      it "redirects to the requested payment type" do
+        post "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments", payment_form: params
+        expect(response).to redirect_to(new_transient_registration_transfer_payment_form_path)
+      end
 
       context "when the payment_type is not recognised" do
         before do

--- a/spec/requests/payments_spec.rb
+++ b/spec/requests/payments_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Payments", type: :request do
+  let(:transient_registration) { create(:transient_registration) }
+
+  describe "GET /bo/transient-registrations/:reg_identifier/payments" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user, :agency) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      it "renders the new template" do
+        get "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments"
+        expect(response).to render_template(:new)
+      end
+
+      it "returns a 200 response" do
+        get "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments"
+        expect(response).to have_http_status(200)
+      end
+    end
+  end
+
+  describe "POST /bo/transient-registrations/:reg_identifier/payments" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user, :agency) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      let(:params) do
+        {
+          reg_identifier: transient_registration.reg_identifier,
+          payment_type: "foo"
+        }
+      end
+    end
+  end
+end

--- a/spec/requests/payments_spec.rb
+++ b/spec/requests/payments_spec.rb
@@ -34,8 +34,24 @@ RSpec.describe "Payments", type: :request do
       let(:params) do
         {
           reg_identifier: transient_registration.reg_identifier,
-          payment_type: "foo"
+          payment_type: "transfer"
         }
+      end
+
+      # it "redirects to the requested payment type" do
+      #   post "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments", payment_form: params
+      #   expect(response).to redirect_to(transient_registration_transfer_payment_form_path(transient_registration.reg_identifier))
+      # end
+
+      context "when the payment_type is not recognised" do
+        before do
+          params[:payment_type] = "foo"
+        end
+
+        it "renders the new template" do
+          post "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments", payment_form: params
+          expect(response).to render_template(:new)
+        end
       end
     end
   end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-377

There are 5 different types of payment which can be manually added. The type of payment a user can add also depends on their role.

Rather than sending the user straight into a form, we first ask them to select which type of payment they want to record, and then direct them to the correct form for that type.
