### PR TITLE
Rescue CanCan::AccessDenied by redirecting to correct page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -32,7 +32,7 @@ class ApplicationController < ActionController::Base
   end
 
   rescue_from CanCan::AccessDenied do
-    redirect_to "/bo/permission"
+    redirect_to "/bo/pages/permission"
   end
 
   # http://jacopretorius.net/2014/01/force-page-to-reload-on-browser-back-in-rails.html

--- a/spec/requests/cash_payment_forms_spec.rb
+++ b/spec/requests/cash_payment_forms_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "CashPaymentForms", type: :request do
 
       it "redirects to the permissions error page" do
         get "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments/cash"
-        expect(response).to redirect_to("/bo/permission")
+        expect(response).to redirect_to("/bo/pages/permission")
       end
     end
   end
@@ -145,7 +145,7 @@ RSpec.describe "CashPaymentForms", type: :request do
 
       it "redirects to the permissions error page" do
         post "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments/cash", cash_payment_form: params
-        expect(response).to redirect_to("/bo/permission")
+        expect(response).to redirect_to("/bo/pages/permission")
       end
 
       it "does not create a new payment" do

--- a/spec/requests/cheque_payment_forms_spec.rb
+++ b/spec/requests/cheque_payment_forms_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "ChequePaymentForms", type: :request do
 
       it "redirects to the permissions error page" do
         get "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments/cheque"
-        expect(response).to redirect_to("/bo/permission")
+        expect(response).to redirect_to("/bo/pages/permission")
       end
     end
   end
@@ -145,7 +145,7 @@ RSpec.describe "ChequePaymentForms", type: :request do
 
       it "redirects to the permissions error page" do
         post "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments/cheque", cheque_payment_form: params
-        expect(response).to redirect_to("/bo/permission")
+        expect(response).to redirect_to("/bo/pages/permission")
       end
 
       it "does not create a new payment" do

--- a/spec/requests/conviction_approval_forms_spec.rb
+++ b/spec/requests/conviction_approval_forms_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "ConvictionApprovalForms", type: :request do
 
       it "redirects to the permissions error page" do
         get "/bo/transient-registrations/#{transient_registration.reg_identifier}/convictions/approve"
-        expect(response).to redirect_to("/bo/permission")
+        expect(response).to redirect_to("/bo/pages/permission")
       end
     end
   end
@@ -163,7 +163,7 @@ RSpec.describe "ConvictionApprovalForms", type: :request do
 
       it "redirects to the permissions error page" do
         post "/bo/transient-registrations/#{transient_registration.reg_identifier}/convictions/approve", conviction_approval_form: params
-        expect(response).to redirect_to("/bo/permission")
+        expect(response).to redirect_to("/bo/pages/permission")
       end
 
       it "does not update the revoked_reason" do

--- a/spec/requests/conviction_rejection_forms_spec.rb
+++ b/spec/requests/conviction_rejection_forms_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "ConvictionRejectionForms", type: :request do
 
       it "redirects to the permissions error page" do
         get "/bo/transient-registrations/#{transient_registration.reg_identifier}/convictions/reject"
-        expect(response).to redirect_to("/bo/permission")
+        expect(response).to redirect_to("/bo/pages/permission")
       end
     end
   end
@@ -115,7 +115,7 @@ RSpec.describe "ConvictionRejectionForms", type: :request do
 
       it "redirects to the permissions error page" do
         post "/bo/transient-registrations/#{transient_registration.reg_identifier}/convictions/reject", conviction_rejection_form: params
-        expect(response).to redirect_to("/bo/permission")
+        expect(response).to redirect_to("/bo/pages/permission")
       end
 
       it "does not update the revoked_reason" do

--- a/spec/requests/postal_order_payment_forms_spec.rb
+++ b/spec/requests/postal_order_payment_forms_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "PostalOrderPaymentForms", type: :request do
 
       it "redirects to the permissions error page" do
         get "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments/postal-order"
-        expect(response).to redirect_to("/bo/permission")
+        expect(response).to redirect_to("/bo/pages/permission")
       end
     end
   end
@@ -145,7 +145,7 @@ RSpec.describe "PostalOrderPaymentForms", type: :request do
 
       it "redirects to the permissions error page" do
         post "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments/postal-order", postal_order_payment_form: params
-        expect(response).to redirect_to("/bo/permission")
+        expect(response).to redirect_to("/bo/pages/permission")
       end
 
       it "does not create a new payment" do

