### PR TITLE
Configure back-office to send emails via SendGrid

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,11 @@ WCRS_BACKOFFICE_AIRBRAKE_PROJECT_KEY=longvaluefullofnumbersandlettersinlowercase
 # Only required when running the app in production. A default is used in
 # development and test
 SECRET_KEY_BASE=somescarylongvaluefullofnumbersandlettersinbothupperandlowercase
+
+# Email settings
+WCRS_EMAIL_HOST=
+WCRS_EMAIL_PORT=
+WCRS_EMAIL_USERNAME=""
+WCRS_EMAIL_PASSWORD=""
+WCRS_EMAIL_TEST_ADDRESS=""
+WCRS_EMAIL_SERVICE_EMAIL=""

--- a/app/mailers/test_mailer.rb
+++ b/app/mailers/test_mailer.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class TestMailer < ActionMailer::Base
+  def test_email
+    from_address = "#{Rails.configuration.email_service_name} <#{Rails.configuration.email_service_email}>"
+    subject = "Waste Carriers Test email"
+    mail(to: Rails.configuration.email_test_address,
+         subject: subject,
+         from: from_address) do |format|
+      format.text(content_type: "text/plain", charset: "UTF-8", content_transfer_encoding: "7bit")
+    end
+  end
+end

--- a/app/views/test_mailer/test_email.text.erb
+++ b/app/views/test_mailer/test_email.text.erb
@@ -1,0 +1,3 @@
+This is a test email sent from the Waste Carriers Registration service.
+
+https://github.com/DEFRA/waste-carriers-back-office

--- a/config/application.rb
+++ b/config/application.rb
@@ -97,6 +97,11 @@ module WasteCarriersBackOffice
     config.worldpay_password = ENV["WCRS_WORLDPAY_MOTO_PASSWORD"]
     config.worldpay_macsecret =  ENV["WCRS_WORLDPAY_MOTO_MACSECRET"]
 
+    # Emails
+    config.email_service_name = "Waste Carriers Registration Service"
+    config.email_service_email = ENV["WCRS_EMAIL_SERVICE_EMAIL"]
+    config.email_test_address = ENV["WCRS_EMAIL_TEST_ADDRESS"]
+
     # Digital or assisted digital metaData.route value
     config.metadata_route = "ASSISTED_DIGITAL"
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -13,8 +13,23 @@ Rails.application.configure do
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
 
-  # Don't care if the mailer can't send.
+  # Sending e-mails is required for user management and registration e-mails
+  config.action_mailer.default_url_options = { host: config.wcrs_back_office_url, protocol: "http" }
+
+  # Don't care if the mailer can't send (if set to false)
   config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.delivery_method = :smtp
+
+  # Default settings are for mailcatcher
+  config.action_mailer.smtp_settings = {
+    user_name: ENV["WCRS_EMAIL_USERNAME"],
+    password: ENV["WCRS_EMAIL_PASSWORD"],
+    domain: config.wcrs_back_office_url,
+    address: ENV["WCRS_EMAIL_HOST"] || "localhost",
+    port: ENV["WCRS_EMAIL_PORT"] || 1025,
+    authentication: :plain,
+    enable_starttls_auto: true
+  }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -87,13 +87,12 @@ Rails.application.configure do
   config.action_mailer.raise_delivery_errors = false
   config.action_mailer.delivery_method = :smtp
 
-  # Default settings are for mailcatcher
   config.action_mailer.smtp_settings = {
     user_name: ENV["WCRS_EMAIL_USERNAME"],
     password: ENV["WCRS_EMAIL_PASSWORD"],
     domain: config.wcrs_back_office_url,
-    address: ENV["WCRS_EMAIL_HOST"] || "localhost",
-    port: ENV["WCRS_EMAIL_PORT"] || 1025,
+    address: ENV["WCRS_EMAIL_HOST"],
+    port: ENV["WCRS_EMAIL_PORT"],
     authentication: :plain,
     enable_starttls_auto: true
   }

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -70,10 +70,6 @@ Rails.application.configure do
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'
 
