### PR TITLE
Add rake task to solve stuck renewals

### DIFF
--- a/lib/tasks/stuck.rake
+++ b/lib/tasks/stuck.rake
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+namespace :fix do
+  desc "Fix expired renewals stuck at 'renewal-received' stage"
+  task unstick_received: :environment do
+    stuck_renewals = WasteCarriersEngine::TransientRegistration.where(workflow_state: "renewal_received_form")
+    stuck_renewals.each do |renewal|
+      check_service = RenewabilityCheckService.new(renewal)
+      can_be_completed = check_service.renewal_ready_to_complete?
+      puts "#{renewal.reg_identifier} can be completed? #{can_be_completed}"
+      check_service.complete_renewal if can_be_completed
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-521

We've known about renewals which are stuck because they are linked to expired registrations. If you attempted to complete them you got [WC-508](https://eaflood.atlassian.net/browse/WC-508) i.e. a registration with no status. We added and shipped [WC-514](https://eaflood.atlassian.net/browse/WC-514) to resolve this.

The example in **WC-508** we were able to complete by manually going to the `renewal-complete` page. This unfortunately though has steered us in the wrong direction. We assumed that any in this limbo state (payment and convictions signed off, but completion errored due to expiration) could be fixed using the same manual fix.

In review it looks like vast majority are stuck with a state of `renewal-received`. Any attempt to go to the renewal complete redirects you back to the renewal-received page for them. No change is made to the record and it is not completed i.e. converted into a registration.

Therefore we believe the best way to unstick them is through a rake task, which this change adds.
