### PR TITLE
 Don't automatically list all renewals in back office dashboard

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -6,6 +6,7 @@ class DashboardsController < ApplicationController
   def index
     set_term_and_filters
     @transient_registrations = Kaminari.paginate_array(matching_renewals).page params[:page]
+    @search_terms_or_filters_present = search_terms_or_filters_present?
   end
 
   private
@@ -28,5 +29,11 @@ class DashboardsController < ApplicationController
                                                      @pending_conviction_check)
 
     service.transient_registrations
+  end
+
+  def search_terms_or_filters_present?
+    return true if @term.present?
+
+    @in_progress || @pending_payment || @pending_conviction_check
   end
 end

--- a/app/services/transient_registration_finder_service.rb
+++ b/app/services/transient_registration_finder_service.rb
@@ -10,6 +10,8 @@ class TransientRegistrationFinderService
   end
 
   def transient_registrations
+    return [] if no_search_terms_or_filters?
+
     transient_registrations = WasteCarriersEngine::TransientRegistration.all.order_by("metaData.lastModified": :desc)
 
     transient_registrations = search_results(transient_registrations)
@@ -19,6 +21,14 @@ class TransientRegistrationFinderService
   end
 
   private
+
+  def no_search_terms_or_filters?
+    return false if @term.present?
+
+    return false if @in_progress || @pending_payment || @pending_conviction_check
+
+    true
+  end
 
   def search_results(transient_registrations)
     return transient_registrations unless @term.present?

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -132,7 +132,7 @@
     </div>
   </div>
 
-<% else %>
+<% elsif @search_terms_or_filters_present %>
 
 <hr>
 

--- a/spec/requests/dashboards_spec.rb
+++ b/spec/requests/dashboards_spec.rb
@@ -20,12 +20,14 @@ RSpec.describe "Dashboards", type: :request do
         expect(response).to have_http_status(200)
       end
 
-      it "links to renewal details pages" do
-        last_modified_renewal = create(:transient_registration)
-        link_to_renewal = transient_registration_path(last_modified_renewal.reg_identifier)
+      context "when a search term is included" do
+        it "links to renewal details pages" do
+          last_modified_renewal = create(:transient_registration)
+          link_to_renewal = transient_registration_path(last_modified_renewal.reg_identifier)
 
-        get "/bo"
-        expect(response.body).to include(link_to_renewal)
+          get "/bo", term: last_modified_renewal.reg_identifier
+          expect(response.body).to include(link_to_renewal)
+        end
       end
     end
 

--- a/spec/requests/dashboards_spec.rb
+++ b/spec/requests/dashboards_spec.rb
@@ -21,12 +21,21 @@ RSpec.describe "Dashboards", type: :request do
       end
 
       context "when a search term is included" do
-        it "links to renewal details pages" do
-          last_modified_renewal = create(:transient_registration)
-          link_to_renewal = transient_registration_path(last_modified_renewal.reg_identifier)
+        context "when there are matches" do
+          it "links to renewal details pages" do
+            last_modified_renewal = create(:transient_registration)
+            link_to_renewal = transient_registration_path(last_modified_renewal.reg_identifier)
 
-          get "/bo", term: last_modified_renewal.reg_identifier
-          expect(response.body).to include(link_to_renewal)
+            get "/bo", term: last_modified_renewal.reg_identifier
+            expect(response.body).to include(link_to_renewal)
+          end
+        end
+
+        context "when there are no matches" do
+          it "says there are no results" do
+            get "/bo", term: "foobarbaz"
+            expect(response.body).to include("No results")
+          end
         end
       end
     end

--- a/spec/services/transient_registration_finder_service_spec.rb
+++ b/spec/services/transient_registration_finder_service_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe TransientRegistrationFinderService do
 
   context "when there are no filters" do
     context "when there is no search term" do
-      it "returns all renewals" do
-        expect(transient_registrations).to include(non_matching_renewal)
+      it "returns no renewals" do
+        expect(transient_registrations).to eq([])
       end
     end
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-485

Currently the back office dashboard displays all renewals by default. The issue is now we have a number in progress, it makes coming back to this page quite slow.

Ideally the page would only list results when a user searches or filters. This should reduce the page load time.