### PR TITLE
Remove passenger from dev group in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,7 +67,7 @@ gem "github_changelog_generator", require: false
 # Test with `curl -I http://localhost:8001/healthcheck`
 gem "aws-healthcheck"
 
-group :development, :production do
+group :production do
   # Web application server that replaces webrick. It handles HTTP requests,
   # manages processes and resources, and enables administration, monitoring
   # and problem diagnosis. It is used in production because it gives us an ability


### PR DESCRIPTION
We added passenger to the dev group in the Gemfile to replace using Webrick as the app server when running the app locally.

The intention was to more closely mirror our setup in production. However on review we have found that there have not been anytimes where this has helped us resolve an issue or develop a new feature. What the dev's often do though is comment it out before running locally so things like **byebug** will work.

So rather than hinder local development for no gain, we have chosen to stop using passenger locally and in our Vagrant build.