### PR TITLE
Update date on verbal privacy policy

### DIFF
--- a/config/locales/ad_privacy_policy.en.yml
+++ b/config/locales/ad_privacy_policy.en.yml
@@ -38,4 +38,4 @@ en:
       contact_details_ico:
         summary: "Contact details for the Information Commissioner's Office"
         website: "The ICO website is: ico.org.uk/your-data-matters"
-      last_updated: "This notice was last updated on {UPDATE_WHEN_RFC_READY} August 2019"
+      last_updated: "This notice was last updated on 2 September 2019"


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-590

Now we have a date for the release which will contain this verbal privacy policy, we can set what the last update date is at the bottom.

This is a small change to set the date.