### PR TITLE
Agency users can record cash payment

### DIFF
--- a/app/controllers/cash_payment_forms_controller.rb
+++ b/app/controllers/cash_payment_forms_controller.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class CashPaymentFormsController < AdminFormsController
+  def new
+    super(CashPaymentForm,
+          "cash_payment_form",
+          params[:transient_registration_reg_identifier],
+          :authorize_action)
+  end
+
+  def create
+    params[:cash_payment_form][:updated_by_user] = current_user.email
+
+    return unless super(CashPaymentForm,
+                        "cash_payment_form",
+                        params[:cash_payment_form][:reg_identifier],
+                        :authorize_action)
+  end
+
+  def authorize_action(transient_registration)
+    authorize! :record_cash_payment, transient_registration
+  end
+end

--- a/app/forms/cash_payment_form.rb
+++ b/app/forms/cash_payment_form.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class CashPaymentForm < PaymentForm
+  def submit(params)
+    payment_type_value = "CASH"
+    super(params, payment_type_value)
+  end
+end

--- a/app/views/cash_payment_forms/new.html.erb
+++ b/app/views/cash_payment_forms/new.html.erb
@@ -1,0 +1,11 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render("waste_carriers_engine/shared/back", back_path: transient_registration_path(@transient_registration.reg_identifier)) %>
+
+    <h1 class="heading-large">
+      <%= t(".heading", reg_identifier: @transient_registration.reg_identifier) %>
+    </h1>
+
+    <%= render("shared/payment_form", form: @cash_payment_form, path: transient_registration_transfer_payment_forms_path) %>
+  </div>
+</div>

--- a/app/views/cash_payment_forms/new.html.erb
+++ b/app/views/cash_payment_forms/new.html.erb
@@ -6,6 +6,6 @@
       <%= t(".heading", reg_identifier: @transient_registration.reg_identifier) %>
     </h1>
 
-    <%= render("shared/payment_form", form: @cash_payment_form, path: transient_registration_transfer_payment_forms_path) %>
+    <%= render("shared/payment_form", form: @cash_payment_form, path: transient_registration_cash_payment_forms_path) %>
   </div>
 </div>

--- a/config/locales/cash_payment_forms.en.yml
+++ b/config/locales/cash_payment_forms.en.yml
@@ -1,0 +1,20 @@
+en:
+  cash_payment_forms:
+    new:
+      title: "Add a cash payment"
+      heading: "Add a cash payment for %{reg_identifier}"
+  activemodel:
+    errors:
+      models:
+        cash_payment_form:
+          attributes:
+            amount:
+              blank: "You must enter an amount"
+              not_a_number: "You must enter a valid number"
+              greater_than: "You must enter a positive number"
+            comment:
+              too_long: "Your comment must not be longer than 250 characters"
+            date_received:
+              blank: "You must enter a valid date"
+            registration_reference:
+              blank: "You must enter a reference"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,11 @@ Rails.application.routes.draw do
                         path: "convictions/reject",
                         path_names: { new: "" }
 
+              resources :cash_payment_forms,
+                        only: [:new, :create],
+                        path: "payments/cash",
+                        path_names: { new: "" }
+
               resources :transfer_payment_forms,
                         only: [:new, :create],
                         path: "payments/transfer",

--- a/spec/requests/cash_payment_forms_spec.rb
+++ b/spec/requests/cash_payment_forms_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "CashPaymentForms", type: :request do
+  let(:transient_registration) { create(:transient_registration, :has_finance_details) }
+
+  describe "GET /bo/transient-registrations/:reg_identifier/payments/cash" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user, :agency) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      it "renders the new template" do
+        get "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments/cash"
+        expect(response).to render_template(:new)
+      end
+
+      it "returns a 200 response" do
+        get "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments/cash"
+        expect(response).to have_http_status(200)
+      end
+
+      it "includes the reg identifier" do
+        get "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments/cash"
+        expect(response.body).to include(transient_registration.reg_identifier)
+      end
+    end
+
+    context "when a non-agency user is signed in" do
+      let(:user) { create(:user, :finance) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      it "redirects to the permissions error page" do
+        get "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments/cash"
+        expect(response).to redirect_to("/bo/permission")
+      end
+    end
+  end
+
+  describe "POST /bo/transient-registrations/:reg_identifier/payments/cash" do
+    let(:params) do
+      {
+        reg_identifier: transient_registration.reg_identifier,
+        amount: "100",
+        comment: "foo",
+        registration_reference: "foo",
+        date_received_day: "1",
+        date_received_month: "1",
+        date_received_year: "2018"
+      }
+    end
+
+    context "when a valid user is signed in" do
+      let(:user) { create(:user, :agency) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      it "redirects to the transient_registration page" do
+        post "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments/cash", cash_payment_form: params
+        expect(response).to redirect_to(transient_registration_path(transient_registration.reg_identifier))
+      end
+
+      it "creates a new payment" do
+        old_payments_count = transient_registration.finance_details.payments.count
+        post "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments/cash", cash_payment_form: params
+        expect(transient_registration.reload.finance_details.payments.count).to eq(old_payments_count + 1)
+      end
+
+      it "assigns the correct updated_by_user to the payment" do
+        post "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments/cash", cash_payment_form: params
+        expect(transient_registration.reload.finance_details.payments.first.updated_by_user).to eq(user.email)
+      end
+
+      context "when the params are invalid" do
+        let(:params) do
+          {
+            reg_identifier: transient_registration.reg_identifier,
+            revoked_reason: ""
+          }
+        end
+
+        it "renders the new template" do
+          post "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments/cash", cash_payment_form: params
+          expect(response).to render_template(:new)
+        end
+
+        it "does not create a new payment" do
+          old_payments_count = transient_registration.finance_details.payments.count
+          post "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments/cash", cash_payment_form: params
+          expect(transient_registration.reload.finance_details.payments.count).to eq(old_payments_count)
+        end
+      end
+    end
+
+    context "when a non-agency user is signed in" do
+      let(:user) { create(:user, :finance) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      it "redirects to the permissions error page" do
+        post "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments/cash", cash_payment_form: params
+        expect(response).to redirect_to("/bo/permission")
+      end
+
+      it "does not create a new payment" do
+        old_payments_count = transient_registration.finance_details.payments.count
+        post "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments/cash", cash_payment_form: params
+        expect(transient_registration.reload.finance_details.payments.count).to eq(old_payments_count)
+      end
+    end
+  end
+end

--- a/spec/requests/payments_spec.rb
+++ b/spec/requests/payments_spec.rb
@@ -38,9 +38,26 @@ RSpec.describe "Payments", type: :request do
         }
       end
 
-      it "redirects to the requested payment type" do
-        post "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments", payment_form: params
-        expect(response).to redirect_to(new_transient_registration_transfer_payment_form_path)
+      context "when the payment_type is cash" do
+        before do
+          params[:payment_type] = "cash"
+        end
+
+        it "redirects to the cash payment form" do
+          post "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments", payment_form: params
+          expect(response).to redirect_to(new_transient_registration_cash_payment_form_path)
+        end
+      end
+
+      context "when the payment_type is transfer" do
+        before do
+          params[:payment_type] = "transfer"
+        end
+
+        it "redirects to the transfer payment form" do
+          post "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments", payment_form: params
+          expect(response).to redirect_to(new_transient_registration_transfer_payment_form_path)
+        end
       end
 
       context "when the payment_type is not recognised" do


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-377

A user with the agency or agency_with_refund role should be able to record when a cash payment has been received.