### PR TITLE
Better renewal end screens for back office users

### DIFF
--- a/config/locales/waste_carriers_engine.en.yml
+++ b/config/locales/waste_carriers_engine.en.yml
@@ -1,0 +1,7 @@
+en:
+  waste_carriers_engine:
+    dashboard_link: "%{root}/registrations"
+    renewal_received_forms:
+      new:
+        conviction_check_subheading: This renewal requires a conviction check
+        conviction_check_paragraph_1: The renewal will not be completed until we have reviewed the registration for possible matching convictions. We'll check your details and let you know whether your application has been successful. We aim to do this within 10 working days.


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-478

Currently the renewal_complete and renewal_received forms show the same content to all users regardless of which app they are mounted in.

Most of the time, this is fine - however, it does cause some problems on these two pages at the end of the renewals journey, as back office users require different links and information.

This relies on https://github.com/DEFRA/waste-carriers-renewals/pull/270