### PR TITLE
Downcase all email characters when transferring registration

### DIFF
--- a/app/forms/registration_transfer_form.rb
+++ b/app/forms/registration_transfer_form.rb
@@ -9,8 +9,8 @@ class RegistrationTransferForm < WasteCarriersEngine::BaseForm
   end
 
   def submit(params)
-    self.email = params[:email]
-    self.confirm_email = params[:confirm_email]
+    self.email = params[:email]&.downcase
+    self.confirm_email = params[:confirm_email]&.downcase
 
     attributes = {}
 

--- a/spec/forms/registration_transfer_form_spec.rb
+++ b/spec/forms/registration_transfer_form_spec.rb
@@ -37,6 +37,26 @@ RSpec.describe RegistrationTransferForm, type: :model do
         expect(registration_transfer_form.submit(invalid_params)).to eq(false)
       end
     end
+
+    context "when the params contain uppercase letters" do
+      let(:uppercase_params) do
+        {
+          reg_identifier: registration_transfer_form.reg_identifier,
+          email: "UPPERCASElowercase@example.com",
+          confirm_email: "UPPERCASElowercase@example.com"
+        }
+      end
+
+      it "lowercases the email" do
+        registration_transfer_form.submit(uppercase_params)
+        expect(registration_transfer_form.email).to eq("uppercaselowercase@example.com")
+      end
+
+      it "lowercases the confirm_email" do
+        registration_transfer_form.submit(uppercase_params)
+        expect(registration_transfer_form.confirm_email).to eq("uppercaselowercase@example.com")
+      end
+    end
   end
 
   describe "#email" do


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-61

If the 'transfer a registration' form is submitted with an email address containing uppercase characters, convert them to lowercase before processing. This means we can avoid issues with case sensitivity when looking up user accounts.