### PR TITLE
Display expiry date of registration in back office

### DIFF
--- a/app/helpers/transient_registrations_helper.rb
+++ b/app/helpers/transient_registrations_helper.rb
@@ -15,6 +15,14 @@ module TransientRegistrationsHelper
       @transient_registration.workflow_state
   end
 
+  def display_expiry_date
+    original_registration.expires_on
+  end
+
+  def display_registration_status
+    original_registration.metaData.status
+  end
+
   def display_registered_address
     displayable_address(@transient_registration.registered_address)
   end
@@ -36,5 +44,11 @@ module TransientRegistrationsHelper
 
     all_requirements = @transient_registration.key_people.map(&:conviction_check_required?)
     all_requirements.count(true)
+  end
+
+  private
+
+  def original_registration
+    WasteCarriersEngine::Registration.where(reg_identifier: @transient_registration.reg_identifier).first
   end
 end

--- a/app/helpers/transient_registrations_helper.rb
+++ b/app/helpers/transient_registrations_helper.rb
@@ -20,7 +20,7 @@ module TransientRegistrationsHelper
   end
 
   def display_registration_status
-    original_registration.metaData.status
+    original_registration.metaData.status.titleize
   end
 
   def display_registered_address

--- a/app/helpers/transient_registrations_helper.rb
+++ b/app/helpers/transient_registrations_helper.rb
@@ -16,7 +16,7 @@ module TransientRegistrationsHelper
   end
 
   def display_expiry_date
-    original_registration.expires_on
+    original_registration.expires_on.to_date
   end
 
   def display_registration_status

--- a/app/views/transient_registrations/show.html.erb
+++ b/app/views/transient_registrations/show.html.erb
@@ -88,6 +88,22 @@
         </tr>
         <tr>
           <td>
+            <%= t(".reg_information.labels.expires_on") %>
+          </td>
+          <td>
+            <%= display_expiry_date %>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <%= t(".reg_information.labels.status") %>
+          </td>
+          <td>
+            <%= display_registration_status %>
+          </td>
+        </tr>
+        <tr>
+          <td>
             <%= t(".reg_information.labels.tier") %>
           </td>
           <td>

--- a/config/locales/transient_registrations.en.yml
+++ b/config/locales/transient_registrations.en.yml
@@ -28,6 +28,8 @@ en:
         labels:
           account_email: "User account email"
           reg_identifier: "Registration number"
+          expires_on: "Expires on"
+          status: "Registration status"
           tier: "Tier"
           registration_type: "Registration type"
       business_information:

--- a/spec/helpers/transient_registrations_helper_spec.rb
+++ b/spec/helpers/transient_registrations_helper_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe WasteCarriersEngine::ApplicationHelper, type: :helper do
 
   describe "#display_registration_status" do
     it "displays the correct value" do
-      expect(helper.display_registration_status).to eq("ACTIVE")
+      expect(helper.display_registration_status).to eq("Active")
     end
   end
 

--- a/spec/helpers/transient_registrations_helper_spec.rb
+++ b/spec/helpers/transient_registrations_helper_spec.rb
@@ -52,10 +52,10 @@ RSpec.describe WasteCarriersEngine::ApplicationHelper, type: :helper do
 
   describe "#display_expiry_date" do
     it "displays the correct date" do
-      correct_expiry_date = DateTime.new(2000).in_time_zone("UTC")
+      correct_expiry_date = DateTime.new(2000, 1, 2, 3, 4, 5).in_time_zone("UTC")
       registration.update_attributes(expires_on: correct_expiry_date)
 
-      expect(helper.display_expiry_date).to eq(correct_expiry_date)
+      expect(helper.display_expiry_date).to eq(Date.new(2000, 1, 2))
     end
   end
 

--- a/spec/helpers/transient_registrations_helper_spec.rb
+++ b/spec/helpers/transient_registrations_helper_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 RSpec.describe WasteCarriersEngine::ApplicationHelper, type: :helper do
   let(:transient_registration) { build(:transient_registration) }
+  let(:registration) { WasteCarriersEngine::Registration.where(reg_identifier: transient_registration.reg_identifier).first }
 
   before do
     assign(:transient_registration, transient_registration)
@@ -46,6 +47,21 @@ RSpec.describe WasteCarriersEngine::ApplicationHelper, type: :helper do
       it "returns the value" do
         expect(helper.display_current_workflow_state).to eq("foo")
       end
+    end
+  end
+
+  describe "#display_expiry_date" do
+    it "displays the correct date" do
+      correct_expiry_date = DateTime.new(2000).in_time_zone("UTC")
+      registration.update_attributes(expires_on: correct_expiry_date)
+
+      expect(helper.display_expiry_date).to eq(correct_expiry_date)
+    end
+  end
+
+  describe "#display_registration_status" do
+    it "displays the correct value" do
+      expect(helper.display_registration_status).to eq("ACTIVE")
     end
   end
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-515

Currently you only see details of the renewal, and not the original registration in the back office.

We have had reported issues where a renewal appears to be stuck, and the problem is that the registration has expired which prevents the renewal from completing. However, the only way to confirm this is to look up the original registration.

We believe it will be useful to see the expiry date and status of a registration within the back office, so that NCCC advisors can see why a renewal may now be stuck, and to aid with prioritisation.