### PR TITLE
Include registrations in dashboard search

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ gem "kaminari-mongoid", "~> 1.0"
 # Use the waste carriers engine for the user journey
 gem "waste_carriers_engine",
     git: "https://github.com/DEFRA/waste-carriers-engine",
-    branch: "feature/search"
+    branch: "master"
 
 # Allows us to automatically generate the change log from the tags, issues,
 # labels and pull requests on GitHub. Added as a dependency so all dev's have

--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ gem "kaminari-mongoid", "~> 1.0"
 # Use the waste carriers engine for the user journey
 gem "waste_carriers_engine",
     git: "https://github.com/DEFRA/waste-carriers-engine",
-    branch: "master"
+    branch: "feature/search"
 
 # Allows us to automatically generate the change log from the tags, issues,
 # labels and pull requests on GitHub. Added as a dependency so all dev's have

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: a8531ed6522cfd4271bad73a95b08838eb8c6ce4
-  branch: master
+  revision: aff08d1d6d70f22852a37bc86c994a66408de8fd
+  branch: feature/search
   specs:
     waste_carriers_engine (0.0.1)
       aasm (~> 4.12)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: aff08d1d6d70f22852a37bc86c994a66408de8fd
-  branch: feature/search
+  revision: 3dfb7535787bd08c440919df4e6f4ce3716521fa
+  branch: master
   specs:
     waste_carriers_engine (0.0.1)
       aasm (~> 4.12)

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 module ActionLinksHelper
+  def display_details_link_for?(resource)
+    resource.is_a?(WasteCarriersEngine::TransientRegistration)
+  end
+
   def display_resume_link_for?(resource)
     return false unless display_transient_registration_links?(resource)
     return false if resource.renewal_application_submitted?

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -4,9 +4,19 @@ class SearchService < ::WasteCarriersEngine::BaseService
   def run(page:, term:)
     return [] if term.blank?
 
-    WasteCarriersEngine::TransientRegistration.search_term(term)
-                                              .order_by("metaData.lastModified": :desc)
-                                              .page(page)
-                                              .read(mode: :secondary)
+    @term = term
+    Kaminari.paginate_array(combined_results).page(page)
+  end
+
+  private
+
+  def combined_results
+    search(WasteCarriersEngine::TransientRegistration) + search(WasteCarriersEngine::Registration)
+  end
+
+  def search(model)
+    model.search_term(@term)
+         .order_by("metaData.lastModified": :desc)
+         .read(mode: :secondary)
   end
 end

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -79,6 +79,8 @@
                 <% end %>
               </td>
               <td>
+                <% if result.is_a?(WasteCarriersEngine::TransientRegistration) %>
+
                 <% if result_type(result).present? %>
                   <%= t(".results.classes.#{result_type(result)}") %><br>
                 <% end %>
@@ -108,6 +110,12 @@
                     <%= t(".results.statuses.in_progress") %>
                   </span>
                 <% end %>
