### PR TITLE
Update dashboard search design

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -4,36 +4,7 @@ class DashboardsController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    set_term_and_filters
-    @transient_registrations = matching_renewals(params[:page])
-    @search_terms_or_filters_present = search_terms_or_filters_present?
-  end
-
-  private
-
-  def set_term_and_filters
     @term = params[:term]
-    @in_progress = get_filter_value(params[:in_progress])
-    @pending_payment = get_filter_value(params[:pending_payment])
-  end
-
-  def get_filter_value(filter_param)
-    filter_param.present? && filter_param == "true"
-  end
-
-  def matching_renewals(page)
-    service = TransientRegistrationSearchService.new(
-      @term,
-      @in_progress,
-      @pending_payment
-    )
-
-    service.search(page)
-  end
-
-  def search_terms_or_filters_present?
-    return true if @term.present?
-
-    @in_progress || @pending_payment
+    @results = SearchService.run(page: params[:page], term: @term)
   end
 end

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class TransientRegistrationSearchService < ::WasteCarriersEngine::BaseService
+class SearchService < ::WasteCarriersEngine::BaseService
   def run(page:, term:)
     return [] if term.blank?
 

--- a/app/services/transient_registration_search_service.rb
+++ b/app/services/transient_registration_search_service.rb
@@ -1,43 +1,12 @@
 # frozen_string_literal: true
 
-class TransientRegistrationSearchService
-  def initialize(term, in_progress, pending_payment)
-    @term = term
+class TransientRegistrationSearchService < ::WasteCarriersEngine::BaseService
+  def run(page:, term:)
+    return [] if term.blank?
 
-    @in_progress = in_progress
-    @pending_payment = pending_payment
+    WasteCarriersEngine::TransientRegistration.search_term(term)
+                                              .order_by("metaData.lastModified": :desc)
+                                              .page(page)
+                                              .read(mode: :secondary)
   end
-
-  def search(page)
-    return WasteCarriersEngine::TransientRegistration.none if no_search_terms_or_filters?
-
-    # Each criteria when added results in an AND search (not an OR). So for a
-    # renewal to be returned it must match all criteria selected. In some cases
-    # this would be impossible, for example `pending_payment` filters on
-    # renewals that have been submitted with a balance != 0. If you also
-    # selected `in_progress` then you'd get nothing because a renewal can't be
-    # both.
-    #
-    # Also note the way criteria works in mongoid is that until we actually
-    # attempt to access a renewal e.g. with `.first` or ``.each` criteria is
-    # just a hash of filters. So when we're merging here we are merging filters
-    # not selected renewals!
-    criteria = WasteCarriersEngine::TransientRegistration.order_by("metaData.lastModified": :desc)
-    criteria.merge!(WasteCarriersEngine::TransientRegistration.search_term(@term)) if @term.present?
-
-    criteria.merge!(WasteCarriersEngine::TransientRegistration.in_progress) if @in_progress
-    criteria.merge!(WasteCarriersEngine::TransientRegistration.pending_payment) if @pending_payment
-
-    criteria.page(page).read(mode: :secondary)
-  end
-
-  private
-
-  def no_search_terms_or_filters?
-    return false if @term.present?
-    return false if @in_progress || @pending_payment
-
-    true
-  end
-
 end

--- a/app/services/waste_carriers_engine/base_service.rb
+++ b/app/services/waste_carriers_engine/base_service.rb
@@ -3,11 +3,7 @@
 module WasteCarriersEngine
   class BaseService
     def self.run(attrs = nil)
-      if attrs
-        new.run(attrs)
-      else
-        new.run
-      end
+      new.run(attrs)
     end
   end
 end

--- a/app/services/waste_carriers_engine/base_service.rb
+++ b/app/services/waste_carriers_engine/base_service.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  class BaseService
+    def self.run(attrs = nil)
+      if attrs
+        new.run(attrs)
+      else
+        new.run
+      end
+    end
+  end
+end

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -36,13 +36,13 @@
   </div>
 </div>
 
-<% if @transient_registrations.present? %>
+<% if @results.present? %>
   <div class="grid-row">
     <div class="column-full">
       <table>
         <caption>
           <h2 class="heading-medium">
-            <%= t(".results.caption", count: @transient_registrations.count) %>
+            <%= t(".results.caption", count: @results.count) %>
           </h2>
         </caption>
         <thead>
@@ -55,7 +55,7 @@
           </tr>
         </thead>
         <tbody>
