### PR TITLE
Transfer a registration to an existing account

### DIFF
--- a/app/controllers/registration_transfers_controller.rb
+++ b/app/controllers/registration_transfers_controller.rb
@@ -26,6 +26,7 @@ class RegistrationTransfersController < ApplicationController
 
   def submit_form
     if @registration_transfer_form.submit(params[:registration_transfer_form])
+      transfer_registration
       redirect_to bo_path
       true
     else
@@ -40,5 +41,10 @@ class RegistrationTransfersController < ApplicationController
 
   def authorize_action
     authorize! :transfer_registration, @registration
+  end
+
+  def transfer_registration
+    registration_transfer_service = RegistrationTransferService.new(@registration)
+    registration_transfer_service.transfer_to_user(@registration_transfer_form.email)
   end
 end

--- a/app/controllers/registration_transfers_controller.rb
+++ b/app/controllers/registration_transfers_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class RegistrationTransfersController < ApplicationController
+  before_action :authenticate_user!
+
+  def new; end
+
+  def create
+    redirect_to bo_path
+  end
+end

--- a/app/controllers/registration_transfers_controller.rb
+++ b/app/controllers/registration_transfers_controller.rb
@@ -4,13 +4,13 @@ class RegistrationTransfersController < ApplicationController
   before_action :authenticate_user!
 
   def new
-    set_up_form(params[:reg_identifier])
+    build_form(params[:reg_identifier])
 
     authorize_action
   end
 
   def create
-    return false unless set_up_form(params[:registration_transfer_form][:reg_identifier])
+    return false unless build_form(params[:registration_transfer_form][:reg_identifier])
 
     authorize_action
 
@@ -19,7 +19,7 @@ class RegistrationTransfersController < ApplicationController
 
   private
 
-  def set_up_form(reg_identifier)
+  def build_form(reg_identifier)
     find_registration(reg_identifier)
     @registration_transfer_form = RegistrationTransferForm.new(@registration)
   end

--- a/app/controllers/registration_transfers_controller.rb
+++ b/app/controllers/registration_transfers_controller.rb
@@ -30,7 +30,6 @@ class RegistrationTransfersController < ApplicationController
 
   def submit_form
     if @registration_transfer_form.submit(params[:registration_transfer_form])
-      transfer_registration
       redirect_to registration_transfer_success_path(params[:registration_transfer_form][:reg_identifier])
       true
     else
@@ -45,10 +44,5 @@ class RegistrationTransfersController < ApplicationController
 
   def authorize_action
     authorize! :transfer_registration, @registration
-  end
-
-  def transfer_registration
-    registration_transfer_service = RegistrationTransferService.new(@registration)
-    registration_transfer_service.transfer_to_user(@registration_transfer_form.email)
   end
 end

--- a/app/controllers/registration_transfers_controller.rb
+++ b/app/controllers/registration_transfers_controller.rb
@@ -4,17 +4,35 @@ class RegistrationTransfersController < ApplicationController
   before_action :authenticate_user!
 
   def new
-    find_registration(params[:reg_identifier])
+    set_up_form(params[:reg_identifier])
+
     authorize_action
   end
 
   def create
-    find_registration(params[:registration_transfer_form][:reg_identifier])
+    return false unless set_up_form(params[:registration_transfer_form][:reg_identifier])
+
     authorize_action
-    redirect_to bo_path
+
+    submit_form
   end
 
   private
+
+  def set_up_form(reg_identifier)
+    find_registration(reg_identifier)
+    @registration_transfer_form = RegistrationTransferForm.new(@registration)
+  end
+
+  def submit_form
+    if @registration_transfer_form.submit(params[:registration_transfer_form])
+      redirect_to bo_path
+      true
+    else
+      render :new
+      false
+    end
+  end
 
   def find_registration(reg_identifier)
     @registration = WasteCarriersEngine::Registration.where(reg_identifier: reg_identifier).first

--- a/app/controllers/registration_transfers_controller.rb
+++ b/app/controllers/registration_transfers_controller.rb
@@ -17,6 +17,10 @@ class RegistrationTransfersController < ApplicationController
     submit_form
   end
 
+  def success
+    find_registration(params[:reg_identifier])
+  end
+
   private
 
   def build_form(reg_identifier)
@@ -27,7 +31,7 @@ class RegistrationTransfersController < ApplicationController
   def submit_form
     if @registration_transfer_form.submit(params[:registration_transfer_form])
       transfer_registration
-      redirect_to bo_path
+      redirect_to registration_transfer_success_path(params[:registration_transfer_form][:reg_identifier])
       true
     else
       render :new

--- a/app/controllers/registration_transfers_controller.rb
+++ b/app/controllers/registration_transfers_controller.rb
@@ -3,9 +3,17 @@
 class RegistrationTransfersController < ApplicationController
   before_action :authenticate_user!
 
-  def new; end
+  def new
+    find_registration(params[:reg_identifier])
+  end
 
   def create
     redirect_to bo_path
+  end
+
+  private
+
+  def find_registration(reg_identifier)
+    @registration = WasteCarriersEngine::Registration.where(reg_identifier: reg_identifier).first
   end
 end

--- a/app/controllers/registration_transfers_controller.rb
+++ b/app/controllers/registration_transfers_controller.rb
@@ -5,9 +5,12 @@ class RegistrationTransfersController < ApplicationController
 
   def new
     find_registration(params[:reg_identifier])
+    authorize_action
   end
 
   def create
+    find_registration(params[:registration_transfer_form][:reg_identifier])
+    authorize_action
     redirect_to bo_path
   end
 
@@ -15,5 +18,9 @@ class RegistrationTransfersController < ApplicationController
 
   def find_registration(reg_identifier)
     @registration = WasteCarriersEngine::Registration.where(reg_identifier: reg_identifier).first
+  end
+
+  def authorize_action
+    authorize! :transfer_registration, @registration
   end
 end

--- a/app/forms/registration_transfer_form.rb
+++ b/app/forms/registration_transfer_form.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class RegistrationTransferForm < WasteCarriersEngine::BaseForm
+  attr_accessor :email, :confirm_email
+
+  def initialize(registration)
+    super
+  end
+
+  def submit(params)
+    attributes = {}
+
+    super(attributes, params[:reg_identifier])
+  end
+
+  validates :email, :confirm_email, presence: true
+end

--- a/app/forms/registration_transfer_form.rb
+++ b/app/forms/registration_transfer_form.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 class RegistrationTransferForm < WasteCarriersEngine::BaseForm
-  attr_accessor :email, :confirm_email
+  attr_accessor :email, :confirm_email, :registration
 
   def initialize(registration)
+    self.registration = registration
     super
   end
 
@@ -18,4 +19,15 @@ class RegistrationTransferForm < WasteCarriersEngine::BaseForm
 
   validates :email, :confirm_email, "waste_carriers_engine/email": true
   validates :confirm_email, "waste_carriers_engine/matching_email": { compare_to: :email }
+  validate :registration_transferred_successfully?
+
+  def registration_transferred_successfully?
+    registration_transfer_service = RegistrationTransferService.new(registration)
+    result = registration_transfer_service.transfer_to_user(email)
+
+    return true if result == :success_existing_user
+
+    errors[:email] << I18n.t("activemodel.errors.models.registration_transfer_form.attributes.email.#{result}")
+    false
+  end
 end

--- a/app/forms/registration_transfer_form.rb
+++ b/app/forms/registration_transfer_form.rb
@@ -8,6 +8,9 @@ class RegistrationTransferForm < WasteCarriersEngine::BaseForm
   end
 
   def submit(params)
+    self.email = params[:email]
+    self.confirm_email = params[:confirm_email]
+
     attributes = {}
 
     super(attributes, params[:reg_identifier])

--- a/app/forms/registration_transfer_form.rb
+++ b/app/forms/registration_transfer_form.rb
@@ -16,5 +16,6 @@ class RegistrationTransferForm < WasteCarriersEngine::BaseForm
     super(attributes, params[:reg_identifier])
   end
 
