### PR TITLE
Add missing translation for overseas business types

### DIFF
--- a/config/locales/transient_registrations.en.yml
+++ b/config/locales/transient_registrations.en.yml
@@ -118,6 +118,7 @@ en:
           authority: "Local authority"
           publicBody: "Public body"
           other: "Other"
+          overseas: "Overseas"
         declaration:
           "1": "Yes"
         finance_details:


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-511

This fixes a translation error on the transient registration page.