### PR TITLE
Switch to new engine repo name

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,7 @@ gem "kaminari-mongoid", "~> 1.0"
 
 # Use the waste carriers engine for the user journey
 gem "waste_carriers_engine",
-    git: "https://github.com/DEFRA/waste-carriers-renewals",
+    git: "https://github.com/DEFRA/waste-carriers-engine",
     branch: "master"
 
 # Allows us to automatically generate the change log from the tags, issues,

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: https://github.com/DEFRA/waste-carriers-renewals
+  remote: https://github.com/DEFRA/waste-carriers-engine
   revision: 2562c1637a4988576742b8f12d26453b68bb0433
   branch: master
   specs:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Waste Carriers Back Office
 
-[![Build Status](https://travis-ci.org/DEFRA/waste-carriers-renewals.svg?branch=master)](https://travis-ci.org/DEFRA/waste-carriers-renewals)
+[![Build Status](https://travis-ci.org/DEFRA/waste-carriers-back-office.svg?branch=master)](https://travis-ci.org/DEFRA/waste-carriers-back-office)
 [![Maintainability](https://api.codeclimate.com/v1/badges/1c4b6080a0833be52c60/maintainability)](https://codeclimate.com/github/DEFRA/waste-carriers-back-office/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/1c4b6080a0833be52c60/test_coverage)](https://codeclimate.com/github/DEFRA/waste-carriers-back-office/test_coverage)
 [![security](https://hakiri.io/github/DEFRA/waste-carriers-back-office/master.svg)](https://hakiri.io/github/DEFRA/waste-carriers-back-office/master)


### PR DESCRIPTION
We have renamed the engine repo from waste-carriers-renewals to waste-carriers-engine. This commit updates the Gemfile.

It also fixes a badge in the README.