### PR TITLE
Add rake task to sync internal users

### DIFF
--- a/lib/db/anonymise_email.rb
+++ b/lib/db/anonymise_email.rb
@@ -31,7 +31,7 @@ module Db
     private
 
     def anonymise_users
-      Db.paged_users(@paging).each do |user|
+      Db.paged_collection(@paging, @collections[:users]).each do |user|
         unless user["email"].end_with?("@example.com")
           result = anonymise_email(
             debug,

--- a/lib/db/db.rb
+++ b/lib/db/db.rb
@@ -25,8 +25,8 @@ module Db
     Mongoid::Clients.with_name("users").database.collections.find { |c| c.name == "back_office_users" }
   end
 
-  def self.paged_users(paging)
-    users_collection
+  def self.paged_collection(paging, collection)
+    collection
       .find
       .skip(paging[:page_size] * (paging[:page_number] - 1))
       .limit(paging[:page_size])

--- a/lib/db/db.rb
+++ b/lib/db/db.rb
@@ -13,6 +13,18 @@ module Db
     Mongoid::Clients.with_name("users").database.collections.find { |c| c.name == "users" }
   end
 
+  def self.admin_users_collection
+    Mongoid::Clients.with_name("users").database.collections.find { |c| c.name == "admins" }
+  end
+
+  def self.agency_users_collection
+    Mongoid::Clients.with_name("users").database.collections.find { |c| c.name == "agency_users" }
+  end
+
+  def self.back_office_users_collection
+    Mongoid::Clients.with_name("users").database.collections.find { |c| c.name == "back_office_users" }
+  end
+
   def self.paged_users(paging)
     users_collection
       .find

--- a/lib/db/db.rb
+++ b/lib/db/db.rb
@@ -25,6 +25,10 @@ module Db
     Mongoid::Clients.with_name("users").database.collections.find { |c| c.name == "back_office_users" }
   end
 
+  def self.roles_collection
+    Mongoid::Clients.with_name("users").database.collections.find { |c| c.name == "roles" }
+  end
+
   def self.paged_collection(paging, collection)
     collection
       .find

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -1,104 +1,12 @@
 # frozen_string_literal: true
 
 require "db"
+require "users"
 
 namespace :users do
   desc "Sync backend users with back-office"
   task sync_internal_users: :environment do
-
-    user_collections = {
-      roles: Db.roles_collection,
-      admin: Db.admin_users_collection,
-      agency: Db.agency_users_collection,
-      back_office: Db.back_office_users_collection
-    }
-
-    counts = Db.counts(user_collections[:admin])
-    paging = Db.paging(counts[:total], 100)
-
-    Db.paged_collection(paging, user_collections[:admin]).each do |user|
-      bo_user = back_office_user(user_collections[:back_office], user["email"])
-      role = determine_admin_role(user_collections[:roles], user)
-      if bo_user.nil?
-        result = create_user(user_collections[:back_office], user, role)
-        puts "Created new user: #{user[:email]}, #{role}" if result
-        puts "Error creating new user: #{user[:email]}, #{role}" unless result
-      elsif role.to_s != bo_user[:role]
-        result = update_role(user_collections[:back_office], bo_user, role)
-        puts "Updated #{user[:email]} to new role #{role}" if result
-        puts "Error updating #{user[:email]} to new role #{role}" unless result
-      else
-        puts "No changes so skipping #{bo_user['email']}"
-      end
-    end
-
-    Db.paged_collection(paging, user_collections[:agency]).each do |user|
-      bo_user = back_office_user(user_collections[:back_office], user["email"])
-      role = determine_role(user_collections[:roles], user)
-      if bo_user.nil?
-        result = create_user(user_collections[:back_office], user, role)
-        puts "Created new user: #{user[:email]}, #{role}" if result
-        puts "Error creating new user: #{user[:email]}, #{role}" unless result
-      elsif role.to_s != bo_user[:role]
-        result = update_role(user_collections[:back_office], bo_user, role)
-        puts "Updated #{user[:email]} to new role #{role}" if result
-        puts "Error updating #{user[:email]} to new role #{role}" unless result
-      else
-        puts "No changes so skipping #{bo_user['email']}"
-      end
-    end
-  end
-
-  def back_office_user(collection, email)
-    collection.find(email: email).first
-  end
-
-  def create_user(collection, user, role)
-    result = collection.insert_one(
-      email: user["email"],
-      encrypted_password: user["encrypted_password"],
-      sign_in_count: 0,
-      failed_attempts: 0,
-      role: role,
-      confirmed_at: Time.now
-    )
-    return true if result.n.positive?
-
-    false
-  end
-
-  def update_role(collection, user, new_role)
-    result = collection.find(_id: user[:_id]).update_one("$set": { role: new_role })
-    return true if result.n.positive?
-
-    false
-  end
-
-  def determine_admin_role(collection, user)
-    return :agency_super unless user["role_ids"]
-
-    role = collection.find(_id: user["role_ids"][0]).first
-    convert_role(role["name"])
-  end
-
-  def determine_role(collection, user)
-    return :agency unless user["role_ids"]
-
-    role = collection.find(_id: user["role_ids"][0]).first
-    convert_role(role["name"])
-  end
-
-  def convert_role(role)
-    case role
-    when "Role_financeSuper"
-      new_role = "finance_super"
-    when "Role_agencyRefundPayment"
-      new_role = "agency_with_refund"
-    when "Role_financeAdmin"
-      new_role = "finance_admin"
-    when "Role_financeBasic"
-      new_role = "finance"
-    end
-    new_role
+    sync_users = Users::SyncUsers.new
+    sync_users.sync
   end
 end

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -8,5 +8,7 @@ namespace :users do
   task sync_internal_users: :environment do
     sync_users = Users::SyncUsers.new
     sync_users.sync
+    puts "Action, Email, Determined role"
+    sync_users.results.each { |result| puts "#{result[:action]}, #{result[:email]}, #{result[:role]}" }
   end
 end

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "db"
+
+namespace :users do
+  desc "Sync backend users with back-office"
+  task sync_internal_users: :environment do
+
+    user_collections = {
+      roles: Db.roles_collection,
+      admin: Db.admin_users_collection,
+      agency: Db.agency_users_collection,
+      back_office: Db.back_office_users_collection
+    }
+
+    counts = Db.counts(user_collections[:admin])
+    paging = Db.paging(counts[:total], 100)
+
+    Db.paged_collection(paging, user_collections[:admin]).each do |user|
+      bo_user = back_office_user(user_collections[:back_office], user["email"])
+      begin
+        if bo_user.nil?
+          role = determine_admin_role(user_collections[:roles], user)
+          create_back_office_user(user, role)
+          puts "Created new back office user: #{user.email}, #{role}"
+        else
+          puts "Skipping admin #{bo_user['email']}"
+        end
+      rescue StandardError => ex
+        puts ex
+      end
+    end
+  end
+
+  def back_office_user(collection, email)
+    collection.find(email: email).first
+  end
+
+  def create_back_office_user(user, role)
+    User.create(
+      email: user["email"],
+      role: role,
+      password: user["encrypted_password"],
+      confirmed_at: Time.now
+    ).save!
+  end
+
+  def determine_admin_role(collection, user)
+    return :agency_super unless user["role_ids"]
+
+    role = collection.find(_id: user["role_ids"][0]).first
+    convert_role(role["name"])
+  end
+
+  def convert_role(role)
+    case role
+    when "Role_financeSuper"
+      new_role = "finance_super"
+    when "Role_agencyRefundPayment"
+      new_role = "agency_with_refund"
+    when "Role_financeAdmin"
+      new_role = "finance_admin"
+    when "Role_financeBasic"
+      new_role = "finance"
+    end
+    new_role
+  end
+end

--- a/lib/users.rb
+++ b/lib/users.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require "users/sync_users"

--- a/lib/users/sync_users.rb
+++ b/lib/users/sync_users.rb
@@ -32,7 +32,7 @@ module Users
     def sync_agency
       @collections[:agency].find.each do |user|
         bo_user = back_office_user(user["email"])
-        role = determine_role(user)
+        role = determine_agency_role(user)
         sync_user(user, bo_user, role)
       end
     end
@@ -61,9 +61,9 @@ module Users
         confirmed_at: Time.now
       )
       if result.n.positive?
