### PR TITLE
Update dashboard search result design

### DIFF
--- a/app/assets/stylesheets/partials/_dashboards.scss
+++ b/app/assets/stylesheets/partials/_dashboards.scss
@@ -21,6 +21,10 @@ ul.dashboard_menu li a {
   margin: 1em;
 }
 
+.results p.address {
+  margin-bottom: 0;
+}
+
 .actions {
   background-color: #EEEEEE;
   padding: 0.5em;

--- a/app/assets/stylesheets/partials/_dashboards.scss
+++ b/app/assets/stylesheets/partials/_dashboards.scss
@@ -21,6 +21,10 @@ ul.dashboard_menu li a {
   margin: 1em;
 }
 
+.results td {
+  vertical-align: top;
+}
+
 .results p.address {
   margin-bottom: 0;
 }

--- a/app/assets/stylesheets/partials/_dashboards.scss
+++ b/app/assets/stylesheets/partials/_dashboards.scss
@@ -25,6 +25,10 @@ ul.dashboard_menu li a {
   vertical-align: top;
 }
 
+.results td:last-child {
+  width: 9em;
+}
+
 .results p.address {
   margin-bottom: 0;
 }

--- a/app/assets/stylesheets/partials/_tags.scss
+++ b/app/assets/stylesheets/partials/_tags.scss
@@ -1,7 +1,7 @@
 // Taken from https://dwp-design-examples.herokuapp.com/example/tags
 @import 'colours';
 
-.app-c-tag {
+.status-tag {
   background-color: $govuk-blue;
   color: $white;
   display: inline-block;
@@ -10,19 +10,29 @@
   font-weight: 700;
   letter-spacing: 1px;
   line-height: 1.25;
-  padding: 5px 8px 0;
+  padding: 5px 5px 2px 5px;
+  margin-bottom: 5px;
   text-decoration: none;
   text-transform: uppercase;
 }
 
-.app-c-tag--success {
-  background-color: $grass-green;
+.status-tag--convictions {
+  background-color: #d4351c;
 }
 
-.app-c-tag--warning {
-  background-color: $brown;
+.status-tag--in-progress {
+  background-color: #005ea5;
 }
 
-.app-c-tag--danger {
-  background-color: $mellow-red;
+.status-tag--payment {
+  color: $black;
+  background-color: #f47738;
+}
+
+.status-tag--stuck {
+  background-color: #d4351c;
+}
+
+.status-tag--rejected {
+  background-color: #6f777b;
 }

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class DashboardsController < ApplicationController
+  helper ActionLinksHelper
+
   before_action :authenticate_user!
 
   def index

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module ActionLinksHelper
+  def display_resume_link_for?(resource)
+    return false unless resource.is_a?(WasteCarriersEngine::TransientRegistration)
+    return false if resource.renewal_application_submitted?
+    return false if resource.workflow_state == "worldpay_form"
+
+    true
+  end
+end

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -2,10 +2,22 @@
 
 module ActionLinksHelper
   def display_resume_link_for?(resource)
-    return false unless resource.is_a?(WasteCarriersEngine::TransientRegistration)
+    return false unless display_transient_registration_links?(resource)
     return false if resource.renewal_application_submitted?
     return false if resource.workflow_state == "worldpay_form"
 
     true
+  end
+
+  def display_payment_link_for?(resource)
+    return false unless display_transient_registration_links?(resource)
+
+    resource.pending_payment?
+  end
+
+  private
+
+  def display_transient_registration_links?(resource)
+    resource.is_a?(WasteCarriersEngine::TransientRegistration) && !resource.metaData.REVOKED?
   end
 end

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -15,6 +15,12 @@ module ActionLinksHelper
     resource.pending_payment?
   end
 
+  def display_convictions_link_for?(resource)
+    return false unless display_transient_registration_links?(resource)
+
+    resource.pending_manual_conviction_check?
+  end
+
   private
 
   def display_transient_registration_links?(resource)

--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -5,7 +5,8 @@ module DashboardsHelper
 
   def inline_registered_address(result)
     address = displayable_address(result.registered_address)
-    return nil if address.empty?
+
+    return if address.empty?
 
     address.join(", ")
   end

--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -13,12 +13,4 @@ module DashboardsHelper
   def result_type(result)
     return "renewal" if result.is_a?(WasteCarriersEngine::TransientRegistration)
   end
-
-  def can_be_resumed?(result)
-    return false unless result.is_a?(WasteCarriersEngine::TransientRegistration)
-    return false if result.renewal_application_submitted?
-    return false if result.workflow_state == "worldpay_form"
-
-    true
-  end
 end

--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -13,4 +13,12 @@ module DashboardsHelper
   def result_type(result)
     return "renewal" if result.is_a?(WasteCarriersEngine::TransientRegistration)
   end
+
+  def can_be_resumed?(result)
+    return false unless result.is_a?(WasteCarriersEngine::TransientRegistration)
+    return false if result.renewal_application_submitted?
+    return false if result.workflow_state == "worldpay_form"
+
+    true
+  end
 end

--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -9,4 +9,8 @@ module DashboardsHelper
 
     address.join(", ")
   end
+
+  def result_type(result)
+    return "renewal" if result.is_a?(WasteCarriersEngine::TransientRegistration)
+  end
 end

--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module DashboardsHelper
+  include WasteCarriersEngine::ApplicationHelper
+
+  def inline_registered_address(result)
+    address = displayable_address(result.registered_address)
+    return nil if address.empty?
+
+    address.join(", ")
+  end
+end

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -130,6 +130,11 @@
                       <%= link_to t(".results.actions.payment"), transient_registration_payments_path(result.reg_identifier) %>
                     </li>
                   <% end %>
+                  <% if display_convictions_link_for?(result) %>
+                    <li>
+                      <%= link_to t(".results.actions.convictions"), transient_registration_convictions_path(result.reg_identifier) %>
+                    </li>
+                  <% end %>
                 </ul>
               </td>
             </tr>

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -79,6 +79,10 @@
                 <% end %>
               </td>
               <td>
+                <% if result_type(result).present? %>
+                  <%= t(".results.classes.#{result_type(result)}") %>
+                <% end %>
+
                 <% if result.metaData.REVOKED? %>
                   <strong class="app-c-tag app-c-tag--danger">
                     <%= t(".results.statuses.rejected") %>

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -110,7 +110,10 @@
                 <% end %>
               </td>
               <td>
-                <%= result.metaData.last_modified.in_time_zone("London").strftime("%H:%M %d/%m/%Y") %>
+                <%= t(".results.date.started", date: result.metaData
+                                                           .last_modified
+                                                           .in_time_zone("London")
+                                                           .strftime("%d/%m/%Y")) %>
               </td>
               <td>
                 <%= link_to t(".results.details_button"), transient_registration_path(result.reg_identifier) %>

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -125,6 +125,11 @@
                       <%= link_to t(".results.actions.resume"), WasteCarriersEngine::Engine.routes.url_helpers.new_renewal_start_form_path(result.reg_identifier) %>
                     </li>
                   <% end %>
+                  <% if display_payment_link_for?(result) %>
+                    <li>
+                      <%= link_to t(".results.actions.payment"), transient_registration_payments_path(result.reg_identifier) %>
+                    </li>
+                  <% end %>
                 </ul>
               </td>
             </tr>

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -120,7 +120,7 @@
                   <li>
                     <%= link_to t(".results.actions.details"), transient_registration_path(result.reg_identifier) %>
                   </li>
-                  <% if can_be_resumed?(result) %>
+                  <% if display_resume_link_for?(result) %>
                     <li>
                       <%= link_to t(".results.actions.resume"), WasteCarriersEngine::Engine.routes.url_helpers.new_renewal_start_form_path(result.reg_identifier) %>
                     </li>

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -74,7 +74,7 @@
                 <%= result.company_name %>
                 <% if result.registered_address.present? %>
                   <p class="address font-xsmall">
-                    <%= displayable_address(result.registered_address).join(", ") %>
+                    <%= inline_registered_address(result) %>
                   </p>
                 <% end %>
               </td>

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -116,7 +116,16 @@
                                                            .strftime("%d/%m/%Y")) %>
               </td>
               <td>
-                <%= link_to t(".results.details_button"), transient_registration_path(result.reg_identifier) %>
+                <ul>
+                  <li>
+                    <%= link_to t(".results.actions.details"), transient_registration_path(result.reg_identifier) %>
+                  </li>
+                  <% if can_be_resumed?(result) %>
+                    <li>
+                      <%= link_to t(".results.actions.resume"), WasteCarriersEngine::Engine.routes.url_helpers.new_renewal_start_form_path(result.reg_identifier) %>
+                    </li>
+                  <% end %>
+                </ul>
               </td>
             </tr>
           <% end %>

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -80,33 +80,33 @@
               </td>
               <td>
                 <% if result_type(result).present? %>
-                  <%= t(".results.classes.#{result_type(result)}") %>
+                  <%= t(".results.classes.#{result_type(result)}") %><br>
                 <% end %>
 
                 <% if result.metaData.REVOKED? %>
-                  <strong class="app-c-tag app-c-tag--danger">
+                  <span class="status-tag status-tag--rejected">
                     <%= t(".results.statuses.rejected") %>
-                  </strong>
+                  </span>
                 <% elsif result.renewal_application_submitted? %>
                     <% if result.pending_payment? %>
-                      <strong class="app-c-tag app-c-tag--success">
+                      <span class="status-tag status-tag--payment">
                         <%= t(".results.statuses.pending_payment") %>
-                      </strong>
+                      </span>
                     <% end %>
                     <% if result.pending_manual_conviction_check? %>
-                      <strong class="app-c-tag app-c-tag--warning">
+                      <span class="status-tag status-tag--convictions">
                         <%= t(".results.statuses.pending_conviction_check") %>
-                      </strong>
+                      </span>
                     <% end %>
                     <% if result.stuck? %>
-                      <strong class="app-c-tag app-c-tag--danger">
+                      <span class="status-tag status-tag--stuck">
                         <%= t(".results.statuses.stuck") %>
-                      </strong>
+                      </span>
                     <% end %>
                 <% else %>
-                  <strong class="app-c-tag">
+                  <span class="status-tag status-tag--in-progress">
                     <%= t(".results.statuses.in_progress") %>
-                  </strong>
+                  </span>
                 <% end %>
               </td>
               <td>

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -49,7 +49,7 @@
 <% if @results.any? %>
   <div class="grid-row">
     <div class="column-full">
-      <table>
+      <table class="results">
         <caption>
           <h2 class="heading-medium">
             <%= t(".results.caption", count: @results.count) %>
@@ -65,31 +65,36 @@
           </tr>
         </thead>
         <tbody>
-          <% @results.each do |transient_registration| %>
+          <% @results.each do |result| %>
             <tr>
               <td>
-                <%= transient_registration.reg_identifier %>
+                <%= result.reg_identifier %>
               </td>
               <td>
-                <%= transient_registration.company_name %>
+                <%= result.company_name %>
+                <% if result.registered_address.present? %>
+                  <p class="address font-xsmall">
+                    <%= displayable_address(result.registered_address).join(", ") %>
+                  </p>
+                <% end %>
               </td>
               <td>
-                <% if transient_registration.metaData.REVOKED? %>
+                <% if result.metaData.REVOKED? %>
                   <strong class="app-c-tag app-c-tag--danger">
                     <%= t(".results.statuses.rejected") %>
                   </strong>
-                <% elsif transient_registration.renewal_application_submitted? %>
-                    <% if transient_registration.pending_payment? %>
+                <% elsif result.renewal_application_submitted? %>
+                    <% if result.pending_payment? %>
                       <strong class="app-c-tag app-c-tag--success">
                         <%= t(".results.statuses.pending_payment") %>
                       </strong>
                     <% end %>
-                    <% if transient_registration.pending_manual_conviction_check? %>
+                    <% if result.pending_manual_conviction_check? %>
                       <strong class="app-c-tag app-c-tag--warning">
                         <%= t(".results.statuses.pending_conviction_check") %>
                       </strong>
                     <% end %>
-                    <% if transient_registration.stuck? %>
+                    <% if result.stuck? %>
                       <strong class="app-c-tag app-c-tag--danger">
                         <%= t(".results.statuses.stuck") %>
                       </strong>
@@ -101,10 +106,10 @@
                 <% end %>
               </td>
               <td>
-                <%= transient_registration.metaData.last_modified.in_time_zone("London").strftime("%H:%M %d/%m/%Y") %>
+                <%= result.metaData.last_modified.in_time_zone("London").strftime("%H:%M %d/%m/%Y") %>
               </td>
               <td>
-                <%= link_to t(".results.details_button"), transient_registration_path(transient_registration.reg_identifier) %>
+                <%= link_to t(".results.details_button"), transient_registration_path(result.reg_identifier) %>
               </td>
             </tr>
           <% end %>

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -58,9 +58,9 @@
         <thead>
           <tr>
             <th><%= t(".results.th.reg_identifier") %></th>
-            <th><%= t(".results.th.company_name") %></th>
+            <th><%= t(".results.th.business") %></th>
             <th><%= t(".results.th.status") %></th>
-            <th><%= t(".results.th.last_modified") %></th>
+            <th><%= t(".results.th.dates") %></th>
             <th><%= t(".results.th.actions") %></th>
           </tr>
         </thead>

--- a/config/locales/dashboard.en.yml
+++ b/config/locales/dashboard.en.yml
@@ -23,6 +23,8 @@ en:
           status: "Status"
           dates: "Dates"
           actions: "Actions"
+        classes:
+          renewal: "Renewal"
         statuses:
           in_progress: "application in progress"
           pending_payment: "pending payment"

--- a/config/locales/dashboard.en.yml
+++ b/config/locales/dashboard.en.yml
@@ -31,5 +31,7 @@ en:
           pending_conviction_check: "convictions"
           rejected: "rejected"
           stuck: "stuck"
+        date:
+          started: "Started %{date}"
         details_button: "Details"
         no_results: "No results found."

--- a/config/locales/dashboard.en.yml
+++ b/config/locales/dashboard.en.yml
@@ -33,5 +33,11 @@ en:
           stuck: "stuck"
         date:
           started: "Started %{date}"
-        details_button: "Details"
+        actions:
+          convictions: "Conviction details"
+          details: "Details"
+          renew: "Renew"
+          resume: "Resume application"
+          payment: "Payment details"
+          transfer: "Transfer"
         no_results: "No results found."

--- a/config/locales/dashboard.en.yml
+++ b/config/locales/dashboard.en.yml
@@ -26,9 +26,9 @@ en:
         classes:
           renewal: "Renewal"
         statuses:
-          in_progress: "application in progress"
-          pending_payment: "pending payment"
-          pending_conviction_check: "pending convictions"
+          in_progress: "in progress"
+          pending_payment: "payment needed"
+          pending_conviction_check: "convictions"
           rejected: "rejected"
           stuck: "stuck"
         details_button: "Details"

--- a/config/locales/dashboard.en.yml
+++ b/config/locales/dashboard.en.yml
@@ -19,9 +19,9 @@ en:
           other: "Found %{count} registrations"
         th:
           reg_identifier: "Registration"
-          company_name: "Company name"
-          last_modified: "Last modified"
+          business: "Business"
           status: "Status"
+          dates: "Dates"
           actions: "Actions"
         statuses:
           in_progress: "application in progress"

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ActionLinksHelper, type: :helper do
+  describe "#display_resume_link_for?" do
+    context "when the result is not a TransientRegistration" do
+      let(:result) { build(:registration) }
+
+      it "returns false" do
+        expect(helper.display_resume_link_for?(result)).to eq(false)
+      end
+    end
+
+    context "when the result is a TransientRegistration" do
+      let(:result) { build(:transient_registration) }
+
+      context "when the result has been submitted" do
+        before { result.workflow_state = "renewal_received_form" }
+
+        it "returns false" do
+          expect(helper.display_resume_link_for?(result)).to eq(false)
+        end
+      end
+
+      context "when the result is in WorldPay" do
+        before { result.workflow_state = "worldpay_form" }
+
+        it "returns false" do
+          expect(helper.display_resume_link_for?(result)).to eq(false)
+        end
+      end
+
+      context "when the result is in a resumable state" do
+        before { result.workflow_state = "location_form" }
+
+        it "returns true" do
+          expect(helper.display_resume_link_for?(result)).to eq(true)
+        end
+      end
+    end
+  end
+end

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -15,6 +15,14 @@ RSpec.describe ActionLinksHelper, type: :helper do
     context "when the result is a TransientRegistration" do
       let(:result) { build(:transient_registration) }
 
+      context "when the result has been revoked" do
+        before { result.metaData.status = "REVOKED" }
+
+        it "returns false" do
+          expect(helper.display_resume_link_for?(result)).to eq(false)
+        end
+      end
+
       context "when the result has been submitted" do
         before { result.workflow_state = "renewal_received_form" }
 
@@ -36,6 +44,44 @@ RSpec.describe ActionLinksHelper, type: :helper do
 
         it "returns true" do
           expect(helper.display_resume_link_for?(result)).to eq(true)
+        end
+      end
+    end
+  end
+
+  describe "#display_payment_link_for?" do
+    context "when the result is not a TransientRegistration" do
+      let(:result) { build(:registration) }
+
+      it "returns false" do
+        expect(helper.display_payment_link_for?(result)).to eq(false)
+      end
+    end
+
+    context "when the result is a TransientRegistration" do
+      let(:result) { build(:transient_registration) }
+
+      context "when the result has been revoked" do
+        before { result.metaData.status = "REVOKED" }
+
+        it "returns false" do
+          expect(helper.display_payment_link_for?(result)).to eq(false)
+        end
+      end
+
+      context "when the result has no pending payment" do
+        let(:result) { build(:transient_registration, :no_pending_payment) }
+
+        it "returns false" do
+          expect(helper.display_payment_link_for?(result)).to eq(false)
+        end
+      end
+
+      context "when the result has a pending payment" do
+        let(:result) { build(:transient_registration, :pending_payment) }
+
+        it "returns true" do
+          expect(helper.display_payment_link_for?(result)).to eq(true)
         end
       end
     end

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -86,4 +86,42 @@ RSpec.describe ActionLinksHelper, type: :helper do
       end
     end
   end
+
+  describe "#display_convictions_link_for?" do
+    context "when the result is not a TransientRegistration" do
+      let(:result) { build(:registration) }
+
+      it "returns false" do
+        expect(helper.display_convictions_link_for?(result)).to eq(false)
+      end
+    end
+
+    context "when the result is a TransientRegistration" do
+      let(:result) { build(:transient_registration) }
+
+      context "when the result has been revoked" do
+        before { result.metaData.status = "REVOKED" }
+
+        it "returns false" do
+          expect(helper.display_convictions_link_for?(result)).to eq(false)
+        end
+      end
+
+      context "when the result has no pending convictions check" do
+        let(:result) { build(:transient_registration, :does_not_require_conviction_check) }
+
+        it "returns false" do
+          expect(helper.display_convictions_link_for?(result)).to eq(false)
+        end
+      end
+
+      context "when the result has a pending convictions check" do
+        let(:result) { build(:transient_registration, :requires_conviction_check) }
+
+        it "returns true" do
+          expect(helper.display_convictions_link_for?(result)).to eq(true)
+        end
+      end
+    end
+  end
 end

--- a/spec/helpers/dashboards_helper_spec.rb
+++ b/spec/helpers/dashboards_helper_spec.rb
@@ -40,4 +40,42 @@ RSpec.describe DashboardsHelper, type: :helper do
       end
     end
   end
+
+  describe "#can_be_resumed?" do
+    context "when the result is not a TransientRegistration" do
+      let(:result) { build(:registration) }
+
+      it "returns false" do
+        expect(helper.can_be_resumed?(result)).to eq(false)
+      end
+    end
+
+    context "when the result is a TransientRegistration" do
+      let(:result) { build(:transient_registration) }
+
+      context "when the result has been submitted" do
+        before { result.workflow_state = "renewal_received_form" }
+
+        it "returns false" do
+          expect(helper.can_be_resumed?(result)).to eq(false)
+        end
+      end
+
+      context "when the result is in WorldPay" do
+        before { result.workflow_state = "worldpay_form" }
+
+        it "returns false" do
+          expect(helper.can_be_resumed?(result)).to eq(false)
+        end
+      end
+
+      context "when the result is in a resumable state" do
+        before { result.workflow_state = "location_form" }
+
+        it "returns true" do
+          expect(helper.can_be_resumed?(result)).to eq(true)
+        end
+      end
+    end
+  end
 end

--- a/spec/helpers/dashboards_helper_spec.rb
+++ b/spec/helpers/dashboards_helper_spec.rb
@@ -40,42 +40,4 @@ RSpec.describe DashboardsHelper, type: :helper do
       end
     end
   end
-
-  describe "#can_be_resumed?" do
-    context "when the result is not a TransientRegistration" do
-      let(:result) { build(:registration) }
-
-      it "returns false" do
-        expect(helper.can_be_resumed?(result)).to eq(false)
-      end
-    end
-
-    context "when the result is a TransientRegistration" do
-      let(:result) { build(:transient_registration) }
-
-      context "when the result has been submitted" do
-        before { result.workflow_state = "renewal_received_form" }
-
-        it "returns false" do
-          expect(helper.can_be_resumed?(result)).to eq(false)
-        end
-      end
-
-      context "when the result is in WorldPay" do
-        before { result.workflow_state = "worldpay_form" }
-
-        it "returns false" do
-          expect(helper.can_be_resumed?(result)).to eq(false)
-        end
-      end
-
-      context "when the result is in a resumable state" do
-        before { result.workflow_state = "location_form" }
-
-        it "returns true" do
-          expect(helper.can_be_resumed?(result)).to eq(true)
-        end
-      end
-    end
-  end
 end

--- a/spec/helpers/dashboards_helper_spec.rb
+++ b/spec/helpers/dashboards_helper_spec.rb
@@ -22,4 +22,22 @@ RSpec.describe DashboardsHelper, type: :helper do
       end
     end
   end
+
+  describe "#result_type" do
+    context "when the result is a TransientRegistration" do
+      let(:result) { build(:transient_registration) }
+
+      it "returns 'renewal'" do
+        expect(helper.result_type(result)).to eq("renewal")
+      end
+    end
+
+    context "when the result is not a TransientRegistration" do
+      let(:result) { build(:registration) }
+
+      it "returns nil" do
+        expect(helper.result_type(result)).to eq(nil)
+      end
+    end
+  end
 end

--- a/spec/helpers/dashboards_helper_spec.rb
+++ b/spec/helpers/dashboards_helper_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DashboardsHelper, type: :helper do
+  let(:result) { build(:transient_registration) }
+
+  describe "#inline_registration_address" do
+    context "when the address is not present" do
+      before do
+        result.addresses = nil
+      end
+
+      it "returns nil" do
+        expect(helper.inline_registered_address(result)).to eq(nil)
+      end
+    end
+
+    context "when the address is present" do
+      it "returns the correct value" do
+        expect(helper.inline_registered_address(result)).to eq("42, Foo Gardens, Baz City, FA1 1KE")
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-696

This PR includes several refinements to the design of the dashboard search results, including:

  - Updating the column titles
  - Adding organisation address under the business name
  - Adding text renewal to the status column for renewals
  - Using date renewal started in the date column
  - Adding context relevant actions to the actions column, e.g. if payment and/or conviction checks are required add links to them
  - Updating statuses to match text in wireframe