### PR TITLE
Add timings and alter output in anonymise email task

### DIFF
--- a/lib/db/anonymise_email.rb
+++ b/lib/db/anonymise_email.rb
@@ -20,17 +20,18 @@ module Db
       @paging = Db.paging(@counts[:total], 100)
     end
 
-    def anonymise(show_output = false)
+    def anonymise(debug = false)
       while @paging[:page_number] <= @paging[:num_of_pages]
         Db.paged_users(@paging).each do |user|
           result = anonymise_email(
-            show_output,
+            debug,
             user["email"],
             "user#{@counts[:id_increment]}@example.com"
           )
           update_counts(result)
         end
         @paging[:page_number] += 1
+        print "." unless debug
       end
     end
 
@@ -42,10 +43,10 @@ module Db
       @counts[:errored] += 1 unless result
     end
 
-    def anonymise_email(show_output, old_email, new_email)
+    def anonymise_email(debug, old_email, new_email)
       results = update_documents(old_email, new_email)
 
-      puts "#{old_email} => #{new_email}: #{results[:regs]}, #{results[:renewals]}" if show_output
+      puts "#{old_email} => #{new_email}: #{results[:regs]}, #{results[:renewals]}" if debug
 
       true
     rescue StandardError => e

--- a/lib/tasks/anonymise.rake
+++ b/lib/tasks/anonymise.rake
@@ -13,9 +13,9 @@ namespace :db do
       puts "Anonymising all emails for #{anonymiser.counts[:total]} users"
       puts "-------------------------"
 
-      anonymiser.anonymise(true)
+      anonymiser.anonymise(false)
 
-      puts "-------------------------"
+      puts "\n-------------------------"
       puts "Final results"
       puts "Errors: #{anonymiser.counts[:errored]}"
       puts "Updated: #{anonymiser.counts[:processed]}"

--- a/lib/tasks/anonymise.rake
+++ b/lib/tasks/anonymise.rake
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 require "db"
+require "time_helpers"
 
 namespace :db do
   namespace :anonymise do
     desc "Anonymise all account and contact email addresses"
     task email: :environment do
+      started = Time.now
       anonymiser = Db::AnonymiseEmail.new
 
       puts "Anonymising all emails for #{anonymiser.counts[:total]} users"
@@ -17,6 +19,7 @@ namespace :db do
       puts "Final results"
       puts "Errors: #{anonymiser.counts[:errored]}"
       puts "Updated: #{anonymiser.counts[:processed]}"
+      puts "Took #{TimeHelpers.humanise(Time.now - started)} to complete"
     end
   end
 end

--- a/lib/time_helpers.rb
+++ b/lib/time_helpers.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module TimeHelpers
+  # https://stackoverflow.com/a/4136485/6117745
+  def self.humanise(seconds)
+    [[60, :seconds], [60, :minutes], [24, :hours], [1000, :days]].map do |count, name|
+      if seconds.positive?
+        seconds, n = seconds.divmod(count)
+        "#{n.to_i} #{name}"
+      end
+    end.compact.reverse.join(" ")
+  end
+end


### PR DESCRIPTION
The rake task will take some time to run, hence it is likely we would leave it running unattended.

For future planning, and to help determine if further optimisation is needed it would be useful to know approximately how long it takes to run. Hence this tweak adds a time taken to the output of the rake task.

Also to get a minor performance bump we realised that in most cases outputting the full details for each account anonymised was unnecessary, but may be needed in future for debugging purposes.

So this change also tweaks how output is managed by the task.