-        puts "Created new user: #{user[:email]}, #{determined_role}"
+        puts "Created new user: #{user[:email]}, #{role}"
       else
-        puts "Error creating new user: #{user[:email]}, #{determined_role}"
+        puts "Error creating new user: #{user[:email]}, #{role}"
       end
     end
 
@@ -72,22 +72,25 @@ module Users
                .find(_id: user[:_id])
                .update_one("$set": { role: new_role })
       if result.n.positive?
-        puts "Updated #{user[:email]} to new role #{determined_role}"
+        puts "Updated #{user[:email]} to new role #{new_role}"
       else
-        puts "Error updating #{user[:email]} to new role #{determined_role}"
+        puts "Error updating #{user[:email]} to new role #{new_role}"
       end
     end
 
     def determine_admin_role(user)
       return :agency_super unless user["role_ids"]
 
-      role = @collections[:roles].find(_id: user["role_ids"][0]).first
-      convert_role(role["name"])
+      determine_role(user)
+    end
+
+    def determine_agency_role(user)
+      return :agency unless user["role_ids"]
+
+      determine_role(user)
     end
 
     def determine_role(user)
-      return :agency unless user["role_ids"]
-
       role = @collections[:roles].find(_id: user["role_ids"][0]).first
       convert_role(role["name"])
     end

