### PR TITLE
Add rake task to fix addresses in incorrect format

### DIFF
--- a/lib/tasks/addresses.rake
+++ b/lib/tasks/addresses.rake
@@ -22,8 +22,8 @@ end
 
 def update_addresses_for(registrations)
   registrations.each do |registration|
-    update_address (registration.registered_address) if address_is_from_os_places?(registration.registered_address)
-    update_address (registration.contact_address) if address_is_from_os_places?(registration.contact_address)
+    update_address(registration.registered_address) if address_is_from_os_places?(registration.registered_address)
+    update_address(registration.contact_address) if address_is_from_os_places?(registration.contact_address)
   end
 end
 
@@ -59,15 +59,11 @@ def search_by_uprn(uprn)
   url = "#{Rails.configuration.os_places_service_url}/addresses/#{uprn}"
 
   begin
-    response = RestClient::Request.execute(
-      method: :get,
-      url: url
-    )
+    response = RestClient::Request.execute(method: :get, url: url)
 
     begin
       JSON.parse(response)
     rescue JSON::ParserError => e
-      Airbrake.notify(e) if defined?(Airbrake)
       Rails.logger.error "OS Places JSON error: " + e.to_s
       nil
     end
@@ -75,11 +71,9 @@ def search_by_uprn(uprn)
     Rails.logger.debug "OS Places: resource not found"
     nil
   rescue RestClient::ExceptionWithResponse => e
-    Airbrake.notify(e) if defined?(Airbrake)
     Rails.logger.error "OS Places response error: " + e.to_s
     nil
   rescue SocketError => e
-    Airbrake.notify(e) if defined?(Airbrake)
     Rails.logger.error "OS Places socket error: " + e.to_s
     nil
   end

--- a/lib/tasks/addresses.rake
+++ b/lib/tasks/addresses.rake
@@ -3,6 +3,64 @@
 namespace :address do
   desc "Fix addresses set in the renewals process to match old data format"
   task update_from_os_places: :environment do
-    puts "TODO"
+    registrations = WasteCarriersEngine::Registration.where(:past_registration.exists => true)
+    transient_registrations = WasteCarriersEngine::TransientRegistration.where(:addresses.exists => true)
+
+    update_addresses_for(registrations)
+    update_addresses_for(transient_registrations)
   end
+end
+
+def update_addresses_for(registrations)
+  registrations.each do |registration|
+    update_address_if_necessary(registration.registered_address)
+    update_address_if_necessary(registration.contact_address)
+  end
+end
+
+def update_address_if_necessary(address)
+  update_address(address) if address_is_from_os_places?(address)
+end
+
+def address_is_from_os_places?(address)
+  address.present? && address.address_mode == "address-results"
+end
+
+def update_address(old_address)
+  new_address = build_updated_address(old_address)
+
+  return unless new_address
+  replace_old_address(old_address, new_address)
+end
+
+def build_updated_address(old_address)
+  # Send request to OS Places
+  address_results = WasteCarriersEngine::AddressFinderService.new(old_address.postcode).search_by_postcode
+
+  # Find the correct match - use UPRN :)
+  matching_address = address_results.find { |result| result["uprn"] == old_address.uprn.to_s }
+
+  if matching_address.blank?
+    puts "Could not update #{old_address.address_type} address for #{old_address._parent.class} #{old_address._parent.reg_identifier} - no matching address found for UPRN #{old_address.uprn}"
+    return nil
+  end
+
+  # Create new address
+  new_address = WasteCarriersEngine::Address.create_from_os_places_data(matching_address)
+  new_address.address_type = old_address.address_type
+
+  new_address
+end
+
+def replace_old_address(old_address, new_address)
+  parent = old_address._parent
+
+  # Update the transient object's nested addresses, replacing any existing address of the same type
+  updated_addresses = parent.addresses
+  updated_addresses.delete(old_address)
+  updated_addresses << new_address
+  parent.addresses = updated_addresses
+
+  puts "Updating #{old_address.address_type} address for #{parent.class} #{parent.reg_identifier}"
+  parent.save!
 end

--- a/lib/tasks/addresses.rake
+++ b/lib/tasks/addresses.rake
@@ -13,13 +13,9 @@ end
 
 def update_addresses_for(registrations)
   registrations.each do |registration|
-    update_address_if_necessary(registration.registered_address)
-    update_address_if_necessary(registration.contact_address)
+    update_address (registration.registered_address) if address_is_from_os_places?(registration.registered_address)
+    update_address (registration.contact_address) if address_is_from_os_places?(registration.contact_address)
   end
-end
-
-def update_address_if_necessary(address)
-  update_address(address) if address_is_from_os_places?(address)
 end
 
 def address_is_from_os_places?(address)

--- a/lib/tasks/addresses.rake
+++ b/lib/tasks/addresses.rake
@@ -3,12 +3,19 @@
 namespace :address do
   desc "Fix addresses set in the renewals process to match old data format"
   task update_from_os_places: :environment do
-    registrations = WasteCarriersEngine::Registration.where(:past_registration.exists => true)
-    transient_registrations = WasteCarriersEngine::TransientRegistration.where(:addresses.exists => true)
-
-    update_addresses_for(registrations)
-    update_addresses_for(transient_registrations)
+    update_addresses_for_registrations
+    update_addresses_for_transient_registrations
   end
+end
+
+def update_addresses_for_registrations
+  registrations = WasteCarriersEngine::Registration.where(:past_registration.exists => true)
+  update_addresses_for(registrations)
+end
+
+def update_addresses_for_transient_registrations
+  transient_registrations = WasteCarriersEngine::TransientRegistration.where(:addresses.exists => true)
+  update_addresses_for(transient_registrations)
 end
 
 def update_addresses_for(registrations)

--- a/lib/tasks/addresses.rake
+++ b/lib/tasks/addresses.rake
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+namespace :address do
+  desc "Fix addresses set in the renewals process to match old data format"
+  task update_from_os_places: :environment do
+    puts "TODO"
+  end
+end

--- a/lib/tasks/addresses.rake
+++ b/lib/tasks/addresses.rake
@@ -28,8 +28,8 @@ end
 
 def update_address(old_address)
   new_address = build_updated_address(old_address)
-
   return unless new_address
+
   replace_old_address(old_address, new_address)
 end
 
@@ -41,7 +41,9 @@ def build_updated_address(old_address)
   matching_address = address_results.find { |result| result["uprn"] == old_address.uprn.to_s }
 
   if matching_address.blank?
-    puts "Could not update #{old_address.address_type} address for #{old_address._parent.class} #{old_address._parent.reg_identifier} - no matching address found for UPRN #{old_address.uprn}"
+    parent = old_address._parent
+    puts "Could not update #{old_address.address_type} address for #{parent.class} #{parent.reg_identifier}"\
+         " - no matching address found for UPRN #{old_address.uprn}"
     return nil
   end
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-500

Once we roll out our fix to make waste-carriers-renewals and waste-carriers-frontend save addresses from OS Places in the same format, we will still have some addresses which have already been saved.

Running this rake task should find the addresses and correct them, so all addresses are in a consistent format.