-  validates :email, :confirm_email, presence: true
+  validates :email, :confirm_email, "waste_carriers_engine/email": true
+  validates :confirm_email, "waste_carriers_engine/matching_email": { compare_to: :email }
 end

--- a/app/mailers/registration_transfer_mailer.rb
+++ b/app/mailers/registration_transfer_mailer.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class RegistrationTransferMailer < ActionMailer::Base
+  helper "waste_carriers_engine/mailer"
+
+  def transfer_to_existing_account_email(registration)
+    @registration = registration
+
+    to_address = @registration.account_email
+    from_address = "#{Rails.configuration.email_service_name} <#{Rails.configuration.email_service_email}>"
+    subject = I18n.t(".registration_transfer_mailer.transfer_to_existing_account_email.subject",
+                     reg_identifier: @registration.reg_identifier)
+
+    mail(to: to_address,
+         from: from_address,
+         subject: subject)
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -26,6 +26,8 @@ class Ability
     can :review_convictions, WasteCarriersEngine::TransientRegistration
 
     can :revert_to_payment_summary, WasteCarriersEngine::TransientRegistration
+
+    can :transfer_registration, WasteCarriersEngine::Registration
   end
 
   def permissions_for_finance_user

--- a/app/models/concerns/can_behave_like_user.rb
+++ b/app/models/concerns/can_behave_like_user.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module CanBehaveLikeUser
+  extend ActiveSupport::Concern
+
+  # rubocop:disable Metrics/BlockLength
+  included do
+    devise :database_authenticatable,
+           :invitable,
+           :lockable,
+           :recoverable,
+           :trackable,
+           :validatable
+
+    ## Confirmable
+    # Any user confirmation happens in the frontend app - however we need this flag to seed confirmed users
+    field :confirmed_at, type: DateTime
+
+    ## Database authenticatable
+    field :email,              type: String, default: ""
+    field :encrypted_password, type: String, default: ""
+
+    # Invitable
+    field :invitation_token,       type: String
+    field :invitation_created_at,  type: Time
+    field :invitation_sent_at,     type: Time
+    field :invitation_accepted_at, type: Time
+    field :invitation_limit,       type: Integer
+
+    index({ invitation_token: 1 }, background: true)
+    index({ invitation_by_id: 1 }, background: true)
+
+    ## Recoverable
+    field :reset_password_token,   type: String
+    field :reset_password_sent_at, type: Time
+
+    ## Trackable
+    field :sign_in_count,      type: Integer, default: 0
+    field :current_sign_in_at, type: Time
+    field :last_sign_in_at,    type: Time
+    field :current_sign_in_ip, type: String
+    field :last_sign_in_ip,    type: String
+
+    ## Lockable
+    field :failed_attempts, type: Integer, default: 0 # Only if lock strategy is :failed_attempts
+    field :unlock_token,    type: String # Only if unlock strategy is :email or :both
+    field :locked_at,       type: Time
+
+    # Validations
+    validates :password, presence: true, length: { in: 8..128 }
+    validate :password_must_have_lowercase_uppercase_and_numeric
+  end
+  # rubocop:enable Metrics/BlockLength
+
+  private
+
+  def password_must_have_lowercase_uppercase_and_numeric
+    has_lowercase = (password =~ /[a-z]/)
+    has_uppercase = (password =~ /[A-Z]/)
+    has_numeric = (password =~ /[0-9]/)
+
+    return true if has_lowercase && has_uppercase && has_numeric
+
+    errors.add(:password, I18n.t("errors.messages.weakPassword"))
+  end
+end

--- a/app/models/external_user.rb
+++ b/app/models/external_user.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class ExternalUser
+  include Mongoid::Document
+  include CanBehaveLikeUser
+
+  # Use the User database
+  store_in client: "users", collection: "users"
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,50 +2,10 @@
 
 class User
   include Mongoid::Document
+  include CanBehaveLikeUser
 
   # Use the User database
   store_in client: "users", collection: "back_office_users"
-
-  devise :database_authenticatable,
-         :invitable,
-         :lockable,
-         :recoverable,
-         :trackable,
-         :validatable
-
-  ## Confirmable
-  # Any user confirmation happens in the frontend app - however we need this flag to seed confirmed users
-  field :confirmed_at, type: DateTime
-
-  ## Database authenticatable
-  field :email,              type: String, default: ""
-  field :encrypted_password, type: String, default: ""
-
-  # Invitable
-  field :invitation_token,       type: String
-  field :invitation_created_at,  type: Time
-  field :invitation_sent_at,     type: Time
-  field :invitation_accepted_at, type: Time
-  field :invitation_limit,       type: Integer
-
-  index({ invitation_token: 1 }, background: true)
-  index({ invitation_by_id: 1 }, background: true)
-
-  ## Recoverable
-  field :reset_password_token,   type: String
-  field :reset_password_sent_at, type: Time
-
-  ## Trackable
-  field :sign_in_count,      type: Integer, default: 0
-  field :current_sign_in_at, type: Time
-  field :last_sign_in_at,    type: Time
-  field :current_sign_in_ip, type: String
-  field :last_sign_in_ip,    type: String
-
-  ## Lockable
-  field :failed_attempts, type: Integer, default: 0 # Only if lock strategy is :failed_attempts
-  field :unlock_token,    type: String # Only if unlock strategy is :email or :both
-  field :locked_at,       type: Time
 
   # Devise security improvements, used to invalidate old sessions on logout
   # Taken from https://makandracards.com/makandra/53562-devise-invalidating-all-sessions-for-a-user
@@ -59,7 +19,7 @@ class User
     self.session_token = SecureRandom.hex
   end
 
