### PR TITLE
Make back to payment exception uniform

### DIFF
--- a/app/controllers/worldpay_escapes_controller.rb
+++ b/app/controllers/worldpay_escapes_controller.rb
@@ -36,9 +36,12 @@ class WorldpayEscapesController < ApplicationController
   end
 
   def log_worldpay_escape
-    message = "#{current_user.email} sent #{@transient_registration.reg_identifier} back to payment summary"
-    Rails.logger.debug message
-    Airbrake.notify message
+    params = {
+      user: current_user.email,
+      registration: @transient_registration.reg_identifier
+    }
+    Rails.logger.debug("#{params[:email]} sent #{params[:registration]} back to payment summary")
+    Airbrake.notify("Sent back to payment summary", params)
   end
 
   def continue_renewal_path


### PR DESCRIPTION
We intended to use Airbrake to track when NCCC users were sending renewals back to the payment summary so we can visibly track when this happens.

Sending a renewal back to payment summary is an indication that something has gone wrong, and we have made changes previously to try and remove the need to do this.

When we first started tracking this we included the user email and the registration reference in the message we were sending to Errbit not realising this would break Errbit's collation logic.

If Errbit receives the same error as previous, rather than create a new entry it instead records it against the initial record. In this way you can distinguish that your app has 'x' errors, and they have each occurred 'y' number of times.

By breaking the collation logic, it now appears we have hundreds of errors, each only occurring once.

This changes makes the message title uniform to fix this. We still get the user and reference number as it's included in the params that get attached.