### PR TITLE
List oldest renewals first on convictions dashboard

### DIFF
--- a/app/controllers/convictions_dashboards_controller.rb
+++ b/app/controllers/convictions_dashboards_controller.rb
@@ -22,7 +22,7 @@ class ConvictionsDashboardsController < ApplicationController
   private
 
   def ordered_and_paged(transient_registrations)
-    @transient_registrations = transient_registrations.order_by("metaData.lastModified": :desc)
+    @transient_registrations = transient_registrations.order_by("metaData.lastModified": :asc)
                                                       .page params[:page]
   end
 end

--- a/spec/factories/conviction_sign_off.rb
+++ b/spec/factories/conviction_sign_off.rb
@@ -12,6 +12,10 @@ FactoryBot.define do
       workflow_state { "checks_in_progress" }
     end
 
+    trait :approved do
+      workflow_state { "approved" }
+    end
+
     trait :rejected do
       workflow_state { "rejected" }
     end

--- a/spec/factories/transient_registration.rb
+++ b/spec/factories/transient_registration.rb
@@ -51,6 +51,13 @@ FactoryBot.define do
       conviction_sign_offs { [build(:conviction_sign_off, :checks_in_progress)] }
     end
 
+    trait :has_approved_conviction_check do
+      workflow_state { "renewal_received_form" }
+      key_people { [build(:key_person, :requires_conviction_check)] }
+      conviction_search_result { build(:conviction_search_result, :match_result_yes) }
+      conviction_sign_offs { [build(:conviction_sign_off, :approved)] }
+    end
+
     trait :has_rejected_conviction_check do
       workflow_state { "renewal_received_form" }
       key_people { [build(:key_person, :requires_conviction_check)] }

--- a/spec/requests/convictions_dashboards_spec.rb
+++ b/spec/requests/convictions_dashboards_spec.rb
@@ -3,6 +3,38 @@
 require "rails_helper"
 
 RSpec.describe "ConvictionsDashboards", type: :request do
+  let!(:link_to_possible_matches_renewal) do
+    renewal = create(:transient_registration, :requires_conviction_check)
+    # Make sure it's one of the 'oldest' renewals so would be top of the list
+    renewal.metaData.update_attributes(last_modified: Date.new(1999, 1, 1))
+
+    transient_registration_path(renewal.reg_identifier)
+  end
+
+  let!(:link_to_checks_in_progress_renewal) do
+    renewal = create(:transient_registration, :has_flagged_conviction_check)
+    # Make sure it's one of the 'oldest' renewals so would be top of the list
+    renewal.metaData.update_attributes(last_modified: Date.new(1999, 1, 1))
+
+    transient_registration_path(renewal.reg_identifier)
+  end
+
+  let!(:link_to_approved_renewal) do
+    renewal = create(:transient_registration, :has_approved_conviction_check)
+    # Make sure it's one of the 'oldest' renewals so would be top of the list
+    renewal.metaData.update_attributes(last_modified: Date.new(1999, 1, 1))
+
+    transient_registration_path(renewal.reg_identifier)
+  end
+
+  let!(:link_to_rejected_renewal) do
+    renewal = create(:transient_registration, :has_rejected_conviction_check)
+    # Make sure it's one of the 'oldest' renewals so would be top of the list
+    renewal.metaData.update_attributes(last_modified: Date.new(1999, 1, 1))
+
+    transient_registration_path(renewal.reg_identifier)
+  end
+
   describe "/bo/convictions" do
     context "when a valid user is signed in" do
       let(:user) { create(:user) }
@@ -21,20 +53,13 @@ RSpec.describe "ConvictionsDashboards", type: :request do
       end
 
       it "links to renewals which require an initial convictions check" do
-        last_modified_renewal = create(:transient_registration, :requires_conviction_check)
-        link_to_renewal = transient_registration_path(last_modified_renewal.reg_identifier)
-
         get "/bo/convictions"
-        expect(response.body).to include(link_to_renewal)
+        expect(response.body).to include(link_to_possible_matches_renewal)
       end
 
       it "does not link to renewals which don't require an initial convictions check" do
-        last_modified_renewal = create(:transient_registration, :requires_conviction_check)
-        last_modified_renewal.conviction_sign_offs.first.approve!(user)
-        link_to_renewal = transient_registration_path(last_modified_renewal.reg_identifier)
-
         get "/bo/convictions"
-        expect(response.body).to_not include(link_to_renewal)
+        expect(response.body).to_not include(link_to_checks_in_progress_renewal)
       end
     end
 
@@ -64,20 +89,13 @@ RSpec.describe "ConvictionsDashboards", type: :request do
       end
 
       it "links to renewals which have have ongoing conviction checks" do
-        last_modified_renewal = create(:transient_registration, :requires_conviction_check)
-        last_modified_renewal.conviction_sign_offs.first.begin_checks!
-        link_to_renewal = transient_registration_path(last_modified_renewal.reg_identifier)
-
         get "/bo/convictions/in-progress"
-        expect(response.body).to include(link_to_renewal)
+        expect(response.body).to include(link_to_checks_in_progress_renewal)
       end
 
       it "does not link to renewals which don't have ongoing conviction checks" do
-        last_modified_renewal = create(:transient_registration, :requires_conviction_check)
-        link_to_renewal = transient_registration_path(last_modified_renewal.reg_identifier)
-
         get "/bo/convictions/in-progress"
-        expect(response.body).to_not include(link_to_renewal)
+        expect(response.body).to_not include(link_to_rejected_renewal)
       end
     end
 
@@ -107,20 +125,13 @@ RSpec.describe "ConvictionsDashboards", type: :request do
       end
 
       it "links to renewals which have have approved conviction checks" do
-        last_modified_renewal = create(:transient_registration, :requires_conviction_check)
-        last_modified_renewal.conviction_sign_offs.first.approve!(user)
-        link_to_renewal = transient_registration_path(last_modified_renewal.reg_identifier)
-
         get "/bo/convictions/approved"
-        expect(response.body).to include(link_to_renewal)
+        expect(response.body).to include(link_to_approved_renewal)
       end
 
       it "does not link to renewals which don't have approved conviction checks" do
-        last_modified_renewal = create(:transient_registration, :requires_conviction_check)
-        link_to_renewal = transient_registration_path(last_modified_renewal.reg_identifier)
-
         get "/bo/convictions/approved"
-        expect(response.body).to_not include(link_to_renewal)
+        expect(response.body).to_not include(link_to_possible_matches_renewal)
       end
     end
 
@@ -150,19 +161,13 @@ RSpec.describe "ConvictionsDashboards", type: :request do
       end
 
       it "links to renewals which have have rejected conviction checks" do
-        last_modified_renewal = create(:transient_registration, :has_rejected_conviction_check)
-        link_to_renewal = transient_registration_path(last_modified_renewal.reg_identifier)
-
         get "/bo/convictions/rejected"
-        expect(response.body).to include(link_to_renewal)
+        expect(response.body).to include(link_to_rejected_renewal)
       end
 
       it "does not link to renewals which don't have rejected conviction checks" do
-        last_modified_renewal = create(:transient_registration, :requires_conviction_check)
-        link_to_renewal = transient_registration_path(last_modified_renewal.reg_identifier)
-
         get "/bo/convictions/rejected"
-        expect(response.body).to_not include(link_to_renewal)
+        expect(response.body).to_not include(link_to_possible_matches_renewal)
       end
     end
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-483

NCCC requested that the least recently modified renewals be listed first, as this matches the workflow they want to follow and lets them focus on renewals which have been waiting the longest. This was a minor change to the controller but led to a larger refactor of the tests, which has hopefully made them more readable.