### PR TITLE
Seed back office users from json file

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,19 +10,12 @@ def find_or_create_user(email, role)
 end
 
 def seed_users
-  # Agency super
-  find_or_create_user("bo-agency-super@wcr.gov.uk", "agency_super")
-  # Finance super
-  find_or_create_user("bo-finance-super@wcr.gov.uk", "finance_super")
+  seeds = JSON.parse(File.read("#{Rails.root}/db/seeds/users.json"))
+  users = seeds["users"]
 
-  # Standard agency user
-  find_or_create_user("bo-user@wcr.gov.uk", "agency")
-  # Agency refund payment user
-  find_or_create_user("bo-user-with-refund@wcr.gov.uk", "agency_with_refund")
-  # Finance basic user
-  find_or_create_user("bo-finance-user@wcr.gov.uk", "finance")
-  # Finance admin user
-  find_or_create_user("bo-finance-admin@wcr.gov.uk", "finance_admin")
+  users.each do |user|
+    find_or_create_user(user["email"], user["role"])
+  end
 end
 
 # Only seed if not running in production or we specifically require it, eg. for Heroku

--- a/db/seeds/users.json
+++ b/db/seeds/users.json
@@ -1,0 +1,52 @@
+{
+	"users" : [
+    {
+			"email" : "bo-agency-super@wcr.gov.uk",
+			"role" : "agency_super"
+		},
+		{
+			"email" : "bo-finance-super@wcr.gov.uk",
+			"role" : "finance_super"
+		},
+		{
+			"email" : "agency-super@wcr.gov.uk",
+			"role" : "agency_super"
+		},
+		{
+			"email" : "finance-super@wcr.gov.uk",
+			"role" : "finance_super"
+		},
+		{
+			"email" : "bo-user@wcr.gov.uk",
+			"role" : "agency"
+		},
+		{
+			"email" : "bo-user-with-refund@wcr.gov.uk",
+			"role" : "agency_with_refund"
+		},
+		{
+			"email" : "bo-finance-user@wcr.gov.uk",
+			"role" : "finance"
+		},
+		{
+			"email" : "bo-finance-admin@wcr.gov.uk",
+			"role" : "finance_admin"
+		},
+		{
+			"email" : "agency-user@wcr.gov.uk",
+			"role" : "agency"
+		},
+		{
+			"email" : "agency-refund-payment-user@wcr.gov.uk",
+			"role" : "agency_with_refund"
+		},
+		{
+			"email" : "finance-user@wcr.gov.uk",
+			"role" : "finance"
+		},
+		{
+			"email" : "finance-admin-user@wcr.gov.uk",
+			"role" : "finance_admin"
+		}
+	]
+}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-454

It came up in testing today that we are not able to replicate the work flow we hope to offer the NCCC team when it comes to working with the two systems; the admin section of waste-carriers-frontend and waste-carriers-back-office.

On the day of release they need to be able to access both systems using the same login. So assume they are dealing with a user that needs to renew; they first log into the back end and search for the registration. Once found they click the renew link. They will be taken to the back-office where they will be asked to login. However they can use the same username and password as previously used. Once signed in they can continue as previous, and from this point on they can switch between both systems without needing to re-authenticate.

The problem we have at the moment is that the frontend seeds completely different users to the back-office. So we can't replicate this behaviour in local development and testing. This change covers ensuring we seed the same users created in the frontend into the back-office so we can.

It should be noted there is no way we can remove the need to sign into both systems at least once. Also if a user changes their password in only one of them, they'll need to remember two passwords. And when a new starter joins NCCC they will need to create a user record in each. Hence the desire to move to just one back office system.

But in the meantime we can seed our local environments based on the ideal setup we want in production.