### PR TITLE
Fix blocked actions post grace window

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-renewals
-  revision: 80a323fcc57c982e14a76d8faea5a80efe12e603
+  revision: b535c6c5c2a3edaa0b7056534d148b76a3ca4bf9
   branch: master
   specs:
     waste_carriers_engine (0.0.1)
@@ -81,7 +81,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    concurrent-ruby (1.1.2)
+    concurrent-ruby (1.1.3)
     countries (2.1.4)
       i18n_data (~> 0.8.0)
       money (~> 6.9)
@@ -375,4 +375,4 @@ RUBY VERSION
    ruby 2.4.2p198
 
 BUNDLED WITH
-   1.16.6
+   1.17.1

--- a/app/controllers/convictions_controller.rb
+++ b/app/controllers/convictions_controller.rb
@@ -6,5 +6,6 @@ class ConvictionsController < ApplicationController
   def index
     reg_identifier = params[:transient_registration_reg_identifier]
     @transient_registration = WasteCarriersEngine::TransientRegistration.where(reg_identifier: reg_identifier).first
+    @registration = WasteCarriersEngine::Registration.where(reg_identifier: reg_identifier).first
   end
 end

--- a/app/views/convictions/index.html.erb
+++ b/app/views/convictions/index.html.erb
@@ -119,7 +119,7 @@
     </table>
     <% end %>
 
-    <% if @transient_registration.metaData.may_renew? && @transient_registration.conviction_check_required? %>
+    <% if @registration.metaData.may_renew? && @transient_registration.conviction_check_required? %>
       <h2 class="heading-medium">
         <%= t(".approve_or_reject.heading") %>
       </h2>

--- a/app/views/convictions/index.html.erb
+++ b/app/views/convictions/index.html.erb
@@ -119,7 +119,7 @@
     </table>
     <% end %>
 
-    <% if @transient_registration.metaData.ACTIVE? && @transient_registration.conviction_check_required? %>
+    <% if @transient_registration.metaData.may_renew? && @transient_registration.conviction_check_required? %>
       <h2 class="heading-medium">
         <%= t(".approve_or_reject.heading") %>
       </h2>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-512

During testing of the grace window it was spotted that if a renewal was expired, and it matched during conviction checks, then it could not be continued because the button to access convictions approvals did not display.

On double checking we found built into the view the check `ACTIVE?`, i.e. if the renewal was not ACTIVE then it could not be approved.