### PR TITLE
Fix database cleaner to keep the test environment clean at every test

### DIFF
--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -11,4 +11,10 @@ RSpec.configure do |config|
 
     DatabaseCleaner.clean
   end
+
+  config.around do |example|
+    DatabaseCleaner.cleaning do
+      example.run
+    end
+  end
 end


### PR DESCRIPTION
Fixes: https://github.com/DEFRA/waste-carriers-back-office/issues/206

The problem was created by the incorrect DB strategy. The DB was cleaned before every suite but not between tests.
Hence, the code in here https://github.com/DEFRA/waste-carriers-back-office/blob/master/spec/services/user_migration_service_spec.rb#L31 was catching the wrong
object.