### PR TITLE
Add ability to skip already anonymised emails

### DIFF
--- a/lib/db/anonymise_email.rb
+++ b/lib/db/anonymise_email.rb
@@ -23,15 +23,17 @@ module Db
     def anonymise(debug = false)
       while @paging[:page_number] <= @paging[:num_of_pages]
         Db.paged_users(@paging).each do |user|
-          result = anonymise_email(
-            debug,
-            user["email"],
-            "user#{@counts[:id_increment]}@example.com"
-          )
+          unless user["email"].end_with?("@example.com")
+            result = anonymise_email(
+              debug,
+              user["email"],
+              "user#{@counts[:id_increment]}@example.com"
+            )
+          end
           update_counts(result)
         end
         @paging[:page_number] += 1
-        print "." unless debug
+        print_progress unless debug
       end
     end
 
@@ -39,13 +41,21 @@ module Db
 
     def update_counts(result)
       @counts[:id_increment] += 1
-      @counts[:processed] += 1 if result
-      @counts[:errored] += 1 unless result
+
+      case result
+      when true
+        @counts[:processed] += 1
+      when false
+        @counts[:errored] += 1
+      else
+        @counts[:skipped] += 1
+      end
     end
 
     def anonymise_email(debug, old_email, new_email)
       results = update_documents(old_email, new_email)
 
+      STDOUT.sync = true
       puts "#{old_email} => #{new_email}: #{results[:regs]}, #{results[:renewals]}" if debug
 
       true
@@ -86,6 +96,11 @@ module Db
                .find(email: old_email)
                .update_one("$set": { email: new_email })
       result.n
+    end
+
+    def print_progress
+      STDOUT.sync = true
+      print "."
     end
   end
 end

--- a/lib/db/anonymise_email.rb
+++ b/lib/db/anonymise_email.rb
@@ -22,22 +22,26 @@ module Db
 
     def anonymise(debug = false)
       while @paging[:page_number] <= @paging[:num_of_pages]
-        Db.paged_users(@paging).each do |user|
-          unless user["email"].end_with?("@example.com")
-            result = anonymise_email(
-              debug,
-              user["email"],
-              "user#{@counts[:id_increment]}@example.com"
-            )
-          end
-          update_counts(result)
-        end
+        anonymise_users
         @paging[:page_number] += 1
         print_progress unless debug
       end
     end
 
     private
+
+    def anonymise_users
+      Db.paged_users(@paging).each do |user|
+        unless user["email"].end_with?("@example.com")
+          result = anonymise_email(
+            debug,
+            user["email"],
+            "user#{@counts[:id_increment]}@example.com"
+          )
+        end
+        update_counts(result)
+      end
+    end
 
     def update_counts(result)
       @counts[:id_increment] += 1

--- a/lib/db/db.rb
+++ b/lib/db/db.rb
@@ -24,6 +24,7 @@ module Db
     counts = {
       total: 0,
       processed: 0,
+      skipped: 0,
       errored: 0
     }
     counts[:total] = collection.find.count

--- a/lib/tasks/anonymise.rake
+++ b/lib/tasks/anonymise.rake
@@ -22,8 +22,9 @@ namespace :db do
 
       puts "\n-------------------------"
       puts "Final results"
-      puts "Errors: #{anonymiser.counts[:errored]}"
+      puts "Skipped: #{anonymiser.counts[:skipped]}"
       puts "Updated: #{anonymiser.counts[:processed]}"
+      puts "Errors: #{anonymiser.counts[:errored]}"
       puts "Took #{TimeHelpers.humanise(Time.now - started)} to complete"
     end
   end


### PR DESCRIPTION
The anonymiser currently takes so long to complete that it's progress is often cut short. However it seems a waste of effort to start from the beginning anonymising emails that have already been anonymised so this change adds a test of the current user email address.

If it ends with '@example.com' the anonymiser skips updating the user and associated records and moves onto the next one.