### PR TITLE
Update anonymise email rake to use bulk write

### DIFF
--- a/lib/db/anonymise_email.rb
+++ b/lib/db/anonymise_email.rb
@@ -20,52 +20,59 @@ module Db
       @paging = Db.paging(@counts[:total], 100)
     end
 
-    def anonymise(debug = false)
+    def anonymise
       while @paging[:page_number] <= @paging[:num_of_pages]
-        anonymise_users
+        page_through_users
         @paging[:page_number] += 1
-        print_progress unless debug
+        print_progress
       end
     end
 
     private
 
-    def anonymise_users
+    def page_through_users
+      registration_updates = []
+      renewal_updates = []
+      user_updates = []
+
       Db.paged_users(@paging).each do |user|
-        unless user["email"].end_with?("@example.com")
-          result = anonymise_email(
-            debug,
-            user["email"],
-            "user#{@counts[:id_increment]}@example.com"
-          )
-        end
-        update_counts(result)
+        next if user["email"].end_with?("@example.com")
+
+        operations = generate_operations(
+          user["email"],
+          "user#{@counts[:id_increment]}@example.com"
+        )
+
+        registration_updates << operations[:registration]
+        renewal_updates << operations[:transient_registration]
+        user_updates << operations[:user]
+
+        @counts[:id_increment] += 1
       end
+      apply_operations(
+        registration_updates,
+        renewal_updates,
+        user_updates
+      )
     end
 
-    def update_counts(result)
-      @counts[:id_increment] += 1
+    def apply_operations(registration_updates, renewal_updates, user_updates)
+      @collections[:users].bulk_write(user_updates) unless user_updates.empty?
+      @collections[:registrations].bulk_write(registration_updates) unless registration_updates.empty?
 
-      case result
-      when true
-        @counts[:processed] += 1
-      when false
-        @counts[:errored] += 1
-      else
-        @counts[:skipped] += 1
-      end
-    end
+      return unless @collections[:renewals]
 
-    def anonymise_email(debug, old_email, new_email)
-      results = update_documents(old_email, new_email)
-
-      STDOUT.sync = true
-      puts "#{old_email} => #{new_email}: #{results[:regs]}, #{results[:renewals]}" if debug
-
-      true
+      @collections[:renewals].bulk_write(renewal_updates) unless renewal_updates.empty?
     rescue StandardError => e
-      puts "Error with #{old_email}: #{e.message}"
-      false
+      puts e.message
+    end
+
+    def generate_operations(old_email, new_email)
+      {
+        registration: update_registrations(old_email, new_email),
+        transient_registration: update_registrations(old_email, new_email),
+        user: update_user(old_email, new_email)
+      }
     end
 
     def update_documents(old_email, new_email)
@@ -80,26 +87,21 @@ module Db
     end
 
     def update_registrations(old_email, new_email)
-      result = @collections[:registrations]
-               .find(accountEmail: old_email)
-               .update_many("$set": { accountEmail: new_email, contactEmail: new_email })
-      result.modified_count
-    end
-
-    def update_transient_registrations(old_email, new_email)
-      return 0 unless @collections[:renewals]
-
-      result = @collections[:renewals]
-               .find(accountEmail: old_email)
-               .update_many("$set": { accountEmail: new_email, contactEmail: new_email })
-      result.modified_count
+      {
+        update_many: {
+          filter: { accountEmail: old_email },
+          update: { "$set": { accountEmail: new_email, contactEmail: new_email } }
+        }
+      }
     end
 
     def update_user(old_email, new_email)
-      result = @collections[:users]
-               .find(email: old_email)
-               .update_one("$set": { email: new_email })
-      result.n
+      {
+        update_many: {
+          filter: { email: old_email },
+          update: { "$set": { email: new_email } }
+        }
+      }
     end
 
     def print_progress

--- a/lib/tasks/anonymise.rake
+++ b/lib/tasks/anonymise.rake
@@ -18,13 +18,9 @@ namespace :db do
       puts "Anonymising all emails for #{anonymiser.counts[:total]} users"
       puts "-------------------------"
 
-      anonymiser.anonymise(false)
+      anonymiser.anonymise
 
       puts "\n-------------------------"
-      puts "Final results"
-      puts "Skipped: #{anonymiser.counts[:skipped]}"
-      puts "Updated: #{anonymiser.counts[:processed]}"
-      puts "Errors: #{anonymiser.counts[:errored]}"
       puts "Took #{TimeHelpers.humanise(Time.now - started)} to complete"
     end
   end


### PR DESCRIPTION
When running in our pre-production environment this task is taking more than a day to complete. We therefore started looking into performance improvements.

One idea was to take the risk of duplicates and simply replace the domain in all emails with **example.com**. However we then realised its not actually very easy to update a field based on an existing value in the document when using MongoDb. In fact up to version 3.4 it wasn't even possible.

So instead we found [bulk_write](https://docs.mongodb.com/ruby-driver/master/tutorials/ruby-driver-bulk-operations/). At the moment for each user we are calling 3 different queries;

- update all registrations with a matching account email
- update all transient_registrationsnm with a matching account email
- update the user's email

In each case we are sending a request, waiting for it to complete, and then MongoDb is sending back a result.

With bulk_write we create an array of update statements for each collection, and then apply them as one. So for every 100 users we are just firing one update per collection. The aim is that the reduction in network traffic will result in an improvement in performance.