### PR TITLE
Fix finish link not going to backend

### DIFF
--- a/config/locales/waste_carriers_engine.en.yml
+++ b/config/locales/waste_carriers_engine.en.yml
@@ -1,6 +1,6 @@
 en:
   waste_carriers_engine:
-    dashboard_link: "%{root}/registrations"
+    dashboard_link: "/registrations"
     renewal_received_forms:
       new:
         conviction_check_subheading: This renewal requires a conviction check


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-478

PR #130 brought in a version of the renewals engine which allows us to override the link to the backend dashboard in the engine. However when tested in our DEVELOPMENT environment (which is setup as PRODUCTION) the link was still using the external domain, hence users would be redirected to the frontend.

This change ensures that the clicking the button takes you to the backend dashboard.
