### PR TITLE
NCCC users can send renewal stuck in WorldPay back to payment summary

### DIFF
--- a/app/controllers/worldpay_escapes_controller.rb
+++ b/app/controllers/worldpay_escapes_controller.rb
@@ -31,7 +31,7 @@ class WorldpayEscapesController < ApplicationController
   end
 
   def change_state_to_payment_summary
-    @transient_registration.workflow_state = "payment_summary_form"
+    @transient_registration.update_attributes(workflow_state: "payment_summary_form")
   end
 
   def continue_renewal_path

--- a/app/controllers/worldpay_escapes_controller.rb
+++ b/app/controllers/worldpay_escapes_controller.rb
@@ -4,7 +4,12 @@ class WorldpayEscapesController < ApplicationController
   def new
     return unless set_up_valid_transient_registration?
 
-    redirect_to continue_renewal_path
+    if correct_workflow_state?
+      change_state_to_payment_summary
+      redirect_to continue_renewal_path
+    else
+      redirect_to transient_registration_path(@transient_registration.reg_identifier)
+    end
   end
 
   private
@@ -15,7 +20,15 @@ class WorldpayEscapesController < ApplicationController
                                                                         .first
   end
 
+  def correct_workflow_state?
+    @transient_registration.workflow_state == "worldpay_form"
+  end
+
+  def change_state_to_payment_summary
+    @transient_registration.workflow_state = "payment_summary_form"
+  end
+
   def continue_renewal_path
-    WasteCarriersEngine::Engine.routes.url_helpers.new_renewal_start_form_path(@transient_registration.reg_identifier)
+    WasteCarriersEngine::Engine.routes.url_helpers.new_payment_summary_form_path(@transient_registration.reg_identifier)
   end
 end

--- a/app/controllers/worldpay_escapes_controller.rb
+++ b/app/controllers/worldpay_escapes_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class WorldpayEscapesController < ApplicationController
+  def new
+    return unless set_up_valid_transient_registration?
+
+    redirect_to continue_renewal_path
+  end
+
+  private
+
+  def set_up_valid_transient_registration?
+    reg_identifier = params[:transient_registration_reg_identifier]
+    @transient_registration = WasteCarriersEngine::TransientRegistration.where(reg_identifier: reg_identifier)
+                                                                        .first
+  end
+
+  def continue_renewal_path
+    WasteCarriersEngine::Engine.routes.url_helpers.new_renewal_start_form_path(@transient_registration.reg_identifier)
+  end
+end

--- a/app/controllers/worldpay_escapes_controller.rb
+++ b/app/controllers/worldpay_escapes_controller.rb
@@ -4,6 +4,8 @@ class WorldpayEscapesController < ApplicationController
   def new
     return unless set_up_valid_transient_registration?
 
+    authorize
+
     if correct_workflow_state?
       change_state_to_payment_summary
       redirect_to continue_renewal_path
@@ -18,6 +20,10 @@ class WorldpayEscapesController < ApplicationController
     reg_identifier = params[:transient_registration_reg_identifier]
     @transient_registration = WasteCarriersEngine::TransientRegistration.where(reg_identifier: reg_identifier)
                                                                         .first
+  end
+
+  def authorize
+    authorize! :revert_to_payment_summary, @transient_registration
   end
 
   def correct_workflow_state?

--- a/app/controllers/worldpay_escapes_controller.rb
+++ b/app/controllers/worldpay_escapes_controller.rb
@@ -8,6 +8,7 @@ class WorldpayEscapesController < ApplicationController
 
     if correct_workflow_state?
       change_state_to_payment_summary
+      log_worldpay_escape
       redirect_to continue_renewal_path
     else
       redirect_to transient_registration_path(@transient_registration.reg_identifier)
@@ -32,6 +33,12 @@ class WorldpayEscapesController < ApplicationController
 
   def change_state_to_payment_summary
     @transient_registration.update_attributes(workflow_state: "payment_summary_form")
+  end
+
+  def log_worldpay_escape
+    message = "#{current_user.email} sent #{@transient_registration.reg_identifier} back to payment summary"
+    Rails.logger.debug message
+    Airbrake.notify message
   end
 
   def continue_renewal_path

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -24,6 +24,8 @@ class Ability
     can :record_postal_order_payment, WasteCarriersEngine::TransientRegistration
 
     can :review_convictions, WasteCarriersEngine::TransientRegistration
+
+    can :revert_to_payment_summary, WasteCarriersEngine::TransientRegistration
   end
 
   def permissions_for_finance_user

--- a/app/views/transient_registrations/show.html.erb
+++ b/app/views/transient_registrations/show.html.erb
@@ -43,12 +43,25 @@
         <h2 class="heading-medium">
           <%= t(".status.headings.in_progress") %>
         </h2>
-        <p>
-          <%= t(".status.messages.in_progress") %> "<%= display_current_workflow_state %>".
-        </p>
 
-        <% if can? :update, @transient_registration %>
-          <%= link_to t(".status.actions.continue_button"), WasteCarriersEngine::Engine.routes.url_helpers.new_renewal_start_form_path(@transient_registration.reg_identifier), class: 'button' %>
+        <% if @transient_registration.workflow_state == "worldpay_form" %>
+          <p>
+            <%= t(".status.messages.worldpay.paragraph_1") %>
+          </p>
+
+          <% if can? :revert_to_payment_summary, @transient_registration %>
+            <p>
+              <%= t(".status.messages.worldpay.paragraph_2") %>
+            </p>
+            <%= link_to t(".status.actions.revert_to_payment_summary_button"), new_transient_registration_worldpay_escape_path(@transient_registration.reg_identifier), class: 'button' %>
+          <% end %>
+        <% else %>
+          <p>
+            <%= t(".status.messages.in_progress") %> "<%= display_current_workflow_state %>".
+          </p>
+          <% if can? :update, @transient_registration %>
+            <%= link_to t(".status.actions.continue_button"), WasteCarriersEngine::Engine.routes.url_helpers.new_renewal_start_form_path(@transient_registration.reg_identifier), class: 'button' %>
+          <% end %>
         <% end %>
       </div>
     <% end %>

