### PR TITLE
Add privacy policy page for renewals

### DIFF
--- a/app/controllers/ad_privacy_policy_controller.rb
+++ b/app/controllers/ad_privacy_policy_controller.rb
@@ -2,7 +2,6 @@
 
 class AdPrivacyPolicyController < ApplicationController
   before_action :authenticate_user!
-  
 
   def show
     @reg_identifier = params[:reg_identifier]

--- a/app/controllers/ad_privacy_policy_controller.rb
+++ b/app/controllers/ad_privacy_policy_controller.rb
@@ -2,6 +2,7 @@
 
 class AdPrivacyPolicyController < ApplicationController
   before_action :authenticate_user!
+  
 
   def show
     @reg_identifier = params[:reg_identifier]

--- a/app/controllers/ad_privacy_policy_controller.rb
+++ b/app/controllers/ad_privacy_policy_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class AdPrivacyPolicyController < ApplicationController
+  before_action :authenticate_user!
+
   def show
     @reg_identifier = params[:reg_identifier]
   end

--- a/app/controllers/ad_privacy_policy_controller.rb
+++ b/app/controllers/ad_privacy_policy_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AdPrivacyPolicyController < ApplicationController
+  def show
+    @reg_identifier = params[:reg_identifier]
+  end
+end

--- a/app/helpers/ad_privacy_policy_helper.rb
+++ b/app/helpers/ad_privacy_policy_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module AdPrivacyPolicyHelper
+  def link_to_privacy_policy
+    path = File.join(Rails.configuration.wcrs_frontend_url, "privacy")
+
+    link_to(t(".privacy_policy"), path, target: "_blank")
+  end
+end

--- a/app/views/ad_privacy_policy/show.html.erb
+++ b/app/views/ad_privacy_policy/show.html.erb
@@ -1,0 +1,61 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render("waste_carriers_engine/shared/back", back_path: root_path) %>
+
+    <h1 class="heading-large">
+      <%= t(".heading") %>
+    </h1>
+    <div class="panel panel-border-wide">
+      <p>
+        <%= t(".sub_heading") %>
+      </p>
+    </div>
+    <p>
+      <%= t(".first_paragraph", link_to_privacy_policy: link_to_privacy_policy).html_safe %>
+    </p>
+    <p>
+      <%= t(".second_paragraph") %>
+    </p>
+    <p>
+      <%= t(".third_paragraph") %>
+    </p>
+    <p>
+      <%= t(".fourth_paragraph") %>
+    </p>
+
+    <details>
+      <summary>
+        <span class="summary"><%= t(".privacy_policy_text.summary") %></span>
+      </summary>
+      <div class="panel panel-border-narrow">
+        <% 1.upto(14).each do |paragraph_index| %>
+          <p>
+            <%= t(".privacy_policy_text.paragraph_#{paragraph_index}") %>
+          </p>
+        <% end %>
+      </div>
+    </details>
+
+    <details>
+      <summary>
+        <span class="summary"><%= t(".contact_details_dpo.summary") %></span>
+      </summary>
+      <div class="panel panel-border-narrow">
+        <p><%= t(".contact_details_dpo.address_html") %></p>
+        <p><%= t(".contact_details_dpo.email") %></p>
+      </div>
+    </details>
+
+    <details>
+      <summary>
+        <span class="summary"><%= t(".contact_details_ico.summary") %></span>
+      </summary>
+      <div class="panel panel-border-narrow">
+        <p><%= t(".contact_details_ico.website") %></p>
+      </div>
+    </details>
+
+    <p><%= link_to "Continue", WasteCarriersEngine::Engine.routes.url_helpers.new_renewal_start_form_path(reg_identifier: @reg_identifier), class: "button" %></p>
+    <p><%= t(".last_updated") %></p>
+  </div>
+</div>

--- a/config/locales/ad_privacy_policy.en.yml
+++ b/config/locales/ad_privacy_policy.en.yml
@@ -1,6 +1,7 @@
 en:
   ad_privacy_policy:
     show:
+      title: "Privacy policy for assisted digital"
       heading: "Privacy policy for Waste Carriers, Brokers and Dealers assisted digital"
       sub_heading: "Tell the customer:"
       privacy_policy: "privacy policy"

