### PR TITLE
Add workflow states to conviction_sign_offs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ gem "kaminari-mongoid", "~> 1.0"
 # Use the waste carriers engine for the user journey
 gem "waste_carriers_engine",
     git: "https://github.com/DEFRA/waste-carriers-renewals",
-    branch: "master"
+    branch: "feature/conviction-check-states"
 
 # Allows us to automatically generate the change log from the tags, issues,
 # labels and pull requests on GitHub. Added as a dependency so all dev's have

--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ gem "kaminari-mongoid", "~> 1.0"
 # Use the waste carriers engine for the user journey
 gem "waste_carriers_engine",
     git: "https://github.com/DEFRA/waste-carriers-renewals",
-    branch: "feature/conviction-check-states"
+    branch: "master"
 
 # Allows us to automatically generate the change log from the tags, issues,
 # labels and pull requests on GitHub. Added as a dependency so all dev's have

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-renewals
-  revision: 4928531379f7c0358f9baaac3c47130d62b8db11
-  branch: feature/conviction-check-states
+  revision: 5ec634a01db7e618d5999a9bb4cf2faf5a0367c3
+  branch: master
   specs:
     waste_carriers_engine (0.0.1)
       aasm (~> 4.12)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-renewals
-  revision: 00d999b94d1e9f49da8312b7db6af60d4d52f725
+  revision: 4928531379f7c0358f9baaac3c47130d62b8db11
   branch: feature/conviction-check-states
   specs:
     waste_carriers_engine (0.0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-renewals
-  revision: ecdea2ef12c699ddd96a7d0e7de55b320d3efdce
-  branch: master
+  revision: 00d999b94d1e9f49da8312b7db6af60d4d52f725
+  branch: feature/conviction-check-states
   specs:
     waste_carriers_engine (0.0.1)
       aasm (~> 4.12)

--- a/app/controllers/conviction_approval_forms_controller.rb
+++ b/app/controllers/conviction_approval_forms_controller.rb
@@ -25,6 +25,6 @@ class ConvictionApprovalFormsController < AdminFormsController
   private
 
   def update_conviction_sign_off
-    @transient_registration.conviction_sign_offs.first.approve(current_user)
+    @transient_registration.conviction_sign_offs.first.approve!(current_user)
   end
 end

--- a/app/controllers/conviction_rejection_forms_controller.rb
+++ b/app/controllers/conviction_rejection_forms_controller.rb
@@ -24,7 +24,6 @@ class ConvictionRejectionFormsController < AdminFormsController
   private
 
   def reject_renewal
-    @transient_registration.metaData.revoke!
-    @transient_registration.metaData.save!
+    @transient_registration.conviction_sign_offs.first.reject!
   end
 end

--- a/spec/requests/conviction_approval_forms_spec.rb
+++ b/spec/requests/conviction_approval_forms_spec.rb
@@ -88,6 +88,11 @@ RSpec.describe "ConvictionApprovalForms", type: :request do
         expect(transient_registration.reload.conviction_sign_offs.first.confirmed_by).to eq(user.email)
       end
 
+      it "updates the conviction_sign_off's workflow_state" do
+        post "/bo/transient-registrations/#{transient_registration.reg_identifier}/convictions/approve", conviction_approval_form: params
+        expect(transient_registration.reload.conviction_sign_offs.first.workflow_state).to eq("approved")
+      end
+
       context "when there is no pending payment" do
         before do
           transient_registration.finance_details = build(:finance_details, balance: 0)

--- a/spec/requests/conviction_rejection_forms_spec.rb
+++ b/spec/requests/conviction_rejection_forms_spec.rb
@@ -70,6 +70,11 @@ RSpec.describe "ConvictionRejectionForms", type: :request do
         expect(transient_registration.reload.metaData.status).to eq("REVOKED")
       end
 
+      it "updates the conviction_sign_off's workflow_state" do
+        post "/bo/transient-registrations/#{transient_registration.reg_identifier}/convictions/reject", conviction_rejection_form: params
+        expect(transient_registration.reload.conviction_sign_offs.first.workflow_state).to eq("rejected")
+      end
+
       context "when the params are invalid" do
         let(:params) do
           {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-483

The current implementation of the conviction checking workflow allows a flagged renewal to be checked, then approved or rejected. However, the actual process is more complex, and a renewal which does have matching convictions goes through an internal process before a final decision is made. To better represent this process, we have updated the engine to include workflow states for the conviction_sign_off.

This commit updates the back office convictions process to use those states.