--- a/spec/requests/registration_transfers_spec.rb
+++ b/spec/requests/registration_transfers_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "RegistrationTransfers", type: :request do
 
       it "redirects to the permissions error page" do
         get "/bo/transfer-registration/#{registration.reg_identifier}"
-        expect(response).to redirect_to("/bo/permission")
+        expect(response).to redirect_to("/bo/pages/permission")
       end
     end
 
@@ -106,7 +106,7 @@ RSpec.describe "RegistrationTransfers", type: :request do
 
       it "redirects to the permissions error page" do
         post "/bo/transfer-registration", registration_transfer_form: params
-        expect(response).to redirect_to("/bo/permission")
+        expect(response).to redirect_to("/bo/pages/permission")
       end
     end
 

--- a/spec/requests/transfer_payment_forms_spec.rb
+++ b/spec/requests/transfer_payment_forms_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "TransferPaymentForms", type: :request do
 
       it "redirects to the permissions error page" do
         get "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments/transfer"
-        expect(response).to redirect_to("/bo/permission")
+        expect(response).to redirect_to("/bo/pages/permission")
       end
     end
   end
@@ -145,7 +145,7 @@ RSpec.describe "TransferPaymentForms", type: :request do
 
       it "redirects to the permissions error page" do
         post "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments/transfer", transfer_payment_form: params
-        expect(response).to redirect_to("/bo/permission")
+        expect(response).to redirect_to("/bo/pages/permission")
       end
 
       context "when the payment_type is worldpay_missed" do

--- a/spec/requests/user_migrations_spec.rb
+++ b/spec/requests/user_migrations_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "UserMigrations", type: :request do
 
       it "redirects to the permissions error page" do
         get "/bo/users/migrate"
-        expect(response).to redirect_to("/bo/permission")
+        expect(response).to redirect_to("/bo/pages/permission")
       end
     end
   end
@@ -70,7 +70,7 @@ RSpec.describe "UserMigrations", type: :request do
 
       it "redirects to the permissions error page" do
         post "/bo/users/migrate"
-        expect(response).to redirect_to("/bo/permission")
+        expect(response).to redirect_to("/bo/pages/permission")
       end
     end
   end
@@ -133,7 +133,7 @@ RSpec.describe "UserMigrations", type: :request do
 
       it "redirects to the permissions error page" do
         get "/bo/users/migrate/results"
-        expect(response).to redirect_to("/bo/permission")
+        expect(response).to redirect_to("/bo/pages/permission")
       end
     end
   end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "Users", type: :request do
 
       it "redirects to the permissions error page" do
         get "/bo/users"
-        expect(response).to redirect_to("/bo/permission")
+        expect(response).to redirect_to("/bo/pages/permission")
       end
     end
 

--- a/spec/requests/worldpay_escapes_spec.rb
+++ b/spec/requests/worldpay_escapes_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "WorldpayEscapes", type: :request do
 
       it "renders the permissions error page" do
         get "/bo/transient-registrations/#{reg_identifier}/revert-to-payment-summary"
-        expect(response).to redirect_to "/bo/permission"
+        expect(response).to redirect_to "/bo/pages/permission"
       end
     end
   end

--- a/spec/requests/worldpay_missed_payment_forms_spec.rb
+++ b/spec/requests/worldpay_missed_payment_forms_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "WorldpayMissedPaymentForms", type: :request do
 
       it "redirects to the permissions error page" do
         get "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments/worldpay-missed"
-        expect(response).to redirect_to("/bo/permission")
+        expect(response).to redirect_to("/bo/pages/permission")
       end
     end
   end
@@ -188,7 +188,7 @@ RSpec.describe "WorldpayMissedPaymentForms", type: :request do
 
       it "redirects to the permissions error page" do
         post "/bo/transient-registrations/#{transient_registration.reg_identifier}/payments/worldpay-missed", worldpay_missed_payment_form: params
-        expect(response).to redirect_to("/bo/permission")
+        expect(response).to redirect_to("/bo/pages/permission")
       end
 
       it "does not create a new payment" do


### PR DESCRIPTION
Resolves https://github.com/DEFRA/waste-carriers-back-office/issues/181

The location of the error pages in the engine was modified, but we didn't update the back-office CanCan error handling to deal with this. This PR fixes the error handling to redirect to the permissions error page, instead of a page which doesn't exist (resulting in a 404 error page instead).