### PR TITLE
Lock Travis to bundler 1.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ services:
   - mongodb
 before_install:
   - export TZ=UTC
+  - gem install -v 1.17.2 bundler --no-rdoc --no-ri
 
 before_script:
   # Set up Mongo databases


### PR DESCRIPTION
Bundler 2.0 has been released but has a dependency on rubygems 3.0, which is not available by default with our version of Ruby. So this PR attempts to lock Travis into using 1.x instead, as otherwise our build fails.