### PR TITLE
Add config for renewal grace window

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-renewals
-  revision: 307ebcff555a99585c7153f6fe2d2ff41b388c76
+  revision: e5d5f42f047a790e7d151e3f667aaf885e5efc39
   branch: master
   specs:
     waste_carriers_engine (0.0.1)
@@ -375,4 +375,4 @@ RUBY VERSION
    ruby 2.4.2p198
 
 BUNDLED WITH
-   1.16.3
+   1.16.6

--- a/config/application.rb
+++ b/config/application.rb
@@ -88,6 +88,7 @@ module WasteCarriersBackOffice
     # Times
     config.renewal_window = ENV["WCRS_REGISTRATION_RENEWAL_WINDOW"].to_i
     config.expires_after = ENV["WCRS_REGISTRATION_EXPIRES_AFTER"].to_i
+    config.grace_window = ENV["WCRS_REGISTRATION_GRACE_WINDOW"].to_i
 
     # Worldpay
     config.worldpay_url = ENV["WCRS_WORLDPAY_URL"] || "https://secure-test.worldpay.com/jsp/merchant/xml/paymentService.jsp"


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-512

We have added to [Waste-carrier-renewals](https://github.com/DEFRA/waste-carriers-renewals) a 'grace window' which allows users of registrations that have expired to still renew, if the current date is within the window.

However to support this new feature we have to add config to the app which hosts the engine hence this change.