### PR TITLE
Use new env var to get backend path

### DIFF
--- a/app/helpers/registration_transfers_helper.rb
+++ b/app/helpers/registration_transfers_helper.rb
@@ -8,7 +8,7 @@ module RegistrationTransfersHelper
   end
 
   def continue_after_transfer_link(registration)
-    [Rails.configuration.wcrs_frontend_url,
+    [Rails.configuration.wcrs_backend_url,
      "/registrations?utf8=%E2%9C%93&q=",
      registration.reg_identifier,
      "&commit=Search&searchWithin=any"].join

--- a/config/application.rb
+++ b/config/application.rb
@@ -75,6 +75,7 @@ module WasteCarriersBackOffice
     # Paths
     config.wcrs_renewals_url = ENV["WCRS_RENEWALS_DOMAIN"] || "http://localhost:3002"
     config.wcrs_frontend_url = ENV["WCRS_FRONTEND_DOMAIN"] || "http://localhost:3000"
+    config.wcrs_backend_url = ENV["WCRS_FRONTEND_ADMIN_DOMAIN"] || "http://localhost:3000"
     config.wcrs_back_office_url = ENV["WCRS_BACK_OFFICE_DOMAIN"] || "http://localhost:8001"
     config.wcrs_services_url = ENV["WCRS_SERVICES_DOMAIN"] || "http://localhost:8003"
     config.os_places_service_url = ENV["WCRS_OS_PLACES_DOMAIN"] || "http://localhost:8005"


### PR DESCRIPTION
The frontend and backend are part of the same application (waste-carriers-frontend) and have the same path locally, but on production they will have different ones. So we need to specify a different variable for it to avoid sending production users to the wrong location.