### PR TITLE
Refactor AdminFormsController options

### DIFF
--- a/app/controllers/admin_forms_controller.rb
+++ b/app/controllers/admin_forms_controller.rb
@@ -5,16 +5,16 @@
 class AdminFormsController < ApplicationController
   before_action :authenticate_user!
 
-  def new(form_class, form, reg_identifier, authorize_action = nil)
+  def new(form_class, form, reg_identifier, options = {})
     set_up_form(form_class, form, reg_identifier)
 
-    public_send(authorize_action, @transient_registration) if authorize_action.present?
+    authorize_if_required(options[:authorize_action])
   end
 
-  def create(form_class, form, reg_identifier, authorize_action = nil)
+  def create(form_class, form, reg_identifier, options = {})
     return false unless set_up_form(form_class, form, reg_identifier)
 
-    public_send(authorize_action, @transient_registration) if authorize_action.present?
+    authorize_if_required(options[:authorize_action])
 
     # Submit the form by getting the instance variable we just set
     submit_form(instance_variable_get("@#{form}"), params[form])
@@ -39,6 +39,10 @@ class AdminFormsController < ApplicationController
       render :new
       false
     end
+  end
+
+  def authorize_if_required(authorize_action)
+    public_send(authorize_action, @transient_registration) if authorize_action.present?
   end
 
   def find_transient_registration(reg_identifier)

--- a/app/controllers/cash_payment_forms_controller.rb
+++ b/app/controllers/cash_payment_forms_controller.rb
@@ -5,7 +5,7 @@ class CashPaymentFormsController < AdminFormsController
     super(CashPaymentForm,
           "cash_payment_form",
           params[:transient_registration_reg_identifier],
-          :authorize_action)
+          { authorize_action: :authorize_action })
   end
 
   def create
@@ -14,7 +14,7 @@ class CashPaymentFormsController < AdminFormsController
     return unless super(CashPaymentForm,
                         "cash_payment_form",
                         params[:cash_payment_form][:reg_identifier],
-                        :authorize_action)
+                        { authorize_action: :authorize_action })
 
     renew_if_possible
   end

--- a/app/controllers/cheque_payment_forms_controller.rb
+++ b/app/controllers/cheque_payment_forms_controller.rb
@@ -5,7 +5,7 @@ class ChequePaymentFormsController < AdminFormsController
     super(ChequePaymentForm,
           "cheque_payment_form",
           params[:transient_registration_reg_identifier],
-          :authorize_action)
+          { authorize_action: :authorize_action })
   end
 
   def create
@@ -14,7 +14,7 @@ class ChequePaymentFormsController < AdminFormsController
     return unless super(ChequePaymentForm,
                         "cheque_payment_form",
                         params[:cheque_payment_form][:reg_identifier],
-                        :authorize_action)
+                        { authorize_action: :authorize_action })
 
     renew_if_possible
   end

--- a/app/controllers/conviction_approval_forms_controller.rb
+++ b/app/controllers/conviction_approval_forms_controller.rb
@@ -5,14 +5,14 @@ class ConvictionApprovalFormsController < AdminFormsController
     super(ConvictionApprovalForm,
           "conviction_approval_form",
           params[:transient_registration_reg_identifier],
-          :authorize_action)
+          { authorize_action: :authorize_action })
   end
 
   def create
     return unless super(ConvictionApprovalForm,
                         "conviction_approval_form",
                         params[:conviction_approval_form][:reg_identifier],
-                        :authorize_action)
+                        { authorize_action: :authorize_action })
 
     update_conviction_sign_off
     renew_if_possible

--- a/app/controllers/conviction_rejection_forms_controller.rb
+++ b/app/controllers/conviction_rejection_forms_controller.rb
@@ -5,14 +5,14 @@ class ConvictionRejectionFormsController < AdminFormsController
     super(ConvictionRejectionForm,
           "conviction_rejection_form",
           params[:transient_registration_reg_identifier],
-          :authorize_action)
+          { authorize_action: :authorize_action })
   end
 
   def create
     return unless super(ConvictionRejectionForm,
                         "conviction_rejection_form",
                         params[:conviction_rejection_form][:reg_identifier],
-                        :authorize_action)
+                        { authorize_action: :authorize_action })
 
     reject_renewal
   end

--- a/app/controllers/postal_order_payment_forms_controller.rb
+++ b/app/controllers/postal_order_payment_forms_controller.rb
@@ -5,7 +5,7 @@ class PostalOrderPaymentFormsController < AdminFormsController
     super(PostalOrderPaymentForm,
           "postal_order_payment_form",
           params[:transient_registration_reg_identifier],
-          :authorize_action)
+          { authorize_action: :authorize_action })
   end
 
   def create
@@ -14,7 +14,7 @@ class PostalOrderPaymentFormsController < AdminFormsController
     return unless super(PostalOrderPaymentForm,
                         "postal_order_payment_form",
                         params[:postal_order_payment_form][:reg_identifier],
-                        :authorize_action)
+                        { authorize_action: :authorize_action })
 
     renew_if_possible
   end

--- a/app/controllers/transfer_payment_forms_controller.rb
+++ b/app/controllers/transfer_payment_forms_controller.rb
@@ -5,7 +5,7 @@ class TransferPaymentFormsController < AdminFormsController
     super(TransferPaymentForm,
           "transfer_payment_form",
           params[:transient_registration_reg_identifier],
-          :authorize_action)
+          { authorize_action: :authorize_action })
   end
 
   def create
@@ -14,7 +14,7 @@ class TransferPaymentFormsController < AdminFormsController
     return unless super(TransferPaymentForm,
                         "transfer_payment_form",
                         params[:transfer_payment_form][:reg_identifier],
-                        :authorize_action)
+                        { authorize_action: :authorize_action })
 
     renew_if_possible
   end

--- a/app/controllers/worldpay_missed_payment_forms_controller.rb
+++ b/app/controllers/worldpay_missed_payment_forms_controller.rb
@@ -5,7 +5,7 @@ class WorldpayMissedPaymentFormsController < AdminFormsController
     super(WorldpayMissedPaymentForm,
           "worldpay_missed_payment_form",
           params[:transient_registration_reg_identifier],
-          :authorize_action)
+          { authorize_action: :authorize_action })
   end
 
   def create
@@ -14,7 +14,7 @@ class WorldpayMissedPaymentFormsController < AdminFormsController
     return unless super(WorldpayMissedPaymentForm,
                         "worldpay_missed_payment_form",
                         params[:worldpay_missed_payment_form][:reg_identifier],
-                        :authorize_action)
+                        { authorize_action: :authorize_action })
 
     renew_if_possible
   end


### PR DESCRIPTION
An upcoming change will require us to pass an additional param to the AdminFormsController's `create` method. To stop the number of arguments from getting too high, this PR implements a new `options` hash instead, which should allow us greater flexibility in what options we pass to the AdminFormsController.

I did this for the `new` method as well for consistency's sake. Also moved the authorization logic into its own method to reduce duplication and improve clarity.