### PR TITLE
Change redirect paths after conviction check action

### DIFF
--- a/app/controllers/admin_forms_controller.rb
+++ b/app/controllers/admin_forms_controller.rb
@@ -17,7 +17,7 @@ class AdminFormsController < ApplicationController
     authorize_if_required(options[:authorize_action])
 
     # Submit the form by getting the instance variable we just set
-    submit_form(instance_variable_get("@#{form}"), params[form])
+    submit_form(instance_variable_get("@#{form}"), params[form], options[:success_path])
   end
 
   private
@@ -31,9 +31,9 @@ class AdminFormsController < ApplicationController
     instance_variable_set("@#{form}", form_class.new(@transient_registration))
   end
 
-  def submit_form(form, params)
+  def submit_form(form, params, success_path)
     if form.submit(params)
-      redirect_to transient_registration_path(@transient_registration.reg_identifier)
+      redirect_to success_path || transient_registration_path(@transient_registration.reg_identifier)
       true
     else
       render :new

--- a/app/controllers/conviction_approval_forms_controller.rb
+++ b/app/controllers/conviction_approval_forms_controller.rb
@@ -12,7 +12,8 @@ class ConvictionApprovalFormsController < AdminFormsController
     return unless super(ConvictionApprovalForm,
                         "conviction_approval_form",
                         params[:conviction_approval_form][:reg_identifier],
-                        { authorize_action: :authorize_action })
+                        { authorize_action: :authorize_action,
+                          success_path: convictions_path })
 
     update_conviction_sign_off
     renew_if_possible

--- a/app/controllers/conviction_rejection_forms_controller.rb
+++ b/app/controllers/conviction_rejection_forms_controller.rb
@@ -12,7 +12,8 @@ class ConvictionRejectionFormsController < AdminFormsController
     return unless super(ConvictionRejectionForm,
                         "conviction_rejection_form",
                         params[:conviction_rejection_form][:reg_identifier],
-                        { authorize_action: :authorize_action })
+                        { authorize_action: :authorize_action,
+                          success_path: convictions_checks_in_progress_path })
 
     reject_renewal
   end

--- a/app/controllers/convictions_controller.rb
+++ b/app/controllers/convictions_controller.rb
@@ -11,7 +11,7 @@ class ConvictionsController < ApplicationController
     assign_registration_and_transient_registration(params[:reg_identifier])
     @transient_registration.conviction_sign_offs.first.begin_checks!
 
-    redirect_to transient_registration_convictions_path(@transient_registration.reg_identifier)
+    redirect_to convictions_path
   end
 
   private

--- a/spec/requests/conviction_approval_forms_spec.rb
+++ b/spec/requests/conviction_approval_forms_spec.rb
@@ -63,9 +63,9 @@ RSpec.describe "ConvictionApprovalForms", type: :request do
         }
       end
 
-      it "redirects to the transient_registration page" do
+      it "redirects to the convictions page" do
         post "/bo/transient-registrations/#{transient_registration.reg_identifier}/convictions/approve", conviction_approval_form: params
-        expect(response).to redirect_to(transient_registration_path(transient_registration.reg_identifier))
+        expect(response).to redirect_to(convictions_path)
       end
 
       it "updates the revoked_reason" do

--- a/spec/requests/conviction_rejection_forms_spec.rb
+++ b/spec/requests/conviction_rejection_forms_spec.rb
@@ -55,9 +55,9 @@ RSpec.describe "ConvictionRejectionForms", type: :request do
         }
       end
 
-      it "redirects to the transient_registration page" do
+      it "redirects to the convictions page" do
         post "/bo/transient-registrations/#{transient_registration.reg_identifier}/convictions/reject", conviction_rejection_form: params
-        expect(response).to redirect_to(transient_registration_path(transient_registration.reg_identifier))
+        expect(response).to redirect_to(convictions_checks_in_progress_path)
       end
 
       it "updates the revoked_reason" do

--- a/spec/requests/convictions_spec.rb
+++ b/spec/requests/convictions_spec.rb
@@ -41,9 +41,9 @@ RSpec.describe "Convictions", type: :request do
         expect(transient_registration.reload.conviction_sign_offs.first.workflow_state).to eq("checks_in_progress")
       end
 
-      it "redirects to the index page" do
+      it "redirects to the convictions page" do
         get "/bo/transient-registrations/#{transient_registration.reg_identifier}/convictions/begin-checks"
-        expect(response).to redirect_to("/bo/transient-registrations/#{transient_registration.reg_identifier}/convictions")
+        expect(response).to redirect_to(convictions_path)
       end
     end
   end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-483

After consulting with NCCC about their workflow, they would prefer for the app to redirect to different pages after the a conviction check action occurs.

- "Accept" should redirect to the 'possible matches' list
- "Has relevant convictions" should redirect to the 'possible matches' list
- "Reject" should redirect to the 'checks in progress' list