--- a/config/locales/transient_registrations.en.yml
+++ b/config/locales/transient_registrations.en.yml
@@ -15,10 +15,14 @@ en:
           pending_convictions_check: "A convictions check is required before this registration can be renewed."
           pending_payment_and_convictions_check: "Payment and a convictions check are required before this registration can be renewed."
           rejected: "This renewal was rejected during a convictions check and cannot be completed. The current registration will remain active until it expires."
+          worldpay:
+            paragraph_1: "The user is currently attempting to pay by WorldPay."
+            paragraph_2: "If an error has occurred and the user is stuck, you can send the renewal back to the payment summary page. They can try to pay with WorldPay again, or select an alternative payment method."
         actions:
           continue_button: "Continue as assisted digital renewal"
           payment_button: "Process payment"
           convictions_check_button: "Check conviction matches"
+          revert_to_payment_summary_button: "Send back to payment summary"
       reg_information:
         heading: "Registration information"
         labels:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,6 +51,11 @@ Rails.application.routes.draw do
                         path: "payments/transfer",
                         path_names: { new: "" }
 
+              resources :worldpay_escapes,
+                        only: :new,
+                        path: "revert-to-payment-summary",
+                        path_names: { new: "" }
+
               resources :worldpay_missed_payment_forms,
                         only: [:new, :create],
                         path: "payments/worldpay-missed",

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -91,6 +91,10 @@ RSpec.describe User, type: :model do
         should be_able_to(:review_convictions, transient_registration)
       end
 
+      it "should be able to revert to payment summary" do
+        should be_able_to(:revert_to_payment_summary, transient_registration)
+      end
+
       it "should not be able to create an agency user" do
         should_not be_able_to(:create_agency_user, user)
       end
@@ -137,6 +141,10 @@ RSpec.describe User, type: :model do
 
       it "should be able to review convictions" do
         should be_able_to(:review_convictions, transient_registration)
+      end
+
+      it "should be able to revert to payment summary" do
+        should be_able_to(:revert_to_payment_summary, transient_registration)
       end
 
       it "should not be able to create an agency user" do
@@ -187,6 +195,10 @@ RSpec.describe User, type: :model do
         should_not be_able_to(:review_convictions, transient_registration)
       end
 
+      it "should not be able to revert to payment summary" do
+        should_not be_able_to(:revert_to_payment_summary, transient_registration)
+      end
+
       it "should not be able to create an agency user" do
         should_not be_able_to(:create_agency_user, user)
       end
@@ -233,6 +245,10 @@ RSpec.describe User, type: :model do
 
       it "should not be able to review convictions" do
         should_not be_able_to(:review_convictions, transient_registration)
+      end
+
+      it "should not be able to revert to payment summary" do
+        should_not be_able_to(:revert_to_payment_summary, transient_registration)
       end
 
       it "should not be able to create an agency user" do
@@ -283,6 +299,10 @@ RSpec.describe User, type: :model do
         should_not be_able_to(:review_convictions, transient_registration)
       end
 
+      it "should not be able to revert to payment summary" do
+        should_not be_able_to(:revert_to_payment_summary, transient_registration)
+      end
+
       it "should be able to create an agency user" do
         should be_able_to(:create_agency_user, user)
       end
@@ -329,6 +349,10 @@ RSpec.describe User, type: :model do
 
       it "should not be able to review convictions" do
         should_not be_able_to(:review_convictions, transient_registration)
+      end
+
+      it "should not be able to revert to payment summary" do
+        should_not be_able_to(:revert_to_payment_summary, transient_registration)
       end
 
       it "should be able to create an agency user" do

--- a/spec/requests/worldpay_escapes_spec.rb
+++ b/spec/requests/worldpay_escapes_spec.rb
@@ -24,6 +24,11 @@ RSpec.describe "WorldpayEscapes", type: :request do
           get "/bo/transient-registrations/#{reg_identifier}/revert-to-payment-summary"
           expect(response).to redirect_to WasteCarriersEngine::Engine.routes.url_helpers.new_payment_summary_form_path(reg_identifier)
         end
+
+        it "updates the workflow_state" do
+          get "/bo/transient-registrations/#{reg_identifier}/revert-to-payment-summary"
+          expect(transient_registration.reload.workflow_state).to eq("payment_summary_form")
+        end
       end
 
       context "when the workflow_state is not worldpay_form" do

--- a/spec/requests/worldpay_escapes_spec.rb
+++ b/spec/requests/worldpay_escapes_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "WorldpayEscapes", type: :request do
+  let(:transient_registration) { create(:transient_registration, workflow_state: "worldpay_form") }
+
+  describe "GET /bo/transient-registrations/:reg_identifier/revert-to-payment-summary" do
+    let(:user) { create(:user) }
+    before(:each) do
+      sign_in(user)
+    end
+
+    it "redirects" do
+      get "/bo/transient-registrations/#{transient_registration.reg_identifier}/revert-to-payment-summary"
+      expect(response.code).to eq("302")
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-487

On the transient registration overview page in the back office, if the current state is worldpay_form, the "Continue renewal" button should be replaced with a "Send back to payment summary" button.

When clicked, this button should change the workflow_state from worldpay_form to payment_summary_form and then redirect the user to the payment summary form.

This should allow NCCC to help out users who have somehow gotten stuck in the WorldPay stage.