### PR TITLE
Add rake task to anonymise emails

### DIFF
--- a/lib/db.rb
+++ b/lib/db.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+require "db/db"
+require "db/anonymise_email"

--- a/lib/db/anonymise_email.rb
+++ b/lib/db/anonymise_email.rb
@@ -4,24 +4,36 @@ require "db/db"
 
 module Db
   class AnonymiseEmail
+
+    attr_reader :counts
+
+    def initialize
+      @counts = Db.counts(Db.users_collection)
+      @counts[:id_increment] = 1
+
+      @paging = Db.paging(@counts[:total], 100)
+    end
+
     def anonymise
-      counts = Db.counts(Db.users_collection)
-      counts[:id_increment] = 1
-
-      paging = Db.paging(counts[:total], 100)
-
-      puts "Anonymising all emails for #{counts[:total]} users"
-      puts "-------------------------"
-
-      counts = page_through_users(paging, counts)
-
-      puts "-------------------------"
-      puts "Final results"
-      puts "Errors: #{counts[:errored]}"
-      puts "Updated: #{counts[:processed]}"
+      while @paging[:page_number] <= @paging[:num_of_pages]
+        Db.paged_users(@paging).each do |user|
+          result = anonymise_email(
+            user["email"],
+            "user#{@counts[:id_increment]}@example.com"
+          )
+          update_counts(result)
+        end
+        @paging[:page_number] += 1
+      end
     end
 
     private
+
+    def update_counts(result)
+      @counts[:id_increment] += 1
+      @counts[:processed] += 1 if result
+      @counts[:errored] += 1 unless result
+    end
 
     def anonymise_email(old_email, new_email)
       regs = update_registrations(old_email, new_email)
@@ -57,23 +69,6 @@ module Db
                  .find(email: old_email)
                  .update_one("$set": { email: new_email })
       result.n
-    end
-
-    def page_through_users(paging, counts)
-      while paging[:page_number] <= paging[:num_of_pages]
-        users = Db.paged_users(paging)
-        users.each do |user|
-          result = anonymise_email(
-            user["email"],
-            "user#{counts[:id_increment]}@example.com"
-          )
-          counts[:id_increment] += 1
-          counts[:processed] += 1 if result
-          counts[:errored] += 1 unless result
-        end
-        paging[:page_number] += 1
-      end
-      counts
     end
   end
 end

--- a/lib/db/anonymise_email.rb
+++ b/lib/db/anonymise_email.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "db/db"
+
+module Db
+  class AnonymiseEmail
+    def anonymise
+      counts = Db.counts(Db.users_collection)
+      counts[:id_increment] = 1
+
+      paging = Db.paging(counts[:total], 100)
+
+      puts "Anonymising all emails for #{counts[:total]} users"
+      puts "-------------------------"
+
+      counts = page_through_users(paging, counts)
+
+      puts "-------------------------"
+      puts "Final results"
+      puts "Errors: #{counts[:errored]}"
+      puts "Updated: #{counts[:processed]}"
+    end
+
+    private
+
+    def anonymise_email(old_email, new_email)
+      regs = update_registrations(old_email, new_email)
+      renewals = update_transient_registrations(old_email, new_email)
+      user = update_user(old_email, new_email)
+
+      raise "Failed to update" unless user.positive?
+
+      puts "#{old_email} => #{new_email}: #{regs}, #{renewals}"
+
+      true
+    rescue StandardError => e
+      puts "Error with #{old_email}: #{e.message}"
+      false
+    end
+
+    def update_registrations(old_email, new_email)
+      result = Db.registrations_collection
+                 .find(accountEmail: old_email)
+                 .update_many("$set": { accountEmail: new_email, contactEmail: new_email })
+      result.modified_count
+    end
+
+    def update_transient_registrations(old_email, new_email)
+      result = Db.transient_registrations_collection
+                 .find(accountEmail: old_email)
+                 .update_many("$set": { accountEmail: new_email, contactEmail: new_email })
+      result.modified_count
+    end
+
+    def update_user(old_email, new_email)
+      result = Db.users_collection
+                 .find(email: old_email)
+                 .update_one("$set": { email: new_email })
+      result.n
+    end
+
+    def page_through_users(paging, counts)
+      while paging[:page_number] <= paging[:num_of_pages]
+        users = Db.paged_users(paging)
+        users.each do |user|
+          result = anonymise_email(
+            user["email"],
+            "user#{counts[:id_increment]}@example.com"
+          )
+          counts[:id_increment] += 1
+          counts[:processed] += 1 if result
+          counts[:errored] += 1 unless result
+        end
+        paging[:page_number] += 1
+      end
+      counts
+    end
+  end
+end

--- a/lib/db/anonymise_email.rb
+++ b/lib/db/anonymise_email.rb
@@ -43,18 +43,25 @@ module Db
     end
 
     def anonymise_email(show_output, old_email, new_email)
-      regs = update_registrations(old_email, new_email)
-      renewals = update_transient_registrations(old_email, new_email)
-      user = update_user(old_email, new_email)
+      results = update_documents(old_email, new_email)
 