-  ## Roles
+  # Roles
 
   ROLES = %w[agency
              agency_with_refund
@@ -70,21 +30,7 @@ class User
 
   field :role, type: String
 
-  ## Validations
+  # Validations
 
-  validates :password, presence: true, length: { in: 8..128 }
-  validate :password_must_have_lowercase_uppercase_and_numeric
   validates :role, inclusion: { in: ROLES }
-
-  private
-
-  def password_must_have_lowercase_uppercase_and_numeric
-    has_lowercase = (password =~ /[a-z]/)
-    has_uppercase = (password =~ /[A-Z]/)
-    has_numeric = (password =~ /[0-9]/)
-
-    return true if has_lowercase && has_uppercase && has_numeric
-
-    errors.add(:password, I18n.t("errors.messages.weakPassword"))
-  end
 end

--- a/app/services/registration_transfer_service.rb
+++ b/app/services/registration_transfer_service.rb
@@ -37,5 +37,8 @@ class RegistrationTransferService
 
   def send_confirmation_email
     RegistrationTransferMailer.transfer_to_existing_account_email(@registration).deliver_now
+  rescue StandardError => e
+    Airbrake.notify(e) if defined?(Airbrake)
+    Rails.logger.error "Registration transfer confirmation email error: " + e.to_s
   end
 end

--- a/app/services/registration_transfer_service.rb
+++ b/app/services/registration_transfer_service.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class RegistrationTransferService
+  def initialize(registration)
+    @registration = registration
+    @transient_registration = find_transient_registration
+  end
+
+  private
+
+  def find_transient_registration
+    WasteCarriersEngine::TransientRegistration.where(reg_identifier: @registration.reg_identifier).first
+  end
+end

--- a/app/services/registration_transfer_service.rb
+++ b/app/services/registration_transfer_service.rb
@@ -12,6 +12,8 @@ class RegistrationTransferService
 
     update_account_email_for(@registration)
     update_account_email_for(@transient_registration) if @transient_registration.present?
+
+    send_confirmation_email
   end
 
   private
@@ -29,5 +31,9 @@ class RegistrationTransferService
   def update_account_email_for(registration)
     registration.account_email = @recipient_user.email
     registration.save!
+  end
+
+  def send_confirmation_email
+    RegistrationTransferMailer.transfer_to_existing_account_email(@registration).deliver_now
   end
 end

--- a/app/services/registration_transfer_service.rb
+++ b/app/services/registration_transfer_service.rb
@@ -8,8 +8,10 @@ class RegistrationTransferService
 
   def transfer_to_user(email)
     @recipient_user = find_user(email)
-
     return :no_matching_user if @recipient_user.blank?
+
+    update_account_email_for(@registration)
+    update_account_email_for(@transient_registration) if @transient_registration.present?
   end
 
   private
@@ -22,5 +24,10 @@ class RegistrationTransferService
     return nil unless email.present?
 
     ExternalUser.where(email: email).first
+  end
+
+  def update_account_email_for(registration)
+    registration.account_email = @recipient_user.email
+    registration.save!
   end
 end

--- a/app/services/registration_transfer_service.rb
+++ b/app/services/registration_transfer_service.rb
@@ -8,6 +8,8 @@ class RegistrationTransferService
 
   def transfer_to_user(email)
     @recipient_user = find_user(email)
+
+    return :no_matching_user if @recipient_user.blank?
   end
 
   private

--- a/app/services/registration_transfer_service.rb
+++ b/app/services/registration_transfer_service.rb
@@ -6,9 +6,19 @@ class RegistrationTransferService
     @transient_registration = find_transient_registration
   end
 
+  def transfer_to_user(email)
+    @recipient_user = find_user(email)
+  end
+
   private
 
   def find_transient_registration
     WasteCarriersEngine::TransientRegistration.where(reg_identifier: @registration.reg_identifier).first
+  end
+
+  def find_user(email)
+    return nil unless email.present?
+
+    ExternalUser.where(email: email).first
   end
 end

--- a/app/services/registration_transfer_service.rb
+++ b/app/services/registration_transfer_service.rb
@@ -14,6 +14,8 @@ class RegistrationTransferService
     update_account_email_for(@transient_registration) if @transient_registration.present?
 
     send_confirmation_email
+
+    :success_existing_user
   end
 
   private

--- a/app/views/registration_transfer_mailer/transfer_to_existing_account_email.html.erb
+++ b/app/views/registration_transfer_mailer/transfer_to_existing_account_email.html.erb
@@ -61,8 +61,15 @@
           </tr>
           <tr>
             <td width="75%" style="font-family: Helvetica, Arial, sans-serif;">
+              <p style="font-size: 19px; line-height: 1.315789474; margin: 15px 0 15px 0;">
+                <%= t(".paragraph_1", company_name: @registration.company_name) %>
+              </p>
               <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 15px 0;">
-                <%= t(".paragraph_1") %>
+                <%= t(".paragraph_2", email: @registration.account_email) %>
+              </p>
+
+              <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 15px 0;">
+                <%= link_to t(".log_in_link"), "#{Rails.configuration.wcrs_frontend_url}/users/sign_in" %>
               </p>
 
               <ul>

--- a/app/views/registration_transfer_mailer/transfer_to_existing_account_email.html.erb
+++ b/app/views/registration_transfer_mailer/transfer_to_existing_account_email.html.erb
@@ -1,0 +1,86 @@
+<!doctype html>
+<!--[if lt IE 7]>  <html class="ie ie6 lte9 lte8 lte7"> <![endif]-->
+<!--[if IE 7]>     <html class="ie ie7 lte9 lte8 lte7"> <![endif]-->
+<!--[if IE 8]>     <html class="ie ie8 lte9 lte8"> <![endif]-->
+<!--[if IE 9]>     <html class="ie ie9 lte9"> <![endif]-->
+<!--[if gt IE 9]>  <html> <![endif]-->
+<!--[if !IE]><!-->
+<html>
+<!--<![endif]-->
+
+<head>
+  <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
+  <meta content="utf-8" http-equiv="encoding">
+  <!-- Use title if it's in the page YAML frontmatter -->
+  <title>Waste Carriers Service</title>
+</head>
+
+<body style="font-family: Helvetica, Arial, sans-serif; font-size: 16px; margin: 0; color: #0b0c0c">
+  <table width="100%" cellpadding="0" cellspacing="0" border="0">
+    <tr>
+      <td width="100%" height="53px" bgcolor="#0b0c0c">
+        <table width="580" cellpadding="0" cellspacing="0" border="0" align="center">
+          <tr>
+            <td width="100%" bgcolor="#0b0c0c" valign="middle">
+              <%= email_image_tag("govuk_logotype_email.png", { alt: 'GOV.UK', border: '0' }) %>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+  <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#FFFFFF">
+    <tr>
+      <td width="100%">
+        <table width="580" cellpadding="0" cellspacing="0" border="0" align="center">
+          <tr>
+            <td width="100%" class="header" style="padding-top: 10px;" colspan="2">
+              <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#FFFFFF">
+                <tr>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <tr>
+            <td width="75%" style="font-family: Helvetica, Arial, sans-serif;">
+              <p style="font-weight: 400; font-size: 16px; line-height: 1; margin: 10px 0 10px 0;">&nbsp;</p>
+            </td>
+            <td width="25%">&nbsp;</td>
+          </tr>
+          <tr>
+            <td bgcolor="#28a197" style="font-family: Helvetica, Arial, sans-serif; margin: 0 0 30px 0;">
+              <p style="font-size: 36px; font-weight: bold; text-align: center; color: #ffffff; line-height: 1.315789474; margin: 30px 0px 15px 0px;">
+                <%= t(".heading") %>
+              </p>
+
+              <p style="font-size: 36px; font-weight: bold; text-align: center; color: #ffffff; line-height: 1.315789474; margin: 15px 0px 30px 0px;">
+                <%= @registration.reg_identifier %>
+              </p>
+            </td>
+            <td width="25%">&nbsp;</td>
+          </tr>
+          <tr>
+            <td width="75%" style="font-family: Helvetica, Arial, sans-serif;">
+              <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 15px 0;">
+                <%= t(".paragraph_1") %>
+              </p>
+
+              <ul>
+                <li style="font-size: 16px; color: #6f777b; line-height: 1.125; margin: 0 0 15px 0;">
+                  <%= t(".footer_list.item_1") %>
+                </li>
+                <li style="font-size: 16px; color: #6f777b; line-height: 1.125; margin: 0 0 30px 0;">
+                  <%= t(".footer_list.item_2") %>
+                </li>
+              </ul>
+            </td>
+            <td width="25%">
+              &nbsp;
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/app/views/registration_transfers/new.html.erb
+++ b/app/views/registration_transfers/new.html.erb
@@ -2,53 +2,97 @@
   <div class="column-two-thirds">
     <%= render("waste_carriers_engine/shared/back", back_path: bo_path) %>
 
-    <h1 class="heading-large">
-      <%= t(".heading", reg_identifier: @registration.reg_identifier) %>
-    </h1>
+    <%= form_for(@registration_transfer_form, url: registration_transfers_path) do |f| %>
+      <%= render("waste_carriers_engine/shared/errors", object: @registration_transfer_form) %>
 
-    <p><%= t(".paragraph_1", email: @registration.account_email) %></p>
+      <h1 class="heading-large">
+        <%= t(".heading", reg_identifier: @registration.reg_identifier) %>
+      </h1>
 
-    <p><%= t(".paragraph_2", reg_identifier: @registration.reg_identifier) %></p>
+      <div class="form-group">
+        <p><%= t(".paragraph_1", email: @registration.account_email) %></p>
+        <p><%= t(".paragraph_2", reg_identifier: @registration.reg_identifier) %></p>
+        <p><%= t(".paragraph_3", email: @registration.account_email) %></p>
+        <p><%= t(".paragraph_4", email: @registration.account_email) %></p>
 
-    <p><%= t(".paragraph_3", email: @registration.account_email) %></p>
+        <table>
+          <caption class="heading-medium">
+            <%= t(".registration_info.heading") %>
+          </caption>
+          <tbody>
+            <tr>
+              <td>
+                <%= t(".registration_info.labels.account_email") %>
+              </td>
+              <td>
+                <%= @registration.account_email %>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <%= t(".registration_info.labels.reg_identifier") %>
+              </td>
+              <td>
+                <%= @registration.reg_identifier %>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <%= t(".registration_info.labels.company_name") %>
+              </td>
+              <td>
+                <%= @registration.company_name %>
+              </td>
+            </tr>
+        </table>
 
-    <p><%= t(".paragraph_4", email: @registration.account_email) %></p>
+        <h2 class="heading-medium">
+          <%= t(".subheading_1") %>
+        </h2>
+      </div>
 
-    <table>
-      <caption class="heading-medium">
-        <%= t(".registration_info.heading") %>
-      </caption>
-      <tbody>
-        <tr>
-          <td>
-            <%= t(".registration_info.labels.account_email") %>
-          </td>
-          <td>
-            <%= @registration.account_email %>
-          </td>
-        </tr>
-        <tr>
-          <td>
-            <%= t(".registration_info.labels.reg_identifier") %>
-          </td>
-          <td>
-            <%= @registration.reg_identifier %>
-          </td>
-        </tr>
-        <tr>
-          <td>
-            <%= t(".registration_info.labels.company_name") %>
-          </td>
-          <td>
-            <%= @registration.company_name %>
-          </td>
-        </tr>
-    </table>
+      <% if @registration_transfer_form.errors[:email].any? %>
+      <div class="form-group form-group-error">
+      <% else %>
+      <div class="form-group">
+      <% end %>
+        <fieldset id="company_name">
+          <legend class="visuallyhidden">
+            <%= t(".heading", reg_identifier: @registration.reg_identifier) %>
+          </legend>
 
-    <h2 class="heading-medium">
-      <%= t(".subheading_1") %>
-    </h2>
+          <% if @registration_transfer_form.errors[:email].any? %>
+          <span class="error-message"><%= @registration_transfer_form.errors[:email].join(", ") %></span>
+          <% end %>
 
-    <p>Form and button go here</p>
+          <%= f.label :email, t(".email_label"), class: "form-label" %>
+          <%= f.text_field :email, class: "form-control" %>
+        </fieldset>
+      </div>
+
+      <% if @registration_transfer_form.errors[:confirm_email].any? %>
+      <div class="form-group form-group-error">
+      <% else %>
+      <div class="form-group">
+      <% end %>
+        <fieldset id="company_name">
+          <legend class="visuallyhidden">
+            <%= t(".heading", reg_identifier: @registration.reg_identifier) %>
+          </legend>
+
+          <% if @registration_transfer_form.errors[:confirm_email].any? %>
+          <span class="error-message"><%= @registration_transfer_form.errors[:confirm_email].join(", ") %></span>
+          <% end %>
+
+          <%= f.label :confirm_email, t(".confirm_email_label"), class: "form-label" %>
+          <%= f.text_field :confirm_email, class: "form-control" %>
+        </fieldset>
+      </div>
+
+      <%= f.hidden_field :reg_identifier, value: @registration_transfer_form.reg_identifier %>
+      <div class="form-group">
+        <%= f.submit t(".button"), class: "button" %>
+      </div>
+    <% end %>
   </end>
 </end>

--- a/app/views/registration_transfers/new.html.erb
+++ b/app/views/registration_transfers/new.html.erb
@@ -1,0 +1,9 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render("waste_carriers_engine/shared/back", back_path: bo_path) %>
+
+    <h1 class="heading-large">
+      <%= t(".heading") %>
+    </h1>
+  </end>
+</end>

--- a/app/views/registration_transfers/new.html.erb
+++ b/app/views/registration_transfers/new.html.erb
@@ -3,7 +3,7 @@
     <%= render("waste_carriers_engine/shared/back", back_path: bo_path) %>
 
     <h1 class="heading-large">
-      <%= t(".heading") %>
+      <%= t(".heading", reg_identifier: @registration.reg_identifier) %>
     </h1>
   </end>
 </end>

--- a/app/views/registration_transfers/new.html.erb
+++ b/app/views/registration_transfers/new.html.erb
@@ -56,7 +56,7 @@
       <% else %>
       <div class="form-group">
       <% end %>
-        <fieldset id="company_name">
+        <fieldset id="email">
           <legend class="visuallyhidden">
             <%= t(".heading", reg_identifier: @registration.reg_identifier) %>
           </legend>
@@ -75,7 +75,7 @@
       <% else %>
       <div class="form-group">
       <% end %>
-        <fieldset id="company_name">
+        <fieldset id="confirm_email">
           <legend class="visuallyhidden">
             <%= t(".heading", reg_identifier: @registration.reg_identifier) %>
           </legend>

--- a/app/views/registration_transfers/new.html.erb
+++ b/app/views/registration_transfers/new.html.erb
@@ -5,5 +5,50 @@
     <h1 class="heading-large">
       <%= t(".heading", reg_identifier: @registration.reg_identifier) %>
     </h1>
+
+    <p><%= t(".paragraph_1", email: @registration.account_email) %></p>
+
+    <p><%= t(".paragraph_2", reg_identifier: @registration.reg_identifier) %></p>
+
+    <p><%= t(".paragraph_3", email: @registration.account_email) %></p>
+
+    <p><%= t(".paragraph_4", email: @registration.account_email) %></p>
+
+    <table>
+      <caption class="heading-medium">
+        <%= t(".registration_info.heading") %>
+      </caption>
+      <tbody>
+        <tr>
+          <td>
+            <%= t(".registration_info.labels.account_email") %>
+          </td>
+          <td>
+            <%= @registration.account_email %>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <%= t(".registration_info.labels.reg_identifier") %>
+          </td>
+          <td>
+            <%= @registration.reg_identifier %>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <%= t(".registration_info.labels.company_name") %>
+          </td>
+          <td>
+            <%= @registration.company_name %>
+          </td>
+        </tr>
+    </table>
+
+    <h2 class="heading-medium">
+      <%= t(".subheading_1") %>
+    </h2>
+
+    <p>Form and button go here</p>
   </end>
 </end>

--- a/app/views/registration_transfers/success.html.erb
+++ b/app/views/registration_transfers/success.html.erb
@@ -1,0 +1,17 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render("waste_carriers_engine/shared/back", back_path: new_registration_transfer_path(@registration.reg_identifier)) %>
+
+    <h1 class="heading-large">
+      <%= t(".heading", reg_identifier: @registration.reg_identifier) %>
+    </h1>
+
+    <div class="form-group">
+      <p><%= t(".paragraph_1", email: @registration.account_email) %></p>
+    </div>
+
+    <div class="form-group">
+      <%= link_to t(".button"), bo_path, class: "button" %>
+    </div>
+  </end>
+</end>

--- a/config/locales/mailers/registration_transfer_mailer.en.yml
+++ b/config/locales/mailers/registration_transfer_mailer.en.yml
@@ -3,7 +3,9 @@ en:
     transfer_to_existing_account_email:
       subject: "The waste carriers registration %{reg_identifier} has been transferred to you"
       heading: "A waste carriers registration has been transferred to your account"
-      paragraph_1: "You can now use this email address to log in and manage this registration."
+      paragraph_1: "You can now manage the registration for %{company_name}."
+      paragraph_2: "Use this email address (%{email}) to sign in."
+      log_in_link: "Sign in to access this registration"
       footer_list:
         item_1: "If you have enquiries please contact the Environment Agency helpline: 03708 506506"
         item_2: "This is an automated email, please do not reply"

--- a/config/locales/mailers/registration_transfer_mailer.en.yml
+++ b/config/locales/mailers/registration_transfer_mailer.en.yml
@@ -1,0 +1,9 @@
+en:
+  registration_transfer_mailer:
+    transfer_to_existing_account_email:
+      subject: "The waste carriers registration %{reg_identifier} has been transferred to you"
+      heading: "A waste carriers registration has been transferred to your account"
+      paragraph_1: "You can now use this email address to log in and manage this registration."
+      footer_list:
+        item_1: "If you have enquiries please contact the Environment Agency helpline: 03708 506506"
+        item_2: "This is an automated email, please do not reply"

--- a/config/locales/registration_transfers.en.yml
+++ b/config/locales/registration_transfers.en.yml
@@ -20,7 +20,7 @@ en:
     success:
       title: "Registration transferred successfully"
       heading: "Registration %{reg_identifier} has been transferred"
-      paragraph: "This registration is now owned by %{email}."
+      paragraph_1: "This registration is now owned by %{email}."
       button: "Continue"
   activemodel:
     errors:

--- a/config/locales/registration_transfers.en.yml
+++ b/config/locales/registration_transfers.en.yml
@@ -23,6 +23,9 @@ en:
         registration_transfer_form:
           attributes:
             email:
-              blank: "You must enter an email"
+              blank: "Enter an email address"
+              invalid_format: "Enter a valid email address - there’s a mistake in that one"
             confirm_email:
-              blank: "You must re-enter the email to confirm it"
+              blank: "Enter the email address again to confirm it"
+              invalid_format: "Enter a valid confirmed email address - there’s a mistake in that one"
+              does_not_match: "The email addresses you’ve entered don’t match"

--- a/config/locales/registration_transfers.en.yml
+++ b/config/locales/registration_transfers.en.yml
@@ -1,0 +1,4 @@
+en:
+  registration_transfers:
+    new:
+      heading: "Transfer a registration to a different user account"

--- a/config/locales/registration_transfers.en.yml
+++ b/config/locales/registration_transfers.en.yml
@@ -16,7 +16,7 @@ en:
       subheading_1: "Transfer the registration"
       email_label: "Email address"
       confirm_email_label: "Confirm email address"
-      button: "Transfer account"
+      button: "Transfer"
     success:
       title: "Registration transferred successfully"
       heading: "Registration %{reg_identifier} has been transferred"

--- a/config/locales/registration_transfers.en.yml
+++ b/config/locales/registration_transfers.en.yml
@@ -30,6 +30,7 @@ en:
             email:
               blank: "Enter an email address"
               invalid_format: "Enter a valid email address - there’s a mistake in that one"
+              no_matching_user: "Enter an email address which belongs to an existing user account"
             confirm_email:
               blank: "Enter the email address again to confirm it"
               invalid_format: "Enter a valid confirmed email address - there’s a mistake in that one"

--- a/config/locales/registration_transfers.en.yml
+++ b/config/locales/registration_transfers.en.yml
@@ -17,3 +17,12 @@ en:
       email_label: "Email address"
       confirm_email_label: "Confirm email address"
       button: "Transfer account"
+  activemodel:
+    errors:
+      models:
+        registration_transfer_form:
+          attributes:
+            email:
+              blank: "You must enter an email"
+            confirm_email:
+              blank: "You must re-enter the email to confirm it"

--- a/config/locales/registration_transfers.en.yml
+++ b/config/locales/registration_transfers.en.yml
@@ -1,4 +1,4 @@
 en:
   registration_transfers:
     new:
-      heading: "Transfer a registration to a different user account"
+      heading: "Transfer registration %{reg_identifier} to a different user account"

--- a/config/locales/registration_transfers.en.yml
+++ b/config/locales/registration_transfers.en.yml
@@ -1,4 +1,16 @@
 en:
   registration_transfers:
     new:
+      title: "Transfer a registration to a different user account"
       heading: "Transfer registration %{reg_identifier} to a different user account"
+      paragraph_1: "This registration currently belongs to %{email}."
+      paragraph_2: "If you know that a different user should own %{reg_identifier}, you can transfer it to a different account."
+      paragraph_3: "Once the registration is transferred, %{email} will no longer be able to view or manage it."
+      paragraph_4: "Any other registrations owned by %{email} will not be affected."
+      registration_info:
+        heading: "About this registration"
+        labels:
+          account_email: "Current user account"
+          reg_identifier: "Registration number"
+          company_name: "Company name"
+      subheading_1: "Transfer the registration"

--- a/config/locales/registration_transfers.en.yml
+++ b/config/locales/registration_transfers.en.yml
@@ -17,6 +17,11 @@ en:
       email_label: "Email address"
       confirm_email_label: "Confirm email address"
       button: "Transfer account"
+    success:
+      title: "Registration transferred successfully"
+      heading: "Registration %{reg_identifier} has been transferred"
+      paragraph: "This registration is now owned by %{email}."
+      button: "Continue"
   activemodel:
     errors:
       models:

--- a/config/locales/registration_transfers.en.yml
+++ b/config/locales/registration_transfers.en.yml
@@ -14,3 +14,6 @@ en:
           reg_identifier: "Registration number"
           company_name: "Company name"
       subheading_1: "Transfer the registration"
+      email_label: "Email address"
+      confirm_email_label: "Confirm email address"
+      button: "Transfer account"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,6 +67,9 @@ Rails.application.routes.draw do
             param: :reg_identifier,
             path: "/bo/transfer-registration",
             path_names: { new: "/:reg_identifier" }
+  get "/bo/transfer-registration/:reg_identifier/success",
+      to: "registration_transfers#success",
+      as: :registration_transfer_success
 
   mount WasteCarriersEngine::Engine => "/bo"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,5 +62,10 @@ Rails.application.routes.draw do
                         path_names: { new: "" }
             end
 
+  resources :registration_transfers,
+            only: [:new, :create],
+            path: "/bo/transfer-registration",
+            path_names: { new: "" }
+
   mount WasteCarriersEngine::Engine => "/bo"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,8 +64,9 @@ Rails.application.routes.draw do
 
   resources :registration_transfers,
             only: [:new, :create],
+            param: :reg_identifier,
             path: "/bo/transfer-registration",
-            path_names: { new: "" }
+            path_names: { new: "/:reg_identifier" }
 
   mount WasteCarriersEngine::Engine => "/bo"
 end

--- a/spec/factories/external_user.rb
+++ b/spec/factories/external_user.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :external_user do
+    sequence :email do |n|
+      "user#{n}@example.com"
+    end
+
+    password { "Secret123" }
+  end
+end

--- a/spec/factories/forms/registration_transfer_form.rb
+++ b/spec/factories/forms/registration_transfer_form.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :registration_transfer_form do
+    email { "foobar@example.com" }
+    confirm_email { "foobar@example.com" }
+
+    initialize_with do
+      new(create(:registration))
+    end
+  end
+end

--- a/spec/forms/registration_transfer_form_spec.rb
+++ b/spec/forms/registration_transfer_form_spec.rb
@@ -15,6 +15,10 @@ RSpec.describe RegistrationTransferForm, type: :model do
         }
       end
 