--- a/lib/users/sync_users.rb
+++ b/lib/users/sync_users.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require "db"
+
+module Users
+  class SyncUsers
+
+    def initialize
+      @collections = {
+        roles: Db.roles_collection,
+        admin: Db.admin_users_collection,
+        agency: Db.agency_users_collection,
+        back_office: Db.back_office_users_collection
+      }
+    end
+
+    def sync
+      sync_admin
+      sync_agency
+    end
+
+    private
+
+    def sync_admin
+      @collections[:admin].find.each do |user|
+        bo_user = back_office_user(user["email"])
+        role = determine_admin_role(user)
+        sync_user(user, bo_user, role)
+      end
+    end
+
+    def sync_agency
+      @collections[:agency].find.each do |user|
+        bo_user = back_office_user(user["email"])
+        role = determine_role(user)
+        sync_user(user, bo_user, role)
+      end
+    end
+
+    def sync_user(user, bo_user, determined_role)
+      if bo_user.nil?
+        create_user(user, determined_role)
+      elsif determined_role.to_s != bo_user[:role]
+        update_role(bo_user, determined_role)
+      else
+        puts "No changes so skipping #{bo_user['email']}"
+      end
+    end
+
+    def back_office_user(email)
+      @collections[:back_office].find(email: email).first
+    end
+
+    def create_user(user, role)
+      result = @collections[:back_office].insert_one(
+        email: user["email"],
+        encrypted_password: user["encrypted_password"],
+        sign_in_count: 0,
+        failed_attempts: 0,
+        role: role,
+        confirmed_at: Time.now
+      )
+      if result.n.positive?
+        puts "Created new user: #{user[:email]}, #{determined_role}"
+      else
+        puts "Error creating new user: #{user[:email]}, #{determined_role}"
+      end
+    end
+
+    def update_role(user, new_role)
+      result = @collections[:back_office]
+               .find(_id: user[:_id])
+               .update_one("$set": { role: new_role })
+      if result.n.positive?
+        puts "Updated #{user[:email]} to new role #{determined_role}"
+      else
+        puts "Error updating #{user[:email]} to new role #{determined_role}"
+      end
+    end
+
+    def determine_admin_role(user)
+      return :agency_super unless user["role_ids"]
+
+      role = @collections[:roles].find(_id: user["role_ids"][0]).first
+      convert_role(role["name"])
+    end
+
+    def determine_role(user)
+      return :agency unless user["role_ids"]
+
+      role = @collections[:roles].find(_id: user["role_ids"][0]).first
+      convert_role(role["name"])
+    end
+
+    def convert_role(role)
+      case role
+      when "Role_financeSuper"
+        new_role = "finance_super"
+      when "Role_agencyRefundPayment"
+        new_role = "agency_with_refund"
+      when "Role_financeAdmin"
+        new_role = "finance_admin"
+      when "Role_financeBasic"
+        new_role = "finance"
+      end
+      new_role
+    end
+  end
+end

