### PR TITLE
Add a quick version of anonymise email task

### DIFF
--- a/lib/db/anonymise_email.rb
+++ b/lib/db/anonymise_email.rb
@@ -17,6 +17,10 @@ module Db
       @counts = Db.counts(@collections[:users])
       @counts[:id_increment] = 1
 
+      @counts[:users_updated] = 0
+      @counts[:registrations_updated] = 0
+      @counts[:transient_registrations_updated] = 0
+
       @paging = Db.paging(@counts[:total], 100)
     end
 

--- a/lib/tasks/anonymise.rake
+++ b/lib/tasks/anonymise.rake
@@ -3,6 +3,7 @@
 require "db"
 require "time_helpers"
 
+# rubocop:disable Metrics/BlockLength
 namespace :db do
   namespace :anonymise do
     # This task can take a long time to complete and therefore you may prefer
@@ -27,5 +28,25 @@ namespace :db do
       puts "Errors: #{anonymiser.counts[:errored]}"
       puts "Took #{TimeHelpers.humanise(Time.now - started)} to complete"
     end
+
+    # This task can take a long time to complete and therefore you may prefer
+    # to run it as a background task using
+    # nohup bundle exec rake db:anonymise:email > anonymise.out 2>&1 </dev/null &
+    desc "Anonymise all account and contact email addresses"
+    task email_quick: :environment do
+      STDOUT.sync = true
+
+      started = Time.now
+      anonymiser = Db::AnonymiseEmail.new
+
+      puts "Anonymising all emails quickly..."
+      puts "-------------------------"
+
+      anonymiser.anonymise_quick
+
+      puts "\n-------------------------"
+      puts "Took #{TimeHelpers.humanise(Time.now - started)} to complete"
+    end
   end
 end
+# rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
The current version of the anonymise email task ensures

- all emails are anonymised
- that the link between user, registrations and transient registrations remains intact

However it taks forever! We have had the task running for more than a day and it is still yet to complete.

So if we really need this we have the option, however we also need a much faster version. This change adds an alternate version that simply replaces the domain of all email addresses with **example.com**. It runs the risk that it will lead to duplicate users e.g. john.smith@gmail.com and john.smith@yahoo.com both become john.smith@example.com.

However we currently do not have a better option to anonymise all emails in a reasonable amount of time.