### PR TITLE
Use shared displayable_address method for displaying addresses

### DIFF
--- a/app/helpers/transient_registrations_helper.rb
+++ b/app/helpers/transient_registrations_helper.rb
@@ -16,21 +16,11 @@ module TransientRegistrationsHelper
   end
 
   def display_registered_address
-    address_lines(@transient_registration.registered_address)
+    displayable_address(@transient_registration.registered_address)
   end
 
   def display_contact_address
-    address_lines(@transient_registration.contact_address)
-  end
-
-  def address_lines(address)
-    [address.address_line_1,
-     address.address_line_2,
-     address.address_line_3,
-     address.address_line_4,
-     address.town_city,
-     address.postcode,
-     address.country].compact
+    displayable_address(@transient_registration.contact_address)
   end
 
   def key_people_with_conviction_search_results?

--- a/spec/helpers/transient_registrations_helper_spec.rb
+++ b/spec/helpers/transient_registrations_helper_spec.rb
@@ -56,7 +56,8 @@ RSpec.describe WasteCarriersEngine::ApplicationHelper, type: :helper do
       end
 
       it "returns the required values in an array" do
-        array = ["Foo Gardens",
+        array = ["42",
+                 "Foo Gardens",
                  "Baz City",
                  "FA1 1KE"]
         expect(helper.display_registered_address).to eq(array)
@@ -71,7 +72,8 @@ RSpec.describe WasteCarriersEngine::ApplicationHelper, type: :helper do
       end
 
       it "returns the required values in an array" do
-        array = ["Foo Gardens",
+        array = ["42",
+                 "Foo Gardens",
                  "Baz City",
                  "FA1 1KE"]
         expect(helper.display_contact_address).to eq(array)


### PR DESCRIPTION
The `address_lines` method is another example of duplication which can now be replaced by the method added in https://github.com/DEFRA/waste-carriers-renewals/pull/281