+      before do
+        allow_any_instance_of(RegistrationTransferService).to receive(:transfer_to_user).and_return(:success_existing_user)
+      end
+
       it "should submit" do
         expect(registration_transfer_form.submit(valid_params)).to eq(true)
       end
@@ -62,6 +66,28 @@ RSpec.describe RegistrationTransferForm, type: :model do
   describe "#confirm_email" do
     context "when it doesn't match the email" do
       before { registration_transfer_form.confirm_email = "no_matchy@example.com" }
+
+      it "is not valid" do
+        expect(registration_transfer_form).to_not be_valid
+      end
+    end
+  end
+
+  describe "#registration_transferred_successfully?" do
+    context "when the RegistrationTransferService returns :success_existing_user" do
+      before do
+        allow_any_instance_of(RegistrationTransferService).to receive(:transfer_to_user).and_return(:success_existing_user)
+      end
+
+      it "is valid" do
+        expect(registration_transfer_form).to be_valid
+      end
+    end
+
+    context "when the RegistrationTransferService returns :no_matching_user" do
+      before do
+        allow_any_instance_of(RegistrationTransferService).to receive(:transfer_to_user).and_return(:no_matching_user)
+      end
 
       it "is not valid" do
         expect(registration_transfer_form).to_not be_valid

--- a/spec/forms/registration_transfer_form_spec.rb
+++ b/spec/forms/registration_transfer_form_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RegistrationTransferForm, type: :model do
+  describe "#submit" do
+    context "when the form is valid" do
+      let(:registration_transfer_form) { build(:registration_transfer_form) }
+      let(:valid_params) do
+        {
+          reg_identifier: registration_transfer_form.reg_identifier,
+          email: registration_transfer_form.email,
+          confirm_email: registration_transfer_form.confirm_email
+        }
+      end
+
+      it "should submit" do
+        expect(registration_transfer_form.submit(valid_params)).to eq(true)
+      end
+    end
+
+    context "when the form is not valid" do
+      let(:registration_transfer_form) { build(:registration_transfer_form) }
+      let(:invalid_params) do
+        {
+          reg_identifier: nil,
+          email: nil,
+          confirm_email: nil
+        }
+      end
+
+      it "should not submit" do
+        expect(registration_transfer_form.submit(invalid_params)).to eq(false)
+      end
+    end
+  end
+end

