### PR TITLE
Clarify account_email label on transient_registration page

### DIFF
--- a/config/locales/transient_registrations.en.yml
+++ b/config/locales/transient_registrations.en.yml
@@ -22,7 +22,7 @@ en:
       reg_information:
         heading: "Registration information"
         labels:
-          account_email: "User"
+          account_email: "User account email"
           reg_identifier: "Registration number"
           tier: "Tier"
           registration_type: "Registration type"


### PR DESCRIPTION
We already displayed the account_email attribute, but it wasn't entirely clear what this attribute was. This microcopy change should clarify things.