-          <% @transient_registrations.each do |transient_registration| %>
+          <% @results.each do |transient_registration| %>
             <tr>
               <td>
                 <%= transient_registration.reg_identifier %>
@@ -107,14 +107,14 @@
     <div class="column-full">
       <nav role="navigation" class="pagination" aria-label="Pagination">
         <div class="pagination__summary">
-          <%= page_entries_info @transient_registrations, entry_name: "item" %>
+          <%= page_entries_info @results, entry_name: "item" %>
         </div>
-        <%= paginate @transient_registrations %>
+        <%= paginate @results %>
       </nav>
     </div>
   </div>
 
-<% elsif @search_terms_or_filters_present %>
+<% elsif @term.present? %>
 
 <hr>
 

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -61,6 +61,11 @@
   <div class="grid-row">
     <div class="column-full">
       <table>
+        <caption>
+          <h2 class="heading-medium">
+            <%= t(".results.caption", count: @transient_registrations.count) %>
+          </h2>
+        </caption>
         <thead>
           <tr>
             <th><%= t(".results.th.reg_identifier") %></th>

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -19,17 +19,13 @@
 
 <div class="grid-row">
   <div class="column-full">
-    <p><%= t(".search.paragraph_1") %></p>
-    <ul class="list list-bullet">
-      <% t(".search.searchable_attributes").each do |attribute| %>
-        <li><%= attribute %></li>
-      <% end %>
-    </ul>
-    <p><%= t(".search.paragraph_2") %></p>
     <div class="form-group">
       <%= form_tag("/bo", method: :get) do %>
-        <%= label_tag :term, t(".search.label"), class: "form-label visually-hidden" %>
-        <%= text_field_tag :term, @term, placeholder: t(".search.placeholder"), class: "form-control" %>
+        <%= label_tag :term, class: "form-label" do %>
+          <%= t(".search.label") %>
+          <span class="form-hint"><%= t(".search.hint") %></span>
+        <% end %>
+        <%= text_field_tag :term, @term, class: "form-control", type: "search" %>
         <%= submit_tag t(".search.submit"), class: "button" %>
       <% end %>
     </div>

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -32,7 +32,7 @@
   </div>
 </div>
 
-<% if @results.present? %>
+<% if @results.any? %>
   <div class="grid-row">
     <div class="column-full">
       <table>

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -26,32 +26,11 @@
       <% end %>
     </ul>
     <p><%= t(".search.paragraph_2") %></p>
-    <div class="form-group panel panel-border-wide">
+    <div class="form-group">
       <%= form_tag("/bo", method: :get) do %>
         <%= label_tag :term, t(".search.label"), class: "form-label visually-hidden" %>
         <%= text_field_tag :term, @term, placeholder: t(".search.placeholder"), class: "form-control" %>
         <%= submit_tag t(".search.submit"), class: "button" %>
-
-        <div class="filters">
-          <p><%= t(".search.filters.paragraph_1") %></p>
-          <div class="form-group">
-            <div class="multiple-choice">
-              <%= check_box_tag :in_progress,
-                                "true",
-                                @in_progress %>
-              <%= label_tag :in_progress,
-                            t(".search.filters.in_progress") %>
-            </div>
-            <div class="multiple-choice">
-              <%= check_box_tag :pending_payment,
-                                "true",
-                                @pending_payment %>
-              <%= label_tag :pending_payment,
-                            t(".search.filters.pending_payment") %>
-            </div>
-          </div>
-          <p><%= link_to t(".search.clear_all_link"), bo_path %></p>
-        </div>
       <% end %>
     </div>
   </div>

--- a/config/locales/dashboard.en.yml
+++ b/config/locales/dashboard.en.yml
@@ -17,11 +17,6 @@ en:
         label: "Search for renewals"
         placeholder: "Enter your search term here"
         submit: "Search"
-        filters:
-          paragraph_1: "Filter the results:"
-          in_progress: "Application in progress"
-          pending_payment: "Pending payment"
-        clear_all_link: "Clear all searches and filters"
       results:
         caption:
           one: "Found 1 registration"

--- a/config/locales/dashboard.en.yml
+++ b/config/locales/dashboard.en.yml
@@ -7,15 +7,8 @@ en:
         sign_out_link: "Sign out"
       heading: "Waste carriers registrations"
       search:
