### PR TITLE
Add link to sign out

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -40,6 +40,7 @@
 @import 'partials/people';
 @import 'partials/search';
 @import 'partials/tags';
+@import 'partials/user';
 
 main {
   max-width: 1080px;

--- a/app/assets/stylesheets/partials/_user.scss
+++ b/app/assets/stylesheets/partials/_user.scss
@@ -1,0 +1,4 @@
+// Signed-in info banner
+#user-status {
+  float: right;
+}

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -1,6 +1,21 @@
-<h1 class="heading-large">
-  <%= t(".heading") %>
-</h1>
+<div class="grid-row">
+  <div class="column-full">
+    <div id="user-status">
+      <p>
+        <%= t(".user_info.signed_in_user", email: current_user.email) %>
+        <%= link_to t(".user_info.sign_out_link"), destroy_user_session_path %>
+      </p>
+    </div>
+  </div>
+</div>
+
+<div class="grid-row">
+  <div class="column-full">
+    <h1 class="heading-large">
+      <%= t(".heading") %>
+    </h1>
+  </div>
+</div>
 
 <div class="grid-row">
   <div class="column-full">

--- a/config/locales/dashboard.en.yml
+++ b/config/locales/dashboard.en.yml
@@ -2,6 +2,9 @@ en:
   dashboards:
     index:
       title: "Renewals dashboard"
+      user_info:
+        signed_in_user: "Signed in as %{email}."
+        sign_out_link: "Sign out"
       heading: "Renewals dashboard"
       search:
         paragraph_1: "You can search for a renewal by:"


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-460

While there is a path to sign out, we didn't link to it, so users would not be able to end their session unless they knew the correct URL. This commit adds a link to sign out to the dashboard, as well as a mention of which account is currently signed in.