### PR TITLE
Update wcr-renewals to ver. with PDF email attach

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ gem "kaminari-mongoid", "~> 1.0"
 # Use the waste carriers engine for the user journey
 gem "waste_carriers_engine",
     git: "https://github.com/DEFRA/waste-carriers-renewals",
-    branch: "master"
+    branch: "generate-pdf-registrations"
 
 # Allows us to automatically generate the change log from the tags, issues,
 # labels and pull requests on GitHub. Added as a dependency so all dev's have

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-renewals
-  revision: d6b669645662afe188a1278a6438404fc94bbe8d
-  branch: master
+  revision: 8f8b6b0251d40e2f1aee7d6f4e9ba905867549ad
+  branch: generate-pdf-registrations
   specs:
     waste_carriers_engine (0.0.1)
       aasm (~> 4.12)
@@ -17,6 +17,7 @@ GIT
       turbolinks
       uk_postcode
       validates_email_format_of
+      wicked_pdf
 
 GEM
   remote: https://rubygems.org/
@@ -332,6 +333,7 @@ GEM
       binding_of_caller (>= 0.7.2)
       railties (>= 4.0)
       sprockets-rails (>= 2.0, < 4.0)
+    wicked_pdf (1.1.0)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-479

The frontend application generates and attachs a PDF version of the registration (often referred to as the 'certificate') to the confirmation email.

Renewals was shipped without this feature, but always with the intention of adding it later. The functionality has been added to the shared [waste-carriers-renewals](https://github.com/DEFRA/waste-carriers-renewals/) project, so this change just covers bumping back office to a version of renewals that includes it.

🎉 WIP 🎉

N.B. Currently the Gemfile points to a branch in renewals rather than master, as it is waiting for the PR to be completed.