### PR TITLE
Finance_admin users can record missed WorldPay payment

### DIFF
--- a/app/controllers/worldpay_missed_payment_forms_controller.rb
+++ b/app/controllers/worldpay_missed_payment_forms_controller.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class WorldpayMissedPaymentFormsController < AdminFormsController
+  def new
+    super(WorldpayMissedPaymentForm,
+          "worldpay_missed_payment_form",
+          params[:transient_registration_reg_identifier],
+          :authorize_action)
+  end
+
+  def create
+    params[:worldpay_missed_payment_form][:updated_by_user] = current_user.email
+
+    return unless super(WorldpayMissedPaymentForm,
+                        "worldpay_missed_payment_form",
+                        params[:worldpay_missed_payment_form][:reg_identifier],
+                        :authorize_action)
+  end
+
+  def authorize_action(transient_registration)
+    authorize! :record_worldpay_missed_payment, transient_registration
+  end
+end

--- a/app/forms/worldpay_missed_payment_form.rb
+++ b/app/forms/worldpay_missed_payment_form.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class WorldpayMissedPaymentForm < PaymentForm
+  def submit(params)
+    payment_type_value = "WORLDPAY_MISSED"
+    super(params, payment_type_value)
+  end
+end

--- a/app/views/worldpay_missed_payment_forms/new.html.erb
+++ b/app/views/worldpay_missed_payment_forms/new.html.erb
@@ -1,0 +1,11 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render("waste_carriers_engine/shared/back", back_path: transient_registration_path(@transient_registration.reg_identifier)) %>
+
+    <h1 class="heading-large">
+      <%= t(".heading", reg_identifier: @transient_registration.reg_identifier) %>
+    </h1>
+
+    <%= render("shared/payment_form", form: @worldpay_missed_payment_form, path: transient_registration_worldpay_missed_payment_forms_path) %>
+  </div>
+</div>

--- a/config/locales/worldpay_missed_payment_forms.en.yml
+++ b/config/locales/worldpay_missed_payment_forms.en.yml
@@ -1,0 +1,20 @@
+en:
+  worldpay_missed_payment_forms:
+    new:
+      title: "Add a missed WorldPay payment"
+      heading: "Add a missed WorldPay payment for %{reg_identifier}"
+  activemodel:
+    errors:
+      models:
+        worldpay_missed_payment_form:
+          attributes:
+            amount:
+              blank: "You must enter an amount"
+              not_a_number: "You must enter a valid number"
+              greater_than: "You must enter a positive number"
+            comment:
+              too_long: "Your comment must not be longer than 250 characters"
+            date_received:
+              blank: "You must enter a valid date"
+            registration_reference:
+              blank: "You must enter a reference"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,11 @@ Rails.application.routes.draw do
                         only: [:new, :create],
                         path: "payments/transfer",
                         path_names: { new: "" }
+
+              resources :worldpay_missed_payment_forms,
+                        only: [:new, :create],
+                        path: "payments/worldpay-missed",
+                        path_names: { new: "" }
             end
 
   mount WasteCarriersEngine::Engine => "/bo"

--- a/spec/requests/payments_spec.rb
+++ b/spec/requests/payments_spec.rb
@@ -49,17 +49,6 @@ RSpec.describe "Payments", type: :request do
         end
       end
 
-      context "when the payment_type is transfer" do
-        before do
-          params[:payment_type] = "transfer"
-        end
-
-        it "redirects to the transfer payment form" do
-          post "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments", payment_form: params
-          expect(response).to redirect_to(new_transient_registration_transfer_payment_form_path)
-        end
-      end
-
       context "when the payment_type is cheque" do
         before do
           params[:payment_type] = "cheque"
@@ -79,6 +68,28 @@ RSpec.describe "Payments", type: :request do
         it "redirects to the postal order payment form" do
           post "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments", payment_form: params
           expect(response).to redirect_to(new_transient_registration_postal_order_payment_form_path)
+        end
+      end
+
+      context "when the payment_type is transfer" do
+        before do
+          params[:payment_type] = "transfer"
+        end
+
+        it "redirects to the transfer payment form" do
+          post "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments", payment_form: params
+          expect(response).to redirect_to(new_transient_registration_transfer_payment_form_path)
+        end
+      end
+
+      context "when the payment_type is worldpay_missed" do
+        before do
+          params[:payment_type] = "worldpay_missed"
+        end
+
+        it "redirects to the worldpay_missed payment form" do
+          post "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments", payment_form: params
+          expect(response).to redirect_to(new_transient_registration_worldpay_missed_payment_form_path)
         end
       end
 

--- a/spec/requests/worldpay_missed_payment_forms_spec.rb
+++ b/spec/requests/worldpay_missed_payment_forms_spec.rb
@@ -2,46 +2,46 @@
 
 require "rails_helper"
 