-  # Ignore bad email addresses and do not raise email delivery errors.
-  # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
-
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true
@@ -83,4 +79,22 @@ Rails.application.configure do
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
+
+  # Sending e-mails is required for user management and registration e-mails
+  config.action_mailer.default_url_options = { host: config.wcrs_back_office_url, protocol: "http" }
+
+  # Don't care if the mailer can't send (if set to false)
+  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.delivery_method = :smtp
+
+  # Default settings are for mailcatcher
+  config.action_mailer.smtp_settings = {
+    user_name: ENV["WCRS_EMAIL_USERNAME"],
+    password: ENV["WCRS_EMAIL_PASSWORD"],
+    domain: config.wcrs_back_office_url,
+    address: ENV["WCRS_EMAIL_HOST"] || "localhost",
+    port: ENV["WCRS_EMAIL_PORT"] || 1025,
+    authentication: :plain,
+    enable_starttls_auto: true
+  }
 end

--- a/db/seeds/users.json
+++ b/db/seeds/users.json
@@ -1,52 +1,52 @@
 {
-	"users" : [
+  "users" : [
     {
-			"email" : "bo-agency-super@wcr.gov.uk",
-			"role" : "agency_super"
-		},
-		{
-			"email" : "bo-finance-super@wcr.gov.uk",
-			"role" : "finance_super"
-		},
-		{
-			"email" : "agency-super@wcr.gov.uk",
-			"role" : "agency_super"
-		},
-		{
-			"email" : "finance-super@wcr.gov.uk",
-			"role" : "finance_super"
-		},
-		{
-			"email" : "bo-user@wcr.gov.uk",
-			"role" : "agency"
-		},
-		{
-			"email" : "bo-user-with-refund@wcr.gov.uk",
-			"role" : "agency_with_refund"
-		},
-		{
-			"email" : "bo-finance-user@wcr.gov.uk",
-			"role" : "finance"
-		},
-		{
-			"email" : "bo-finance-admin@wcr.gov.uk",
-			"role" : "finance_admin"
-		},
-		{
-			"email" : "agency-user@wcr.gov.uk",
-			"role" : "agency"
-		},
-		{
-			"email" : "agency-refund-payment-user@wcr.gov.uk",
-			"role" : "agency_with_refund"
-		},
-		{
-			"email" : "finance-user@wcr.gov.uk",
-			"role" : "finance"
-		},
-		{
-			"email" : "finance-admin-user@wcr.gov.uk",
-			"role" : "finance_admin"
-		}
-	]
+      "email" : "bo-agency-super@wcr.gov.uk",
+      "role" : "agency_super"
+    },
+    {
+      "email" : "bo-finance-super@wcr.gov.uk",
+      "role" : "finance_super"
+    },
+    {
+      "email" : "agency-super@wcr.gov.uk",
+      "role" : "agency_super"
+    },
+    {
+      "email" : "finance-super@wcr.gov.uk",
+      "role" : "finance_super"
+    },
+    {
+      "email" : "bo-user@wcr.gov.uk",
+      "role" : "agency"
+    },
+    {
+      "email" : "bo-user-with-refund@wcr.gov.uk",
+      "role" : "agency_with_refund"
+    },
+    {
+      "email" : "bo-finance-user@wcr.gov.uk",
+      "role" : "finance"
+    },
+    {
+      "email" : "bo-finance-admin@wcr.gov.uk",
+      "role" : "finance_admin"
+    },
+    {
+      "email" : "agency-user@wcr.gov.uk",
+      "role" : "agency"
+    },
+    {
+      "email" : "agency-refund-payment-user@wcr.gov.uk",
+      "role" : "agency_with_refund"
+    },
+    {
+      "email" : "finance-user@wcr.gov.uk",
+      "role" : "finance"
+    },
+    {
+      "email" : "finance-admin-user@wcr.gov.uk",
+      "role" : "finance_admin"
+    }
+  ]
 }

--- a/lib/tasks/email.rake
+++ b/lib/tasks/email.rake
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+namespace :email do
+  desc "Send a test email to confirm confirm setup is correct"
+  task test: :environment do
+    puts TestMailer.test_email.deliver_now
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-393
https://eaflood.atlassian.net/browse/WC-353
https://eaflood.atlassian.net/browse/WC-354

The engine will be responsible for building emails and triggering when they are sent (see DEFRA/waste-carriers-renewals#261 for implementation of the completed renewal confirmation email). However, as the host applications are sending the emails, they need to be configured to enable this.