-        paragraph_1: "You can search for a renewal by:"
-        searchable_attributes:
-          - "registration number"
-          - "company name"
-          - "last name of contact person"
-          - "postcode (if confirmed during renewal process)"
-        paragraph_2: "You can filter the search results, or search without a term to use the filters on their own."
-        label: "Search for renewals"
-        placeholder: "Enter your search term here"
+        label: "Search for a registration"
+        hint: "Using registration number, business or contact last name, postcode"
         submit: "Search"
       results:
         caption:

--- a/config/locales/dashboard.en.yml
+++ b/config/locales/dashboard.en.yml
@@ -23,6 +23,9 @@ en:
           pending_payment: "Pending payment"
         clear_all_link: "Clear all searches and filters"
       results:
+        caption:
+          one: "Found 1 registration"
+          other: "Found %{count} registrations"
         th:
           reg_identifier: "Registration"
           company_name: "Company name"

--- a/config/locales/dashboard.en.yml
+++ b/config/locales/dashboard.en.yml
@@ -1,11 +1,11 @@
 en:
   dashboards:
     index:
-      title: "Renewals dashboard"
+      title: "Waste carriers registrations"
       user_info:
         signed_in_user: "Signed in as %{email}."
         sign_out_link: "Sign out"
-      heading: "Renewals dashboard"
+      heading: "Waste carriers registrations"
       search:
         paragraph_1: "You can search for a renewal by:"
         searchable_attributes:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,7 +5,7 @@ en:
     application:
       feedback_url: https://www.gov.uk/done/waste-carrier-or-broker-registration
       menu:
-        dashboard: "Renewals dashboard"
+        dashboard: "Registrations search"
         convictions: "Conviction checks"
         users: "Manage users"
   shared:

--- a/spec/services/search_service_spec.rb
+++ b/spec/services/search_service_spec.rb
@@ -2,12 +2,12 @@
 
 require "rails_helper"
 
-RSpec.describe TransientRegistrationSearchService do
+RSpec.describe SearchService do
   let(:page) { 1 }
   let(:term) { nil }
 
   let(:service) do
-    TransientRegistrationSearchService.run(page: page, term: term)
+    SearchService.run(page: page, term: term)
   end
 
   let(:non_matching_renewal) { create(:transient_registration) }

--- a/spec/services/transient_registration_search_service_spec.rb
+++ b/spec/services/transient_registration_search_service_spec.rb
@@ -3,143 +3,88 @@
 require "rails_helper"
 
 RSpec.describe TransientRegistrationSearchService do
+  let(:page) { 1 }
   let(:term) { nil }
 
-  let(:in_progress) { false }
-  let(:pending_payment) { false }
-
-  let(:transient_registrations) do
-    service = TransientRegistrationSearchService.new(term,
-                                                     in_progress,
-                                                     pending_payment)
-    service.search(1)
+  let(:service) do
+    TransientRegistrationSearchService.run(page: page, term: term)
   end
 
   let(:non_matching_renewal) { create(:transient_registration) }
 
-  context "when there are no filters" do
-    context "when there is no search term" do
-      it "returns no renewals" do
-        expect(transient_registrations).to eq([])
-      end
-    end
-
-    context "when there is a search term" do
-      let(:address) { build(:address, postcode: "AB1 2CD") }
-      let(:matching_renewal) do
-        create(:transient_registration,
-               company_name: "Acme",
-               last_name: "Aardvark",
-               addresses: [address])
-      end
-
-      context "when there is a match on a reg_identifier" do
-        let(:term) { matching_renewal.reg_identifier }
-
-        it "displays the matching renewal" do
-          expect(transient_registrations).to include(matching_renewal)
-        end
-
-        it "does not display a non-matching renewal" do
-          expect(transient_registrations).to_not include(non_matching_renewal)
-        end
-      end
-
-      context "when there is a match on a company_name" do
-        let(:term) { matching_renewal.company_name }
-
-        it "displays the matching renewal" do
-          expect(transient_registrations).to include(matching_renewal)
-        end
-      end
-
-      context "when there is a match on a last_name" do
-        let(:term) { matching_renewal.last_name }
-
-        it "displays the matching renewal" do
-          expect(transient_registrations).to include(matching_renewal)
-        end
-      end
-
-      context "when there is a match on a postcode" do
-        let(:term) { address.postcode }
-
-        it "displays the matching renewal" do
-          expect(transient_registrations).to include(matching_renewal)
-        end
-      end
-
-      context "when the term has a case-insensitive match" do
-        let(:term) { matching_renewal.reg_identifier.downcase }
-
-        it "includes the matching renewal" do
-          expect(transient_registrations).to include(matching_renewal)
-        end
-      end
-
-      context "when there is a partial match on the reg_identifier" do
-        let(:term) { matching_renewal.reg_identifier.chop }
-
-        it "does not include the partial match" do
-          expect(transient_registrations).to_not include(matching_renewal)
-        end
-      end
-
-      context "when there is a partial match on the last_name" do
-        let(:term) { matching_renewal.last_name.chop }
-
-        it "includes the partial match" do
-          expect(transient_registrations).to include(matching_renewal)
-        end
-      end
+  context "when there is no search term" do
+    it "returns no results" do
+      expect(service).to eq([])
     end
   end
 