-RSpec.describe "TransferPaymentForms", type: :request do
+RSpec.describe "WorldpayMissedPaymentForms", type: :request do
   let(:transient_registration) { create(:transient_registration, :has_finance_details) }
 
-  describe "GET /bo/transient-registrations/:reg_identifier/payments/transfer" do
+  describe "GET /bo/transient-registrations/:reg_identifier/payments/worldpay-missed" do
     context "when a valid user is signed in" do
-      let(:user) { create(:user, :finance) }
+      let(:user) { create(:user, :finance_admin) }
       before(:each) do
         sign_in(user)
       end
 
       it "renders the new template" do
-        get "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments/transfer"
+        get "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments/worldpay-missed"
         expect(response).to render_template(:new)
       end
 
       it "returns a 200 response" do
-        get "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments/transfer"
+        get "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments/worldpay-missed"
         expect(response).to have_http_status(200)
       end
 
       it "includes the reg identifier" do
-        get "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments/transfer"
+        get "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments/worldpay-missed"
         expect(response.body).to include(transient_registration.reg_identifier)
       end
     end
 
-    context "when a non-finance user is signed in" do
+    context "when a non-finance_admin user is signed in" do
       let(:user) { create(:user, :agency) }
       before(:each) do
         sign_in(user)
       end
 
       it "redirects to the permissions error page" do
-        get "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments/transfer"
+        get "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments/worldpay-missed"
         expect(response).to redirect_to("/bo/permission")
       end
     end
   end
 
-  describe "POST /bo/transient-registrations/:reg_identifier/payments/transfer" do
+  describe "POST /bo/transient-registrations/:reg_identifier/payments/worldpay-missed" do
     let(:params) do
       {
         reg_identifier: transient_registration.reg_identifier,
@@ -55,24 +55,24 @@ RSpec.describe "TransferPaymentForms", type: :request do
     end
 
     context "when a valid user is signed in" do
-      let(:user) { create(:user, :finance) }
+      let(:user) { create(:user, :finance_admin) }
       before(:each) do
         sign_in(user)
       end
 
       it "redirects to the transient_registration page" do
-        post "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments/transfer", transfer_payment_form: params
+        post "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments/worldpay-missed", worldpay_missed_payment_form: params
         expect(response).to redirect_to(transient_registration_path(transient_registration.reg_identifier))
       end
 
       it "creates a new payment" do
         old_payments_count = transient_registration.finance_details.payments.count
-        post "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments/transfer", transfer_payment_form: params
+        post "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments/worldpay-missed", worldpay_missed_payment_form: params
         expect(transient_registration.reload.finance_details.payments.count).to eq(old_payments_count + 1)
       end
 
       it "assigns the correct updated_by_user to the payment" do
-        post "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments/transfer", transfer_payment_form: params
+        post "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments/worldpay-missed", worldpay_missed_payment_form: params
         expect(transient_registration.reload.finance_details.payments.first.updated_by_user).to eq(user.email)
       end
 
@@ -85,43 +85,32 @@ RSpec.describe "TransferPaymentForms", type: :request do
         end
 
         it "renders the new template" do
-          post "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments/transfer", transfer_payment_form: params
+          post "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments/worldpay-missed", worldpay_missed_payment_form: params
           expect(response).to render_template(:new)
         end
 
         it "does not create a new payment" do
           old_payments_count = transient_registration.finance_details.payments.count
-          post "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments/transfer", transfer_payment_form: params
+          post "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments/worldpay-missed", worldpay_missed_payment_form: params
           expect(transient_registration.reload.finance_details.payments.count).to eq(old_payments_count)
         end
       end
     end
 
-    context "when a non-finance user is signed in" do
+    context "when a non-finance_admin user is signed in" do
       let(:user) { create(:user, :agency) }
       before(:each) do
         sign_in(user)
       end
 
       it "redirects to the permissions error page" do
-        post "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments/transfer", transfer_payment_form: params
+        post "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments/worldpay-missed", worldpay_missed_payment_form: params
         expect(response).to redirect_to("/bo/permission")
-      end
-
-      context "when the payment_type is worldpay_missed" do
-        before do
-          params[:payment_type] = "worldpay_missed"
-        end
-
-        it "redirects to the worldpay_missed payment form" do
-          post "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments", payment_form: params
-          expect(response).to redirect_to(new_transient_registration_worldpay_missed_payment_form_path)
-        end
       end
 
       it "does not create a new payment" do
         old_payments_count = transient_registration.finance_details.payments.count
-        post "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments/transfer", transfer_payment_form: params
+        post "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments/worldpay-missed", worldpay_missed_payment_form: params
         expect(transient_registration.reload.finance_details.payments.count).to eq(old_payments_count)
       end
     end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-377

A user with the agency or agency_with_refund role should be able to record when a WorldPay payment has been received, but wasn't automatically captured by the usual process (eg the payment was pending and not confirmed immediately).

This works in a very similar way to the bank transfer form we've previously added, although permissions for it are different.