### PR TITLE
Clarify user migration content

### DIFF
--- a/config/locales/user_migrations.en.yml
+++ b/config/locales/user_migrations.en.yml
@@ -25,8 +25,8 @@ en:
             one: "%{count} user had their role updated"
             other: "%{count} users had their role updated"
           skipped:
-            one: "%{count} user was not modified"
-            other: "%{count} users were not modified"
+            one: "%{count} user matched in the backend and back office and was not modified"
+            other: "%{count} users matched in the backend and back office and were not modified"
           errored:
             one: "%{count} error encountered"
             other: "%{count} errors encountered"


### PR DESCRIPTION
Had some feedback during QA that "X users were not modified" wasn't as clear as it could be, especially when there were back office users that weren't in the backend and numbers didn't add up (not likely to be an issue in production, but we should account for this possibility anyway).