### PR TITLE
Fix Airbrake for the dev environment

### DIFF
--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -9,57 +9,60 @@
 #
 # Configuration details:
 # https://github.com/airbrake/airbrake-ruby#configuration
-if Rails.configuration.airbrake_on
-  Airbrake.configure do |config|
-    # Set project details
-    config.host = Rails.configuration.airbrake_host
-    config.project_id = Rails.configuration.airbrake_id
-    config.project_key = Rails.configuration.airbrake_key
 
-    # Configures the root directory of your project. Expects a String or a
-    # Pathname, which represents the path to your project. Providing this option
-    # helps us to filter out repetitive data from backtrace frames and link to
-    # GitHub files from our dashboard.
-    # https://github.com/airbrake/airbrake-ruby#root_directory
-    config.root_directory = Rails.root
+Airbrake.configure do |config|
+  # By default, it is set to airbrake.io As we use our own hosted instance of
+  # Errbit we need to set this value
+  config.host = Rails.configuration.airbrake_host
+  # You must set both project_id & project_key. To find your project_id and
+  # project_key navigate to your project's General Settings and copy the values
+  # from the right sidebar.
+  # https://github.com/airbrake/airbrake-ruby#project_id--project_key
+  config.project_id = Rails.configuration.airbrake_id
+  config.project_key = Rails.configuration.airbrake_key
 
-    # By default, Airbrake Ruby outputs to STDOUT. In Rails apps it makes sense to
-    # use the Rails' logger.
-    # https://github.com/airbrake/airbrake-ruby#logger
-    config.logger = Rails.logger
+  # Configures the root directory of your project. Expects a String or a
+  # Pathname, which represents the path to your project. Providing this option
+  # helps us to filter out repetitive data from backtrace frames and link to
+  # GitHub files from our dashboard.
+  # https://github.com/airbrake/airbrake-ruby#root_directory
+  config.root_directory = Rails.root
 
-    # Configures the environment the application is running in. Helps the Airbrake
-    # dashboard to distinguish between exceptions occurring in different
-    # environments.
-    # NOTE: This option must be set in order to make the 'ignore_environments'
-    # option work.
-    # https://github.com/airbrake/airbrake-ruby#environment
-    config.environment = Rails.env
+  # By default, Airbrake Ruby outputs to STDOUT. In Rails apps it makes sense to
+  # use the Rails' logger.
+  # https://github.com/airbrake/airbrake-ruby#logger
+  config.logger = Rails.logger
 
-    # Setting this option allows Airbrake to filter exceptions occurring in
-    # unwanted environments such as :test.
-    # NOTE: This option *does not* work if you don't set the 'environment' option.
-    # https://github.com/airbrake/airbrake-ruby#ignore_environments
-    config.ignore_environments = %w[test]
+  # Configures the environment the application is running in. Helps the Airbrake
+  # dashboard to distinguish between exceptions occurring in different
+  # environments.
+  # NOTE: This option must be set in order to make the 'ignore_environments'
+  # option work.
+  # https://github.com/airbrake/airbrake-ruby#environment
+  config.environment = Rails.env
 
-    # A list of parameters that should be filtered out of what is sent to
-    # Airbrake. By default, all "password" attributes will have their contents
-    # replaced.
-    # https://github.com/airbrake/airbrake-ruby#blacklist_keys
-    config.blacklist_keys = [/password/i, /authorization/i]
-    #
-    # Alternatively, you can integrate with Rails' filter_parameters.
-    # Read more: https://goo.gl/gqQ1xS
-    # c.blacklist_keys = Rails.application.config.filter_parameters
-  end
+  # Setting this option allows Airbrake to filter exceptions occurring in
+  # unwanted environments such as :test.
+  # NOTE: This option *does not* work if you don't set the 'environment' option.
+  # https://github.com/airbrake/airbrake-ruby#ignore_environments
+  config.ignore_environments = %w[test]
+
+  # A list of parameters that should be filtered out of what is sent to
+  # Airbrake. By default, all "password" attributes will have their contents
+  # replaced.
+  # https://github.com/airbrake/airbrake-ruby#blacklist_keys
+  config.blacklist_keys = [/password/i, /authorization/i]
+  #
+  # Alternatively, you can integrate with Rails' filter_parameters.
+  # Read more: https://goo.gl/gqQ1xS
+  # c.blacklist_keys = Rails.application.config.filter_parameters
 end
 
-# A filter that collects request body information. Enable it if you are sure you
-# don't send sensitive information to Airbrake in your body (such as passwords).
-# https://github.com/airbrake/airbrake#requestbodyfilter
-# Airbrake.add_filter(Airbrake::Rack::RequestBodyFilter.new)
-
-# If you want to convert your log messages to Airbrake errors, we offer an
-# integration with the Logger class from stdlib.
-# https://github.com/airbrake/airbrake#logger
-# Rails.logger = Airbrake::AirbrakeLogger.new(Rails.logger)
+# Unfortunately the airbrake initializer errors if project_key is not set. The
+# problem is that the initializer is fired in scenarios where we are not
+# actually using the app, for example when running a rake task.
+#
+# In production when we run rake tasks it's in an environment where environment
+# variables have not been  set. As such we need a way to disable using airbrake
+# unless we actually need it.
+Airbrake.add_filter(&:ignore!) unless Rails.configuration.airbrake_on


### PR DESCRIPTION
This fixes the issue where 500 error stack traces are swallowed up by the Airbrake module. When `ENV["USE_AIRBRAKE"]` is not `"true"` (as would be the case for the dev environment), this change successfully disables Airbrake.

Using `Airbrake.add_filter(&:ignore!)` is the recommended approach for Airbrake 5. The previous implementation would have worked in Airbrake 4.