--- a/spec/forms/registration_transfer_form_spec.rb
+++ b/spec/forms/registration_transfer_form_spec.rb
@@ -3,9 +3,10 @@
 require "rails_helper"
 
 RSpec.describe RegistrationTransferForm, type: :model do
+  let(:registration_transfer_form) { build(:registration_transfer_form) }
+
   describe "#submit" do
     context "when the form is valid" do
-      let(:registration_transfer_form) { build(:registration_transfer_form) }
       let(:valid_params) do
         {
           reg_identifier: registration_transfer_form.reg_identifier,
@@ -20,7 +21,6 @@ RSpec.describe RegistrationTransferForm, type: :model do
     end
 
     context "when the form is not valid" do
-      let(:registration_transfer_form) { build(:registration_transfer_form) }
       let(:invalid_params) do
         {
           reg_identifier: nil,
@@ -31,6 +31,40 @@ RSpec.describe RegistrationTransferForm, type: :model do
 
       it "should not submit" do
         expect(registration_transfer_form.submit(invalid_params)).to eq(false)
+      end
+    end
+  end
+
+  describe "#email" do
+    context "when it's blank" do
+      before do
+        registration_transfer_form.email = ""
+        registration_transfer_form.confirm_email = ""
+      end
+
+      it "is not valid" do
+        expect(registration_transfer_form).to_not be_valid
+      end
+    end
+
+    context "when it isn't in the correct format" do
+      before do
+        registration_transfer_form.email = "foo"
+        registration_transfer_form.confirm_email = "foo"
+      end
+
+      it "is not valid" do
+        expect(registration_transfer_form).to_not be_valid
+      end
+    end
+  end
+
+  describe "#confirm_email" do
+    context "when it doesn't match the email" do
+      before { registration_transfer_form.confirm_email = "no_matchy@example.com" }
+
+      it "is not valid" do
+        expect(registration_transfer_form).to_not be_valid
       end
     end
   end

--- a/spec/mailers/transfer_registration_mailer_spec.rb
+++ b/spec/mailers/transfer_registration_mailer_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe RegistrationTransferMailer, type: :mailer do
+    before do
+      allow(Rails.configuration).to receive(:email_service_email).and_return("test@example.com")
+    end
+
+    describe "send_renewal_complete_email" do
+      let(:registration) { create(:registration) }
+      let(:mail) { RegistrationTransferMailer.transfer_to_existing_account_email(registration) }
+
+      it "uses the correct 'to' address" do
+        expect(mail.to).to eq([registration.account_email])
+      end
+
+      it "uses the correct 'from' address" do
+        expect(mail.from).to eq(["test@example.com"])
+      end
+
+      it "uses the correct subject" do
+        subject = "The waste carriers registration #{registration.reg_identifier} has been transferred to you"
+        expect(mail.subject).to eq(subject)
+      end
+
+      it "includes the correct reg_identifier in the body" do
+        expect(mail.body.encoded).to include(registration.reg_identifier)
+      end
+    end
+  end
+end

--- a/spec/models/external_user_spec.rb
+++ b/spec/models/external_user_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "cancan/matchers"
+require "rails_helper"
+
+RSpec.describe ExternalUser, type: :model do
+  describe "#password" do
+    context "when the external_user's password meets the requirements" do
+      let(:external_user) { build(:external_user, password: "Secret123") }
+
+      it "should be valid" do
+        expect(external_user).to be_valid
+      end
+    end
+
+    context "when the external_user's password is blank" do
+      let(:external_user) { build(:external_user, password: "") }
+
+      it "should not be valid" do
+        expect(external_user).to_not be_valid
+      end
+    end
+
+    context "when the external_user's password has no lowercase letters" do
+      let(:external_user) { build(:external_user, password: "SECRET123") }
+
+      it "should not be valid" do
+        expect(external_user).to_not be_valid
+      end
+    end
+
+    context "when the external_user's password has no uppercase letters" do
+      let(:external_user) { build(:external_user, password: "secret123") }
+
+      it "should not be valid" do
+        expect(external_user).to_not be_valid
+      end
+    end
+
+    context "when the external_user's password has no numbers" do
+      let(:external_user) { build(:external_user, password: "SuperSecret") }
+
+      it "should not be valid" do
+        expect(external_user).to_not be_valid
+      end
+    end
+
+    context "when the external_user's password is too short" do
+      let(:external_user) { build(:external_user, password: "Sec123") }
+
+      it "should not be valid" do
+        expect(external_user).to_not be_valid
+      end
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe User, type: :model do
   describe "abilities" do
     subject(:ability) { Ability.new(user) }
     let(:user) { build(:user) }
+    let(:registration) { build(:registration) }
     let(:transient_registration) { build(:transient_registration) }
     let(:other_user) { build(:user) }
 
@@ -110,6 +111,10 @@ RSpec.describe User, type: :model do
       it "should not be able to create a finance admin user" do
         should_not be_able_to(:create_finance_admin_user, user)
       end
+
+      it "should be able to transfer a registration" do
+        should be_able_to(:transfer_registration, registration)
+      end
     end
 
     context "when the user is an agency with refund user" do
@@ -161,6 +166,10 @@ RSpec.describe User, type: :model do
 
       it "should not be able to create a finance admin user" do
         should_not be_able_to(:create_finance_admin_user, user)
+      end
+
+      it "should be able to transfer a registration" do
+        should be_able_to(:transfer_registration, registration)
       end
     end
 
@@ -214,6 +223,10 @@ RSpec.describe User, type: :model do
       it "should not be able to create a finance admin user" do
         should_not be_able_to(:create_finance_admin_user, user)
       end
+
+      it "should not be able to transfer a registration" do
+        should_not be_able_to(:transfer_registration, registration)
+      end
     end
 
     context "when the user is a finance admin user" do
@@ -265,6 +278,10 @@ RSpec.describe User, type: :model do
 
       it "should not be able to create a finance admin user" do
         should_not be_able_to(:create_finance_admin_user, user)
+      end
+
+      it "should not be able to transfer a registration" do
+        should_not be_able_to(:transfer_registration, registration)
       end
     end
 
@@ -318,6 +335,10 @@ RSpec.describe User, type: :model do
       it "should not be able to create a finance admin user" do
         should_not be_able_to(:create_finance_admin_user, user)
       end
+
+      it "should be able to transfer a registration" do
+        should be_able_to(:transfer_registration, registration)
+      end
     end
 
     context "when the user is a finance super user" do
@@ -369,6 +390,10 @@ RSpec.describe User, type: :model do
 
       it "should be able to create a finance admin user" do
         should be_able_to(:create_finance_admin_user, user)
+      end
+
+      it "should not be able to transfer a registration" do
+        should_not be_able_to(:transfer_registration, registration)
       end
     end
   end

--- a/spec/requests/registration_transfers_spec.rb
+++ b/spec/requests/registration_transfers_spec.rb
@@ -65,9 +65,9 @@ RSpec.describe "RegistrationTransfers", type: :request do
       end
 
       context "when the params are valid" do
-        it "redirects to bo_path" do
+        it "redirects to the success page" do
           post "/bo/transfer-registration", registration_transfer_form: params
-          expect(response).to redirect_to(bo_path)
+          expect(response).to redirect_to("/bo/transfer-registration/#{params[:reg_identifier]}/success")
         end
 
         it "changes the account_email" do
@@ -85,7 +85,7 @@ RSpec.describe "RegistrationTransfers", type: :request do
           }
         end
 
-        it "redirects to bo_path" do
+        it "renders the new template" do
           post "/bo/transfer-registration", registration_transfer_form: params
           expect(response).to render_template(:new)
         end

--- a/spec/requests/registration_transfers_spec.rb
+++ b/spec/requests/registration_transfers_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe "RegistrationTransfers", type: :request do
+  let(:registration) { create(:registration) }
+
   describe "GET /bo/transfer-registration" do
     context "when a valid user is signed in" do
       let(:user) { create(:user) }
@@ -11,19 +13,24 @@ RSpec.describe "RegistrationTransfers", type: :request do
       end
 
       it "renders the new template" do
-        get "/bo/transfer-registration"
+        get "/bo/transfer-registration/#{registration.reg_identifier}"
         expect(response).to render_template(:new)
       end
 
+      it "includes the registration info on the page" do
+        get "/bo/transfer-registration/#{registration.reg_identifier}"
+        expect(response.body).to include("Transfer registration #{registration.reg_identifier}")
+      end
+
       it "returns a 200 response" do
-        get "/bo/transfer-registration"
+        get "/bo/transfer-registration/#{registration.reg_identifier}"
         expect(response).to have_http_status(200)
       end
     end
 
     context "when a user is not signed in" do
       it "redirects to the sign-in page" do
-        get "/bo/transfer-registration"
+        get "/bo/transfer-registration/#{registration.reg_identifier}"
         expect(response).to redirect_to(new_user_session_path)
       end
     end

--- a/spec/requests/registration_transfers_spec.rb
+++ b/spec/requests/registration_transfers_spec.rb
@@ -49,9 +49,11 @@ RSpec.describe "RegistrationTransfers", type: :request do
   end
 
   describe "POST /bo/transfer-registration" do
-    let(:valid_params) do
+    let(:params) do
       {
-        reg_identifier: registration.reg_identifier
+        reg_identifier: registration.reg_identifier,
+        email: "foo@example.com",
+        confirm_email: "foo@example.com"
       }
     end
 
@@ -61,9 +63,26 @@ RSpec.describe "RegistrationTransfers", type: :request do
         sign_in(user)
       end
 
-      it "redirects to bo_path" do
-        post "/bo/transfer-registration", registration_transfer_form: valid_params
-        expect(response).to redirect_to(bo_path)
+      context "when the params are valid" do
+        it "redirects to bo_path" do
+          post "/bo/transfer-registration", registration_transfer_form: params
+          expect(response).to redirect_to(bo_path)
+        end
+      end
+
+      context "when the params are invalid" do
+        let(:params) do
+          {
+            reg_identifier: registration.reg_identifier,
+            email: nil,
+            confirm_email: nil
+          }
+        end
+
+        it "redirects to bo_path" do
+          post "/bo/transfer-registration", registration_transfer_form: params
+          expect(response).to render_template(:new)
+        end
       end
     end
 
@@ -74,14 +93,14 @@ RSpec.describe "RegistrationTransfers", type: :request do
       end
 
       it "redirects to the permissions error page" do
-        post "/bo/transfer-registration", registration_transfer_form: valid_params
+        post "/bo/transfer-registration", registration_transfer_form: params
         expect(response).to redirect_to("/bo/permission")
       end
     end
 
     context "when a user is not signed in" do
       it "redirects to the sign-in page" do
-        post "/bo/transfer-registration", registration_transfer_form: valid_params
+        post "/bo/transfer-registration", registration_transfer_form: params
         expect(response).to redirect_to(new_user_session_path)
       end
     end

--- a/spec/requests/registration_transfers_spec.rb
+++ b/spec/requests/registration_transfers_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 RSpec.describe "RegistrationTransfers", type: :request do
   let(:registration) { create(:registration) }
+  let(:other_external_user) { create(:external_user) }
 
   describe "GET /bo/transfer-registration" do
     context "when a valid user is signed in" do
@@ -52,8 +53,8 @@ RSpec.describe "RegistrationTransfers", type: :request do
     let(:params) do
       {
         reg_identifier: registration.reg_identifier,
-        email: "foo@example.com",
-        confirm_email: "foo@example.com"
+        email: other_external_user.email,
+        confirm_email: other_external_user.email
       }
     end
 
@@ -67,6 +68,11 @@ RSpec.describe "RegistrationTransfers", type: :request do
         it "redirects to bo_path" do
           post "/bo/transfer-registration", registration_transfer_form: params
           expect(response).to redirect_to(bo_path)
+        end
+
+        it "changes the account_email" do
+          post "/bo/transfer-registration", registration_transfer_form: params
+          expect(registration.reload.account_email).to eq(params[:email])
         end
       end
 
@@ -82,6 +88,12 @@ RSpec.describe "RegistrationTransfers", type: :request do
         it "redirects to bo_path" do
           post "/bo/transfer-registration", registration_transfer_form: params
           expect(response).to render_template(:new)
+        end
+
+        it "does not change the account_email" do
+          old_email = registration.account_email
+          post "/bo/transfer-registration", registration_transfer_form: params
+          expect(registration.reload.account_email).to eq(old_email)
         end
       end
     end

--- a/spec/requests/registration_transfers_spec.rb
+++ b/spec/requests/registration_transfers_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "RegistrationTransfers", type: :request do
+  describe "GET /bo/transfer-registration" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      it "renders the new template" do
+        get "/bo/transfer-registration"
+        expect(response).to render_template(:new)
+      end
+
+      it "returns a 200 response" do
+        get "/bo/transfer-registration"
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context "when a user is not signed in" do
+      it "redirects to the sign-in page" do
+        get "/bo/transfer-registration"
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  describe "POST /bo/transfer-registration" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      it "redirects to bo_path" do
+        post "/bo/transfer-registration"
+        expect(response).to redirect_to(bo_path)
+      end
+    end
+
+    context "when a user is not signed in" do
+      it "redirects to the sign-in page" do
+        post "/bo/transfer-registration"
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+end

--- a/spec/requests/registration_transfers_spec.rb
+++ b/spec/requests/registration_transfers_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "RegistrationTransfers", type: :request do
 
   describe "GET /bo/transfer-registration" do
     context "when a valid user is signed in" do
-      let(:user) { create(:user) }
+      let(:user) { create(:user, :agency) }
       before(:each) do
         sign_in(user)
       end
@@ -28,6 +28,18 @@ RSpec.describe "RegistrationTransfers", type: :request do
       end
     end
 
+    context "when a non-agency user is signed in" do
+      let(:user) { create(:user, :finance) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      it "redirects to the permissions error page" do
+        get "/bo/transfer-registration/#{registration.reg_identifier}"
+        expect(response).to redirect_to("/bo/permission")
+      end
+    end
+
     context "when a user is not signed in" do
       it "redirects to the sign-in page" do
         get "/bo/transfer-registration/#{registration.reg_identifier}"
@@ -37,21 +49,39 @@ RSpec.describe "RegistrationTransfers", type: :request do
   end
 
   describe "POST /bo/transfer-registration" do
+    let(:valid_params) do
+      {
+        reg_identifier: registration.reg_identifier
+      }
+    end
+
     context "when a valid user is signed in" do
-      let(:user) { create(:user) }
+      let(:user) { create(:user, :agency) }
       before(:each) do
         sign_in(user)
       end
 
       it "redirects to bo_path" do
-        post "/bo/transfer-registration"
+        post "/bo/transfer-registration", registration_transfer_form: valid_params
         expect(response).to redirect_to(bo_path)
+      end
+    end
+
+    context "when a non-agency user is signed in" do
+      let(:user) { create(:user, :finance) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      it "redirects to the permissions error page" do
+        post "/bo/transfer-registration", registration_transfer_form: valid_params
+        expect(response).to redirect_to("/bo/permission")
       end
     end
 
     context "when a user is not signed in" do
       it "redirects to the sign-in page" do
-        post "/bo/transfer-registration"
+        post "/bo/transfer-registration", registration_transfer_form: valid_params
         expect(response).to redirect_to(new_user_session_path)
       end
     end

--- a/spec/services/registration_transfer_service_spec.rb
+++ b/spec/services/registration_transfer_service_spec.rb
@@ -59,6 +59,17 @@ RSpec.describe RegistrationTransferService do
       it "updates the transient_registration's account_email" do
         expect(transient_registration.reload.account_email).to eq(recipient_email)
       end
+
+      it "sends an email" do
+        old_emails_sent_count = ActionMailer::Base.deliveries.count
+        registration_transfer_service.transfer_to_user(recipient_email)
+        expect(ActionMailer::Base.deliveries.count).to eq(old_emails_sent_count + 1)
+      end
+
+      it "sends an email to the correct address" do
+        last_delivery = ActionMailer::Base.deliveries.last
+        expect(last_delivery.header["to"].value).to eq(recipient_email)
+      end
     end
 
     context "when there is no external user with a matching email" do

--- a/spec/services/registration_transfer_service_spec.rb
+++ b/spec/services/registration_transfer_service_spec.rb
@@ -70,6 +70,10 @@ RSpec.describe RegistrationTransferService do
         last_delivery = ActionMailer::Base.deliveries.last
         expect(last_delivery.header["to"].value).to eq(recipient_email)
       end
+
+      it "returns :success_existing_user" do
+        expect(registration_transfer_service.transfer_to_user(recipient_email)).to eq(:success_existing_user)
+      end
     end
 
     context "when there is no external user with a matching email" do

--- a/spec/services/registration_transfer_service_spec.rb
+++ b/spec/services/registration_transfer_service_spec.rb
@@ -40,8 +40,11 @@ RSpec.describe RegistrationTransferService do
     let(:recipient_email) { existing_user.email }
 
     let(:recipient_user_instance_variable) do
-      registration_transfer_service.transfer_to_user(recipient_email)
       registration_transfer_service.instance_variable_get(:@recipient_user)
+    end
+
+    before do
+      registration_transfer_service.transfer_to_user(recipient_email)
     end
 
     context "when there is an external user with a matching email" do
@@ -50,12 +53,10 @@ RSpec.describe RegistrationTransferService do
       end
 
       it "updates the registration's account_email" do
-        registration_transfer_service.transfer_to_user(recipient_email)
         expect(registration.reload.account_email).to eq(recipient_email)
       end
 
       it "updates the transient_registration's account_email" do
-        registration_transfer_service.transfer_to_user(recipient_email)
         expect(transient_registration.reload.account_email).to eq(recipient_email)
       end
     end

--- a/spec/services/registration_transfer_service_spec.rb
+++ b/spec/services/registration_transfer_service_spec.rb
@@ -34,4 +34,36 @@ RSpec.describe RegistrationTransferService do
       end
     end
   end
+
+  describe "#transfer_to_user" do
+    let(:existing_user) { create(:external_user) }
+    let(:recipient_email) { existing_user.email }
+
+    let(:recipient_user_instance_variable) do
+      registration_transfer_service.transfer_to_user(recipient_email)
+      registration_transfer_service.instance_variable_get(:@recipient_user)
+    end
+
+    context "when there is an external user with a matching email" do
+      it "sets @recipient_user" do
+        expect(recipient_user_instance_variable).to eq(existing_user)
+      end
+    end
+
+    context "when there is no external user with a matching email" do
+      let(:recipient_email) { "unused-email@example.com" }
+
+      it "sets @recipient_user to nil" do
+        expect(recipient_user_instance_variable).to eq(nil)
+      end
+    end
+
+    context "when the email is nil" do
+      let(:recipient_email) { nil }
+
+      it "sets @recipient_user to nil" do
+        expect(recipient_user_instance_variable).to eq(nil)
+      end
+    end
+  end
 end

--- a/spec/services/registration_transfer_service_spec.rb
+++ b/spec/services/registration_transfer_service_spec.rb
@@ -48,6 +48,16 @@ RSpec.describe RegistrationTransferService do
       it "sets @recipient_user" do
         expect(recipient_user_instance_variable).to eq(existing_user)
       end
+
+      it "updates the registration's account_email" do
+        registration_transfer_service.transfer_to_user(recipient_email)
+        expect(registration.reload.account_email).to eq(recipient_email)
+      end
+
+      it "updates the transient_registration's account_email" do
+        registration_transfer_service.transfer_to_user(recipient_email)
+        expect(transient_registration.reload.account_email).to eq(recipient_email)
+      end
     end
 
     context "when there is no external user with a matching email" do

--- a/spec/services/registration_transfer_service_spec.rb
+++ b/spec/services/registration_transfer_service_spec.rb
@@ -56,6 +56,10 @@ RSpec.describe RegistrationTransferService do
       it "sets @recipient_user to nil" do
         expect(recipient_user_instance_variable).to eq(nil)
       end
+
+      it "returns :no_matching_user" do
+        expect(registration_transfer_service.transfer_to_user(recipient_email)).to eq(:no_matching_user)
+      end
     end
 
     context "when the email is nil" do
@@ -63,6 +67,10 @@ RSpec.describe RegistrationTransferService do
 
       it "sets @recipient_user to nil" do
         expect(recipient_user_instance_variable).to eq(nil)
+      end
+
+      it "returns :no_matching_user" do
+        expect(registration_transfer_service.transfer_to_user(recipient_email)).to eq(:no_matching_user)
       end
     end
   end

--- a/spec/services/registration_transfer_service_spec.rb
+++ b/spec/services/registration_transfer_service_spec.rb
@@ -74,6 +74,16 @@ RSpec.describe RegistrationTransferService do
       it "returns :success_existing_user" do
         expect(registration_transfer_service.transfer_to_user(recipient_email)).to eq(:success_existing_user)
       end
+
+      context "when the mailer encounters an error" do
+        before do
+          allow(RegistrationTransferMailer).to receive(:transfer_to_existing_account_email).and_raise(StandardError)
+        end
+
+        it "returns :success_existing_user" do
+          expect(registration_transfer_service.transfer_to_user(recipient_email)).to eq(:success_existing_user)
+        end
+      end
     end
 
     context "when there is no external user with a matching email" do

--- a/spec/services/registration_transfer_service_spec.rb
+++ b/spec/services/registration_transfer_service_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RegistrationTransferService do
+  let(:transient_registration) do
+    create(:transient_registration, :ready_to_renew)
+  end
+
+  let(:registration) do
+    WasteCarriersEngine::Registration.where(reg_identifier: transient_registration.reg_identifier).first
+  end
+
+  let(:registration_transfer_service) do
+    RegistrationTransferService.new(registration)
+  end
+
+  describe "#initialize" do
+    context "when a transient_registration exists" do
+      it "sets @transient_registration" do
+        instance_var = registration_transfer_service.instance_variable_get(:@transient_registration)
+        expect(instance_var).to eq(transient_registration)
+      end
+    end
+
+    context "when no transient_registration exists" do
+      let(:registration_transfer_service) do
+        RegistrationTransferService.new(create(:registration))
+      end
+
+      it "sets @transient_registration to nil" do
+        instance_var = registration_transfer_service.instance_variable_get(:@transient_registration)
+        expect(instance_var).to eq(nil)
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-61

Sometimes NCCC will need to transfer ownership of a registration to a different account.

As a first step, we will set up transfer of a registration to an account which already exists.