-      raise "Failed to update" unless user.positive?
-
-      puts "#{old_email} => #{new_email}: #{regs}, #{renewals}" if show_output
+      puts "#{old_email} => #{new_email}: #{results[:regs]}, #{results[:renewals]}" if show_output
 
       true
     rescue StandardError => e
       puts "Error with #{old_email}: #{e.message}"
       false
+    end
+
+    def update_documents(old_email, new_email)
+      results = {
+        regs: update_registrations(old_email, new_email),
+        renewals: update_transient_registrations(old_email, new_email),
+        user: update_user(old_email, new_email)
+      }
+      raise "Failed to update" unless results[:user].positive?
+
+      results
     end
 
     def update_registrations(old_email, new_email)

--- a/lib/db/anonymise_email.rb
+++ b/lib/db/anonymise_email.rb
@@ -58,9 +58,12 @@ module Db
     end
 
     def update_transient_registrations(old_email, new_email)
-      result = Db.transient_registrations_collection
-                 .find(accountEmail: old_email)
-                 .update_many("$set": { accountEmail: new_email, contactEmail: new_email })
+      collection = Db.transient_registrations_collection
+      return 0 unless collection
+
+      result = collection
+               .find(accountEmail: old_email)
+               .update_many("$set": { accountEmail: new_email, contactEmail: new_email })
       result.modified_count
     end
 

--- a/lib/db/anonymise_email.rb
+++ b/lib/db/anonymise_email.rb
@@ -20,10 +20,11 @@ module Db
       @paging = Db.paging(@counts[:total], 100)
     end
 
-    def anonymise
+    def anonymise(show_output = false)
       while @paging[:page_number] <= @paging[:num_of_pages]
         Db.paged_users(@paging).each do |user|
           result = anonymise_email(
+            show_output,
             user["email"],
             "user#{@counts[:id_increment]}@example.com"
           )
@@ -41,14 +42,14 @@ module Db
       @counts[:errored] += 1 unless result
     end
 
-    def anonymise_email(old_email, new_email)
+    def anonymise_email(show_output, old_email, new_email)
       regs = update_registrations(old_email, new_email)
       renewals = update_transient_registrations(old_email, new_email)
       user = update_user(old_email, new_email)
 
       raise "Failed to update" unless user.positive?
 
-      puts "#{old_email} => #{new_email}: #{regs}, #{renewals}"
+      puts "#{old_email} => #{new_email}: #{regs}, #{renewals}" if show_output
 
       true
     rescue StandardError => e

--- a/lib/db/db.rb
+++ b/lib/db/db.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Db
+  def self.registrations_collection
+    Mongoid::Clients.default.database.collections.find { |c| c.name == "registrations" }
+  end
+
+  def self.transient_registrations_collection
+    Mongoid::Clients.default.database.collections.find { |c| c.name == "transient_registrations" }
+  end
+
+  def self.users_collection
+    Mongoid::Clients.with_name("users").database.collections.find { |c| c.name == "users" }
+  end
+
+  def self.paged_users(paging)
+    users_collection
+      .find
+      .skip(paging[:page_size] * (paging[:page_number] - 1))
+      .limit(paging[:page_size])
+  end
+
+  def self.counts(collection)
+    counts = {
+      total: 0,
+      processed: 0,
+      errored: 0
+    }
+    counts[:total] = collection.find.count
+
+    counts
+  end
+
+  def self.paging(total, size)
+    {
+      page_size: size,
+      page_number: 1,
+      num_of_pages: (total / size.to_f).ceil
+    }
+  end
+end

--- a/lib/tasks/anonymise.rake
+++ b/lib/tasks/anonymise.rake
@@ -7,7 +7,16 @@ namespace :db do
     desc "Anonymise all account and contact email addresses"
     task email: :environment do
       anonymiser = Db::AnonymiseEmail.new
+
+      puts "Anonymising all emails for #{anonymiser.counts[:total]} users"
+      puts "-------------------------"
+
       anonymiser.anonymise
+
+      puts "-------------------------"
+      puts "Final results"
+      puts "Errors: #{anonymiser.counts[:errored]}"
+      puts "Updated: #{anonymiser.counts[:processed]}"
     end
   end
 end

--- a/lib/tasks/anonymise.rake
+++ b/lib/tasks/anonymise.rake
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "db"
+
+namespace :db do
+  namespace :anonymise do
+    desc "Anonymise all account and contact email addresses"
+    task email: :environment do
+      anonymiser = Db::AnonymiseEmail.new
+      anonymiser.anonymise
+    end
+  end
+end

--- a/lib/tasks/anonymise.rake
+++ b/lib/tasks/anonymise.rake
@@ -11,7 +11,7 @@ namespace :db do
       puts "Anonymising all emails for #{anonymiser.counts[:total]} users"
       puts "-------------------------"
 
-      anonymiser.anonymise
+      anonymiser.anonymise(true)
 
       puts "-------------------------"
       puts "Final results"


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-525

We often need to test stuff against production data. If when testing we complete a renewal then the service will send an email to the actual user. We could break the link to our email server within the environment under test, however this could lead to unrelated errors occurring during testing because an email failed to send.

So instead we really need someway that having restored production data ready for debugging/testing, we can then anonymise the email addresses so they will never actually get sent to a real inbox.