--- a/lib/users/sync_users.rb
+++ b/lib/users/sync_users.rb
@@ -23,7 +23,7 @@ module Users
 
     def sync_admin
       @collections[:admin].find.each do |user|
-        bo_user = back_office_user(user["email"])
+        bo_user = back_office_user(user[:email])
         role = determine_admin_role(user)
         sync_user(user, bo_user, role)
       end
@@ -31,7 +31,7 @@ module Users
 
     def sync_agency
       @collections[:agency].find.each do |user|
-        bo_user = back_office_user(user["email"])
+        bo_user = back_office_user(user[:email])
         role = determine_agency_role(user, bo_user)
         sync_user(user, bo_user, role)
       end
@@ -43,7 +43,7 @@ module Users
       elsif determined_role.to_s != bo_user[:role]
         update_role(bo_user, determined_role)
       else
-        puts "No changes so skipping #{bo_user['email']}"
+        puts "No changes so skipping #{bo_user[:email]}"
       end
     end
 
@@ -53,8 +53,8 @@ module Users
 
     def create_user(user, role)
       result = @collections[:back_office].insert_one(
-        email: user["email"],
-        encrypted_password: user["encrypted_password"],
+        email: user[:email],
+        encrypted_password: user[:encrypted_password],
         sign_in_count: 0,
         failed_attempts: 0,
         role: role,
@@ -93,15 +93,15 @@ module Users
       # an admin role, we leave it as is rather than overwriting it (in the
       # back office admins can do pretty much anything hence only one user
       # needed)
-      return bo_user["role"] if bo_user && admin_role?(bo_user[:role])
-      return "agency" unless user["role_ids"]
+      return bo_user[:role] if bo_user && admin_role?(bo_user[:role])
+      return "agency" unless user[:role_ids]
 
       determine_role(user)
     end
 
     def determine_role(user)
-      role = @collections[:roles].find(_id: user["role_ids"][0]).first
-      convert_role(role["name"])
+      role = @collections[:roles].find(_id: user[:role_ids][0]).first
+      convert_role(role[:name])
     end
 
     def convert_role(role)

--- a/lib/users/sync_users.rb
+++ b/lib/users/sync_users.rb
@@ -41,7 +41,15 @@ module Users
       if bo_user.nil?
         create_user(user, determined_role)
       elsif determined_role.to_s != bo_user[:role]
-        update_role(bo_user, determined_role)
+        # Because we are syncing across from the backend, we have to deal with
+        # the fact that they have individuals who have both an admin and agency
+        # user (because in the backend system admins can only manage users, not
+        # actually do anything with registrations).
+        # So when syncing agency users, if the role found in the back office is
+        # an admin role, we leave it as is rather than overwriting it (in the
+        # back office admins can do pretty much anything hence only one user
+        # needed)
+        update_role(bo_user, determined_role) unless admin_role?(bo_user[:role])
       else
         puts "No changes so skipping #{bo_user['email']}"
       end
@@ -107,6 +115,10 @@ module Users
         new_role = "finance"
       end
       new_role
+    end
+
+    def admin_role?(role)
+      %w[agency_super finance_super].include?(role)
     end
   end
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-524

When the service went live on September 19 we ran a JS script to create users in the back office based on users that already existed in the old back end.

As we do not currently have the ability to maintain users in the back office (see WC-495) this still remains the only means to create users.

Having spoken with the NCCC team lead, just being able to re-sync the back office users with those in the backend and create any new ones would suffice.

Hence this change which adds a rake task to do just that.
