### PR TITLE
Remove conviction status from dashboard search filters

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -15,7 +15,6 @@ class DashboardsController < ApplicationController
     @term = params[:term]
     @in_progress = get_filter_value(params[:in_progress])
     @pending_payment = get_filter_value(params[:pending_payment])
-    @pending_conviction_check = get_filter_value(params[:pending_conviction_check])
   end
 
   def get_filter_value(filter_param)
@@ -26,8 +25,7 @@ class DashboardsController < ApplicationController
     service = TransientRegistrationSearchService.new(
       @term,
       @in_progress,
-      @pending_payment,
-      @pending_conviction_check
+      @pending_payment
     )
 
     service.search(page)
@@ -36,6 +34,6 @@ class DashboardsController < ApplicationController
   def search_terms_or_filters_present?
     return true if @term.present?
 
-    @in_progress || @pending_payment || @pending_conviction_check
+    @in_progress || @pending_payment
   end
 end

--- a/app/services/transient_registration_search_service.rb
+++ b/app/services/transient_registration_search_service.rb
@@ -1,12 +1,11 @@
 # frozen_string_literal: true
 
 class TransientRegistrationSearchService
-  def initialize(term, in_progress, pending_payment, pending_conviction_check)
+  def initialize(term, in_progress, pending_payment)
     @term = term
 
     @in_progress = in_progress
     @pending_payment = pending_payment
-    @pending_conviction_check = pending_conviction_check
   end
 
   def search(page)
@@ -28,7 +27,6 @@ class TransientRegistrationSearchService
 
     criteria.merge!(WasteCarriersEngine::TransientRegistration.in_progress) if @in_progress
     criteria.merge!(WasteCarriersEngine::TransientRegistration.pending_payment) if @pending_payment
-    criteria.merge!(WasteCarriersEngine::TransientRegistration.pending_approval) if @pending_conviction_check
 
     criteria.page(page).read(mode: :secondary)
   end
@@ -37,7 +35,7 @@ class TransientRegistrationSearchService
 
   def no_search_terms_or_filters?
     return false if @term.present?
-    return false if @in_progress || @pending_payment || @pending_conviction_check
+    return false if @in_progress || @pending_payment
 
     true
   end

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -49,13 +49,6 @@
               <%= label_tag :pending_payment,
                             t(".search.filters.pending_payment") %>
             </div>
-            <div class="multiple-choice">
-              <%= check_box_tag :pending_conviction_check,
-                                "true",
-                                @pending_conviction_check %>
-              <%= label_tag :pending_conviction_check,
-                            t(".search.filters.pending_conviction_check") %>
-            </div>
           </div>
           <p><%= link_to t(".search.clear_all_link"), bo_path %></p>
         </div>

--- a/config/locales/dashboard.en.yml
+++ b/config/locales/dashboard.en.yml
@@ -21,7 +21,6 @@ en:
           paragraph_1: "Filter the results:"
           in_progress: "Application in progress"
           pending_payment: "Pending payment"
-          pending_conviction_check: "Pending manual convictions check"
         clear_all_link: "Clear all searches and filters"
       results:
         th:

--- a/spec/services/transient_registration_search_service_spec.rb
+++ b/spec/services/transient_registration_search_service_spec.rb
@@ -7,13 +7,11 @@ RSpec.describe TransientRegistrationSearchService do
 
   let(:in_progress) { false }
   let(:pending_payment) { false }
-  let(:pending_conviction_check) { false }
 
   let(:transient_registrations) do
     service = TransientRegistrationSearchService.new(term,
                                                      in_progress,
-                                                     pending_payment,
-                                                     pending_conviction_check)
+                                                     pending_payment)
     service.search(1)
   end
 
@@ -122,35 +120,6 @@ RSpec.describe TransientRegistrationSearchService do
     it "does not display non-matching renewals" do
       paid_renewal = create(:transient_registration, :no_pending_payment)
       expect(transient_registrations).to_not include(paid_renewal)
-    end
-  end
-
-  context "when the pending_conviction_check filter is on" do
-    let(:pending_conviction_check) { true }
-
-    it "displays matching renewals" do
-      pending_conviction_check_renewal = create(:transient_registration, :requires_conviction_check)
-      expect(transient_registrations).to include(pending_conviction_check_renewal)
-    end
-
-    it "does not display non-matching renewals" do
-      no_conviction_check_renewal = create(:transient_registration, :does_not_require_conviction_check)
-      expect(transient_registrations).to_not include(no_conviction_check_renewal)
-    end
-  end
-
-  context "when multiple filters are on" do
-    let(:pending_payment) { true }
-    let(:pending_conviction_check) { true }
-
-    it "displays renewals which match all the filters" do
-      matches_both_filters = create(:transient_registration, :pending_payment, :requires_conviction_check)
-      expect(transient_registrations).to include(matches_both_filters)
-    end
-
-    it "does not display renewals which only match one filter" do
-      matches_one_filter = create(:transient_registration, :no_pending_payment, :requires_conviction_check)
-      expect(transient_registrations).to_not include(matches_one_filter)
     end
   end
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-483

With the addition of the new convictions dashboard (https://github.com/DEFRA/waste-carriers-back-office/pull/197) we no longer need to include conviction status as a filter on the main search dashboard. This PR removes that functionality.