### PR TITLE
Ensure output to STDOUT is immediate in anonymise

### DIFF
--- a/lib/tasks/anonymise.rake
+++ b/lib/tasks/anonymise.rake
@@ -5,8 +5,13 @@ require "time_helpers"
 
 namespace :db do
   namespace :anonymise do
+    # This task can take a long time to complete and therefore you may prefer
+    # to run it as a background task using
+    # nohup bundle exec rake db:anonymise:email > anonymise.out 2>&1 </dev/null &
     desc "Anonymise all account and contact email addresses"
     task email: :environment do
+      STDOUT.sync = true
+
       started = Time.now
       anonymiser = Db::AnonymiseEmail.new
 


### PR DESCRIPTION
Initial runs of the anonymise email task have shown that it takes a very long time to complete. Therefore its something we want to set running, particularly if we are ssh'd in, then log off and come back to later.

We can do this using something like nohup and redirecting output to a log file, but when we do we have found no output appears in the log file until we command quits or finishes.

Some googling later, and the suggestion is this is due to the output not being flushed. The general concensus was that adding `STDOUT.sync = true` above where your output occurs will resolve the issue.