### PR TITLE
Fix persistence of updated session token after logout

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,7 +16,8 @@ class User
   end
 
   def invalidate_all_sessions!
-    update_attributes(session_token: SecureRandom.hex)
+    # Use set to avoid validation checks on other fields
+    set(session_token: SecureRandom.hex)
   end
 
   # Roles


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-381

This fix worked with our Postgres apps but didn't seem to persist with Mongoid. I think this is because Mongoid was attempting to re-validate the password when we persisted the session token. Using `set` gets around that by only storing the update to the session token and not bothering with the other attributes.