### PR TITLE
Add a menu to the back office

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,9 +10,23 @@
 <% content_for :proposition_header do %>
   <div class="header-proposition">
     <div class="content">
-      <nav id="proposition-menu">
+      <% if user_signed_in? %>
         <%= link_to t(:global_proposition_header), main_app.bo_path, id: "proposition-name" %>
-      </nav>
+        <a role="button" href="#proposition-links" class="js-header-toggle menu" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</a>
+          <nav id="proposition-menu">
+            <ul id="proposition-links" aria-label="Top Level Navigation">
+              <li>
+                <%= link_to t("layouts.application.menu.dashboard"),
+                            main_app.bo_path,
+                            class: (current_page?(main_app.bo_path) ? "active" : "") %>
+              </li>
+            </ul>
+          </nav>
+      <% else %>
+        <nav id="proposition-menu">
+          <%= link_to t(:global_proposition_header), main_app.bo_path, id: "proposition-name" %>
+        </nav>
+      <% end %>
     </div>
   </div>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,6 +4,8 @@ en:
   layouts:
     application:
       feedback_url: https://www.gov.uk/done/waste-carrier-or-broker-registration
+      menu:
+        dashboard: "Renewals dashboard"
   shared:
     conviction_search_result:
       match_result: "Match result"


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-496

As we add new functionality to the back office, providing links in renewal details is not always going to be the most appropriate place to access the functionality from, and in a lot of cases won't make sense. So we need to add a menu.

This will be used to link to upcoming features like user management, improved convictions workflow, etc.