--- a/config/locales/ad_privacy_policy.en.yml
+++ b/config/locales/ad_privacy_policy.en.yml
@@ -1,0 +1,40 @@
+en:
+  ad_privacy_policy:
+    show:
+      heading: "Privacy policy for Waste Carriers, Brokers and Dealers assisted digital"
+      sub_heading: "Tell the customer:"
+      privacy_policy: "privacy policy"
+      first_paragraph: "The %{link_to_privacy_policy} for the Waste Carriers, Brokers and Dealers Service has been updated, and can be viewed online at: wastecarriersregistration.service.gov.uk/privacy"
+      second_paragraph: "If you want to read the updated privacy policy but don't have internet access, I can email or post a copy to you, or I can read it to you now."
+      third_paragraph: "You'll receive a copy of the privacy policy by email when you submit your registration."
+      fourth_paragraph: "Would you like me to read it to you now?"
+      privacy_policy_text:
+        summary: "Waste carriers, brokers and dealers privacy policy text"
+        paragraph_1: "The Environment Agency runs the Register Waste Carriers, Brokers and Dealers Service. We are the data controller, which means we determine how and why personal information is processed."
+        paragraph_2: "Our personal information charter explains your rights and how we deal with your personal information. You can access the charter by going to GOV.UK and searching for 'Environment Agency personal information charter’."
+        paragraph_3: "The personal data we collect about you includes the name and address of your business or organisation, contact details, date of birth, and details of relevant criminal convictions."
+        paragraph_4: "We can process your personal data because we have official authority to register waste carriers, brokers and dealers. The lawful basis for processing your personal data is to exercise our official authority that is set out in law. We process personal data relating to criminal convictions and offences under the same official authority."
+        paragraph_5: "We use your personal data in order to process your transaction and register you as a waste carrier, broker or dealer. If you don't provide the information requested, we can't register you as a waste carrier, broker or dealer."
+        paragraph_6: "We will use the personal data you provide about criminal convictions for making a decision about whether you can register as a waste carrier. If you disclose that a person in the company’s management has a relevant criminal conviction, your application to register as a waste carrier could be refused."
+        paragraph_7: "We put some of the information from your registration on a public register. Only the name and address of your organisation will appear on the public register."
+        paragraph_8: "We will not share or disclose any further personal data to any other party outside the Environment Agency without your explicit consent, unless lawfully able to do so."
+        paragraph_9: "We store and process your personal data on our servers within the European Economic Area."
+        paragraph_10: "We do not use your personal data to make an automated decision or for automated profiling."
+        paragraph_11: "Personal data in an upper-tier registration is kept for 7 years after a registration has ended. Lower-tier registrations are non-expiring, and personal data is retained unless you request it is removed. To request that your personal data is removed, please contact the Environment Agency helpline."
+        paragraph_12: "Our Data Protection Officer (DPO) is responsible for independent advice and monitoring of the Environment Agency’s use of personal information. If you have any queries about how we process personal data, or would like to make a complaint or request relating to data protection, please contact our Data Protection Officer."
+        paragraph_13: "The Information Commissioner's Office is the supervisory authority for data protection legislation. The ICO website has a full list of your rights under data protection legislation. You have the right to lodge a complaint with the ICO at any time."
+        paragraph_14: "Would you like the contact details for the Data Protection Officer or the Information Commissioner's Office?"
+      contact_details_dpo:
+        summary: "Contact details for the Data Protection Officer"
+        address_html: |
+          Data Protection Officer<br>
+          Environment Agency<br>
+          Horizon House<br>
+          Deanery Road<br>
+          Bristol<br>
+          BS1 5AH
+        email: "Email: dataprotection@environment-agency.gov.uk"
+      contact_details_ico:
+        summary: "Contact details for the Information Commissioner's Office"
+        website: "The ICO website is: ico.org.uk/your-data-matters"
+      last_updated: "This notice was last updated on {UPDATE_WHEN_RFC_READY} August 2019"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,9 @@ Rails.application.routes.draw do
   get "/bo/convictions/approved" => "convictions_dashboards#approved", as: :convictions_approved
   get "/bo/convictions/rejected" => "convictions_dashboards#rejected", as: :convictions_rejected
 
+  # Privacy policy
+  get "/ad-privacy-policy/:reg_identifier", to: "ad_privacy_policy#show", as: :ad_privacy_policy
+
   resources :transient_registrations,
             only: :show,
             param: :reg_identifier,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
   get "/bo/convictions/rejected" => "convictions_dashboards#rejected", as: :convictions_rejected
 
   # Privacy policy
-  get "/ad-privacy-policy/:reg_identifier", to: "ad_privacy_policy#show", as: :ad_privacy_policy
+  get "/bo/ad-privacy-policy/:reg_identifier", to: "ad_privacy_policy#show", as: :ad_privacy_policy
 
   resources :transient_registrations,
             only: :show,

--- a/spec/requests/ad_privacy_policy_spec.rb
+++ b/spec/requests/ad_privacy_policy_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Assisted digital privacy policy", type: :request do
+  let(:registration) { create(:registration, :expires_soon) }
+  let(:user) { create(:user, :agency) }
+
+  before(:each) do
+    sign_in(user)
+  end
+
+  describe "GET /ad-privacy-policy/:reg_identifier" do
+    it "renders the correct template" do
+      get ad_privacy_policy_path(registration.reg_identifier)
+
+      expect(response).to render_template("ad_privacy_policy/show")
+    end
+
+    it "responds with a 200 status code" do
+      get ad_privacy_policy_path(registration.reg_identifier)
+
+      expect(response.code).to eq("200")
+    end
+  end
+end


### PR DESCRIPTION
From https://eaflood.atlassian.net/browse/RUBY-302

Add verbal privacy policy screen on the backoffice.
The page's button "continue" will redirect to the beginning of the renewal journey for the given registration.
The front office dashboard renewal link will be changed to point to this page instead of directly the start of the journey.
This is the same strategy used for the verbal privacy policy on WEX.

<img width="1088" alt="Screenshot 2019-07-18 at 16 22 36" src="https://user-images.githubusercontent.com/1385397/61470252-a6231f00-a978-11e9-8fe4-3f246ca5170a.png">