-  context "when the in_progress filter is on" do
-    let(:in_progress) { true }
-
-    it "displays matching renewals" do
-      in_progress_renewal = create(:transient_registration)
-      expect(transient_registrations).to include(in_progress_renewal)
+  context "when there is a search term" do
+    let(:address) { build(:address, postcode: "AB1 2CD") }
+    let(:matching_renewal) do
+      create(:transient_registration,
+             company_name: "Acme",
+             last_name: "Aardvark",
+             addresses: [address])
     end
 
-    it "does not display non-matching renewals" do
-      submitted_renewal = create(:transient_registration, workflow_state: "renewal_received_form")
-      expect(transient_registrations).to_not include(submitted_renewal)
-    end
-  end
+    context "when there is a match on a reg_identifier" do
+      let(:term) { matching_renewal.reg_identifier }
 
-  context "when the pending_payment filter is on" do
-    let(:pending_payment) { true }
+      it "displays the matching result" do
+        expect(service).to include(matching_renewal)
+      end
 
-    it "displays matching renewals" do
-      pending_payment_renewal = create(:transient_registration, :pending_payment)
-      expect(transient_registrations).to include(pending_payment_renewal)
+      it "does not display a non-matching result" do
+        expect(service).to_not include(non_matching_renewal)
+      end
     end
 
-    it "does not display non-matching renewals" do
-      paid_renewal = create(:transient_registration, :no_pending_payment)
-      expect(transient_registrations).to_not include(paid_renewal)
-    end
-  end
+    context "when there is a match on a company_name" do
+      let(:term) { matching_renewal.company_name }
 
-  context "when a search term and a filter are both present" do
-    let(:term) { "Acme" }
-    let(:pending_payment) { true }
-
-    it "displays renewals which match the search term and filter" do
-      matching_search_term_and_filter = create(:transient_registration, :pending_payment, company_name: term)
-      expect(transient_registrations).to include(matching_search_term_and_filter)
+      it "displays the matching result" do
+        expect(service).to include(matching_renewal)
+      end
     end
 
-    it "does not display renewals which only match the search term" do
-      matching_search_term = create(:transient_registration, :no_pending_payment, company_name: term)
-      expect(transient_registrations).to_not include(matching_search_term)
+    context "when there is a match on a last_name" do
+      let(:term) { matching_renewal.last_name }
+
+      it "displays the matching result" do
+        expect(service).to include(matching_renewal)
+      end
     end
 
-    it "does not display renewals which only match the filter" do
-      matching_filter = create(:transient_registration, :pending_payment)
-      expect(transient_registrations).to_not include(matching_filter)
+    context "when there is a match on a postcode" do
+      let(:term) { address.postcode }
+
+      it "displays the matching result" do
+        expect(service).to include(matching_renewal)
+      end
+    end
+
+    context "when the term has a case-insensitive match" do
+      let(:term) { matching_renewal.reg_identifier.downcase }
+
+      it "includes the matching result" do
+        expect(service).to include(matching_renewal)
+      end
+    end
+
+    context "when there is a partial match on the reg_identifier" do
+      let(:term) { matching_renewal.reg_identifier.chop }
+
+      it "does not include the partial match" do
+        expect(service).to_not include(matching_renewal)
+      end
+    end
+
+    context "when there is a partial match on the last_name" do
+      let(:term) { matching_renewal.last_name.chop }
+
+      it "includes the partial match" do
+        expect(service).to include(matching_renewal)
+      end
     end
   end
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-694

This PR includes a number of updates to the renewals dashboard to prepare it for being the main back office dashboard. This includes:

- update name in page menu
- update H1 title for page
- update guidance text
- remove search filters (and update query)
- remove clear all searches link and function
- add result count above search results