### PR TITLE
Remove active styling from menu links

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,14 +17,12 @@
             <ul id="proposition-links" aria-label="Top Level Navigation">
               <li>
                 <%= link_to t("layouts.application.menu.dashboard"),
-                            main_app.bo_path,
-                            class: (current_page?(main_app.bo_path) ? "active" : "") %>
+                            main_app.bo_path %>
               </li>
               <% if can?(:manage_back_office_users, current_user) %>
                 <li>
                   <%= link_to t("layouts.application.menu.users"),
-                              main_app.users_path,
-                              class: (current_page?(main_app.users_path) ? "active" : "") %>
+                              main_app.users_path %>
                 </li>
               <% end %>
             </ul>


### PR DESCRIPTION
Previously we applied the 'active' class to links when they were for the current page. However this gave them a blue colour which had low contrast with the black background. So we're removing this styling for accessibility reasons.