### PR TITLE
Add missing companies house configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,3 +28,9 @@ WCRS_EMAIL_USERNAME=""
 WCRS_EMAIL_PASSWORD=""
 WCRS_EMAIL_TEST_ADDRESS=""
 WCRS_EMAIL_SERVICE_EMAIL=""
+
+# Companies House API key
+# The app will make a call to companies house to validate any registration
+# numbers entered for limited or LLP organisations. To do this it will need
+# a valid companies house API key
+WCRS_COMPANIES_HOUSE_API_KEY=longvaluefullofnumbersandlettersinlowercase

--- a/config/initializers/waste_carriers_engine.rb
+++ b/config/initializers/waste_carriers_engine.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+WasteCarriersEngine.configure do |configuration|
+  # Companies house API config
+  configuration.companies_house_api_key = ENV["WCRS_COMPANIES_HOUSE_API_KEY"]
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-659

Our experience building Waste Carriers, Waste Exemptions and Flood Risk Activity Exemptions is that they generally share the same validations.

To reduce duplication and help maintenance we built the [defra-ruby-validators](https://github.com/DEFRA/defra-ruby-validators) gem. One of its validators is to confirm that for LTD/LLP organisations the companies house number provided exists and belongs to an active entity.

We've recently incorporated the gem in Waste Carriers, but it expects that at somepoint a call will be made to configure it, because host apps must provide the companies house API key.

After some investigation we've managed to find that we've not done this, which means the validator is not working, which for LTD/LLP users means their registration will be blocked.