### PR TITLE
Allow finance admin users to add 'stuck' WorldPay payments

### DIFF
--- a/app/controllers/worldpay_missed_payment_forms_controller.rb
+++ b/app/controllers/worldpay_missed_payment_forms_controller.rb
@@ -16,10 +16,17 @@ class WorldpayMissedPaymentFormsController < AdminFormsController
                         params[:worldpay_missed_payment_form][:reg_identifier],
                         { authorize_action: :authorize_action })
 
+    change_state_if_possible
     renew_if_possible
   end
 
   def authorize_action(transient_registration)
     authorize! :record_worldpay_missed_payment, transient_registration
+  end
+
+  private
+
+  def change_state_if_possible
+    @transient_registration.next! if @transient_registration.workflow_state == "worldpay_form"
   end
 end

--- a/app/views/transient_registrations/show.html.erb
+++ b/app/views/transient_registrations/show.html.erb
@@ -51,9 +51,14 @@
 
           <% if can? :revert_to_payment_summary, @transient_registration %>
             <p>
-              <%= t(".status.messages.worldpay.paragraph_2") %>
+              <%= t(".status.messages.worldpay.paragraph_2.revert") %>
             </p>
             <%= link_to t(".status.actions.revert_to_payment_summary_button"), new_transient_registration_worldpay_escape_path(@transient_registration.reg_identifier), class: 'button' %>
+          <% elsif can? :record_worldpay_missed_payment, @transient_registration %>
+            <p>
+              <%= t(".status.messages.worldpay.paragraph_2.missed_payment") %>
+            </p>
+            <%= link_to t(".status.actions.missed_worldpay_payment_button"), new_transient_registration_worldpay_missed_payment_form_path(@transient_registration.reg_identifier), class: 'button' %>
           <% end %>
         <% else %>
           <p>

--- a/config/locales/transient_registrations.en.yml
+++ b/config/locales/transient_registrations.en.yml
@@ -17,12 +17,15 @@ en:
           rejected: "This renewal was rejected during a convictions check and cannot be completed. The current registration will remain active until it expires."
           worldpay:
             paragraph_1: "The user is currently attempting to pay by WorldPay."
-            paragraph_2: "If an error has occurred and the user is stuck, you can send the renewal back to the payment summary page. They can try to pay with WorldPay again, or select an alternative payment method."
+            paragraph_2:
+              revert: "If an error has occurred and the user is stuck, you can send the renewal back to the payment summary page. They can try to pay with WorldPay again, or select an alternative payment method."
+              missed_payment: "If an error has occurred and payment has been received, but not recorded, you can record a missed WorldPay payment."
         actions:
           continue_button: "Continue as assisted digital renewal"
           payment_button: "Process payment"
           convictions_check_button: "Check conviction matches"
           revert_to_payment_summary_button: "Send back to payment summary"
+          missed_worldpay_payment_button: "Add a missed WorldPay payment"
       reg_information:
         heading: "Registration information"
         labels:


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-503

If an external user makes a payment on WorldPay, but WorldPay fails to redirect them back to the app afterwards, then payment is taken but the app does not know about it, and leaves them in the `worldpay_form` state.

Finance picks up these 'missed' payments and records them, but isn't able to do this until the application has been submitted. This means that an agency user first has to move the application to a submitted state, and then a finance user adds the payment to complete the renewal.

To speed up this process, this change allows finance admin users to add a missed WorldPay payment once the renewal is in the `worldpay_form` state. Once the payment is added, the transient_registration should then progress to the next stage (either `renewal_received` or `renewal_complete` depending on other checks) as if the app received record of the payment directly from WorldPay.