+
+                <% else %>
+
+                  Registration
+
+                <% end %>
               </td>
               <td>
                 <%= t(".results.date.started", date: result.metaData
@@ -117,15 +125,17 @@
               </td>
               <td>
                 <ul>
-                  <li>
-                    <%= link_to transient_registration_path(result.reg_identifier) do %>
-                      <%= t(".results.actions.details.link_text") %>
-                      <span class="visually-hidden">
-                        <%= t(".results.actions.details.visually_hidden_text",
-                              name: result.company_name) %>
-                      </span>
-                    <% end %>
-                  </li>
+                  <% if display_details_link_for?(result) %>
+                    <li>
+                      <%= link_to transient_registration_path(result.reg_identifier) do %>
+                        <%= t(".results.actions.details.link_text") %>
+                        <span class="visually-hidden">
+                          <%= t(".results.actions.details.visually_hidden_text",
+                                name: result.company_name) %>
+                        </span>
+                      <% end %>
+                    </li>
+                  <% end %>
                   <% if display_resume_link_for?(result) %>
                     <li>
                       <%= link_to WasteCarriersEngine::Engine.routes.url_helpers.new_renewal_start_form_path(result.reg_identifier) do %>

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -3,6 +3,24 @@
 require "rails_helper"
 
 RSpec.describe ActionLinksHelper, type: :helper do
+  describe "#display_details_link_for?" do
+    context "when the result is not a TransientRegistration" do
+      let(:result) { build(:registration) }
+
+      it "returns false" do
+        expect(helper.display_details_link_for?(result)).to eq(false)
+      end
+    end
+
+    context "when the result is a TransientRegistration" do
+      let(:result) { build(:transient_registration) }
+
+      it "returns true" do
+        expect(helper.display_details_link_for?(result)).to eq(true)
+      end
+    end
+  end
+
   describe "#display_resume_link_for?" do
     context "when the result is not a TransientRegistration" do
       let(:result) { build(:registration) }

--- a/spec/services/search_service_spec.rb
+++ b/spec/services/search_service_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe SearchService do
   end
 
   let(:non_matching_renewal) { create(:transient_registration) }
+  let(:non_matching_registration) { WasteCarriersEngine::Registration.where(reg_identifier: non_matching_renewal.reg_identifier).first }
 
   context "when there is no search term" do
     it "returns no results" do
@@ -19,71 +20,100 @@ RSpec.describe SearchService do
   end
 
   context "when there is a search term" do
-    let(:address) { build(:address, postcode: "AB1 2CD") }
     let(:matching_renewal) do
-      create(:transient_registration,
-             company_name: "Acme",
-             last_name: "Aardvark",
-             addresses: [address])
+      create(:transient_registration)
     end
+    let(:matching_registration) { WasteCarriersEngine::Registration.where(reg_identifier: matching_renewal.reg_identifier).first }
 
     context "when there is a match on a reg_identifier" do
       let(:term) { matching_renewal.reg_identifier }
 
-      it "displays the matching result" do
+      it "displays the matching transient_registration" do
         expect(service).to include(matching_renewal)
       end
 
-      it "does not display a non-matching result" do
+      it "displays the matching registration" do
+        expect(service).to include(matching_registration)
+      end
+
+      it "does not display a non-matching transient_registration" do
         expect(service).to_not include(non_matching_renewal)
+      end
+
+      it "does not display a non-matching registration" do
+        expect(service).to_not include(non_matching_registration)
       end
     end
 
     context "when there is a match on a company_name" do
       let(:term) { matching_renewal.company_name }
 
-      it "displays the matching result" do
+      it "displays the matching transient_registration" do
         expect(service).to include(matching_renewal)
+      end
+
+      it "displays the matching registration" do
+        expect(service).to include(matching_registration)
       end
     end
 
     context "when there is a match on a last_name" do
       let(:term) { matching_renewal.last_name }
 
-      it "displays the matching result" do
+      it "displays the matching transient_registration" do
         expect(service).to include(matching_renewal)
+      end
+
+      it "displays the matching registration" do
+        expect(service).to include(matching_registration)
       end
     end
 
     context "when there is a match on a postcode" do
-      let(:term) { address.postcode }
+      let(:term) { matching_renewal.addresses.first.postcode }
 
-      it "displays the matching result" do
+      it "displays the matching transient_registration" do
         expect(service).to include(matching_renewal)
+      end
+
+      it "displays the matching registration" do
+        expect(service).to include(matching_registration)
       end
     end
 
     context "when the term has a case-insensitive match" do
       let(:term) { matching_renewal.reg_identifier.downcase }
 
-      it "includes the matching result" do
+      it "displays the matching transient_registration" do
         expect(service).to include(matching_renewal)
+      end
+
+      it "displays the matching registration" do
+        expect(service).to include(matching_registration)
       end
     end
 
     context "when there is a partial match on the reg_identifier" do
       let(:term) { matching_renewal.reg_identifier.chop }
 
-      it "does not include the partial match" do
+      it "does not include the partially-matching transient_registration" do
         expect(service).to_not include(matching_renewal)
+      end
+
+      it "does not include the partially-matching registration" do
+        expect(service).to_not include(matching_registration)
       end
     end
 
     context "when there is a partial match on the last_name" do
       let(:term) { matching_renewal.last_name.chop }
 
-      it "includes the partial match" do
+      it "includes the partially-matching transient_registration" do
         expect(service).to include(matching_renewal)
+      end
+
+      it "includes the partially-matching registration" do
+        expect(service).to include(matching_registration)
       end
     end
   end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-704

The back office dashboard search was originally designed to only look at renewals - records in the TransientRegistrations table. We want to look at the Registrations table as well so we can see completed registrations and new applications in progress.

This will require updating our search service, as well as changing the design of the dashboard to be able to handle both types of object and show the correct information and actions for them.