### PR TITLE
Display 'renew' action on renewable reg results

### DIFF
--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -21,9 +21,29 @@ module ActionLinksHelper
     resource.pending_manual_conviction_check?
   end
 
+  def display_renew_link_for?(resource)
+    return false unless display_registration_links?(resource)
+
+    reg_identifier = resource.reg_identifier
+    transient_registration = WasteCarriersEngine::TransientRegistration.where(reg_identifier: reg_identifier).first ||
+                             WasteCarriersEngine::TransientRegistration.new(reg_identifier: reg_identifier)
+    transient_registration.can_be_renewed?
+  end
+
   private
 
   def display_transient_registration_links?(resource)
-    resource.is_a?(WasteCarriersEngine::TransientRegistration) && !resource.metaData.REVOKED?
+    resource.is_a?(WasteCarriersEngine::TransientRegistration) && not_revoked_or_refused?(resource)
+  end
+
+  def display_registration_links?(resource)
+    resource.is_a?(WasteCarriersEngine::Registration) && not_revoked_or_refused?(resource)
+  end
+
+  def not_revoked_or_refused?(resource)
+    return false if resource.metaData.REVOKED?
+    return false if resource.metaData.REFUSED?
+
+    true
   end
 end

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -159,6 +159,17 @@
                       <% end %>
                     </li>
                   <% end %>
+                  <% if display_renew_link_for?(result) %>
+                    <li>
+                      <%= link_to WasteCarriersEngine::Engine.routes.url_helpers.new_renewal_start_form_path(result.reg_identifier) do %>
+                        <%= t(".results.actions.renew.link_text") %>
+                        <span class="visually-hidden">
+                          <%= t(".results.actions.renew.visually_hidden_text",
+                                name: result.company_name) %>
+                        </span>
+                      <% end %>
+                    </li>
+                  <% end %>
                 </ul>
               </td>
             </tr>

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -141,77 +141,77 @@ RSpec.describe ActionLinksHelper, type: :helper do
         end
       end
     end
+  end
 
-    describe "#display_renew_link_for?" do
-      context "when the result is not a Registration" do
-        let(:result) { build(:transient_registration) }
+  describe "#display_renew_link_for?" do
+    context "when the result is not a Registration" do
+      let(:result) { build(:transient_registration) }
+
+      it "returns false" do
+        expect(helper.display_renew_link_for?(result)).to eq(false)
+      end
+    end
+
+    context "when the result is a Registration" do
+      let(:result) { build(:registration) }
+
+      context "when the result is lower tier" do
+        before { result.tier = "LOWER" }
 
         it "returns false" do
           expect(helper.display_renew_link_for?(result)).to eq(false)
         end
       end
 
-      context "when the result is a Registration" do
-        let(:result) { build(:registration) }
+      context "when the result is upper tier" do
+        before { result.tier = "UPPER" }
 
-        context "when the result is lower tier" do
-          before { result.tier = "LOWER" }
+        context "when the result has been revoked or refused" do
+          before { result.metaData.status = %w[REVOKED REFUSED].sample }
 
           it "returns false" do
             expect(helper.display_renew_link_for?(result)).to eq(false)
           end
         end
 
-        context "when the result is upper tier" do
-          before { result.tier = "UPPER" }
+        context "when the result has not been revoked or refused" do
+          before { result.metaData.status = "ACTIVE" }
 
-          context "when the result has been revoked or refused" do
-            before { result.metaData.status = %w[REVOKED REFUSED].sample }
+          context "when the result is in the grace window" do
+            before { allow_any_instance_of(WasteCarriersEngine::ExpiryCheckService).to receive(:in_expiry_grace_window?).and_return(true) }
 
-            it "returns false" do
-              expect(helper.display_renew_link_for?(result)).to eq(false)
+            it "returns true" do
+              expect(helper.display_renew_link_for?(result)).to eq(true)
             end
           end
 
-          context "when the result has not been revoked or refused" do
-            before { result.metaData.status = "ACTIVE" }
+          context "when the result is not in the grace window" do
+            before { allow_any_instance_of(WasteCarriersEngine::ExpiryCheckService).to receive(:in_expiry_grace_window?).and_return(false) }
 
-            context "when the result is in the grace window" do
-              before { allow_any_instance_of(WasteCarriersEngine::ExpiryCheckService).to receive(:in_expiry_grace_window?).and_return(true) }
+            context "when the result is past the expiry date" do
+              before { allow_any_instance_of(WasteCarriersEngine::ExpiryCheckService).to receive(:expired?).and_return(true) }
 
-              it "returns true" do
-                expect(helper.display_renew_link_for?(result)).to eq(true)
+              it "returns false" do
+                expect(helper.display_renew_link_for?(result)).to eq(false)
               end
             end
 
-            context "when the result is not in the grace window" do
-              before { allow_any_instance_of(WasteCarriersEngine::ExpiryCheckService).to receive(:in_expiry_grace_window?).and_return(false) }
+            context "when the result is not past the expiry date" do
+              before { allow_any_instance_of(WasteCarriersEngine::ExpiryCheckService).to receive(:expired?).and_return(false) }
 
-              context "when the result is past the expiry date" do
-                before { allow_any_instance_of(WasteCarriersEngine::ExpiryCheckService).to receive(:expired?).and_return(true) }
+              context "when the result is in the renewal window" do
+                before { allow_any_instance_of(WasteCarriersEngine::ExpiryCheckService).to receive(:in_renewal_window?).and_return(true) }
 
-                it "returns false" do
-                  expect(helper.display_renew_link_for?(result)).to eq(false)
+                it "returns true" do
+                  expect(helper.display_renew_link_for?(result)).to eq(true)
                 end
               end
 
-              context "when the result is not past the expiry date" do
-                before { allow_any_instance_of(WasteCarriersEngine::ExpiryCheckService).to receive(:expired?).and_return(false) }
+              context "when the result is not in the renewal window" do
+                before { allow_any_instance_of(WasteCarriersEngine::ExpiryCheckService).to receive(:in_renewal_window?).and_return(false) }
 
-                context "when the result is in the renewal window" do
-                  before { allow_any_instance_of(WasteCarriersEngine::ExpiryCheckService).to receive(:in_renewal_window?).and_return(true) }
-
-                  it "returns true" do
-                    expect(helper.display_renew_link_for?(result)).to eq(true)
-                  end
-                end
-
-                context "when the result is not in the renewal window" do
-                  before { allow_any_instance_of(WasteCarriersEngine::ExpiryCheckService).to receive(:in_renewal_window?).and_return(false) }
-
-                  it "returns false" do
-                    expect(helper.display_renew_link_for?(result)).to eq(false)
-                  end
+                it "returns false" do
+                  expect(helper.display_renew_link_for?(result)).to eq(false)
                 end
               end
             end
@@ -219,33 +219,33 @@ RSpec.describe ActionLinksHelper, type: :helper do
         end
       end
     end
+  end
 
-    describe "#display_transfer_link_for?" do
-      context "when the result is not a Registration" do
-        let(:result) { build(:transient_registration) }
+  describe "#display_transfer_link_for?" do
+    context "when the result is not a Registration" do
+      let(:result) { build(:transient_registration) }
+
+      it "returns false" do
+        expect(helper.display_transfer_link_for?(result)).to eq(false)
+      end
+    end
+
+    context "when the result is a Registration" do
+      let(:result) { build(:registration) }
+
+      context "when the result has been revoked or refused" do
+        before { result.metaData.status = %w[REVOKED REFUSED].sample }
 
         it "returns false" do
           expect(helper.display_transfer_link_for?(result)).to eq(false)
         end
       end
 
-      context "when the result is a Registration" do
-        let(:result) { build(:registration) }
+      context "when the result is not revoked or refused" do
+        before { result.metaData.status = %w[ACTIVE EXPIRED PENDING].sample }
 
-        context "when the result has been revoked or refused" do
-          before { result.metaData.status = %w[REVOKED REFUSED].sample }
-
-          it "returns false" do
-            expect(helper.display_transfer_link_for?(result)).to eq(false)
-          end
-        end
-
-        context "when the result is not revoked or refused" do
-          before { result.metaData.status = %w[ACTIVE EXPIRED PENDING].sample }
-
-          it "returns true" do
-            expect(helper.display_transfer_link_for?(result)).to eq(true)
-          end
+        it "returns true" do
+          expect(helper.display_transfer_link_for?(result)).to eq(true)
         end
       end
     end

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -123,5 +123,47 @@ RSpec.describe ActionLinksHelper, type: :helper do
         end
       end
     end
+
+    describe "#display_renew_link_for?" do
+      context "when the result is not a Registration" do
+        let(:result) { build(:transient_registration) }
+
+        it "returns false" do
+          expect(helper.display_renew_link_for?(result)).to eq(false)
+        end
+      end
+
+      context "when the result is a Registration" do
+        let(:result) { build(:registration) }
+
+        context "when the result has been revoked or refused" do
+          before { result.metaData.status = %w[REVOKED REFUSED].sample }
+
+          it "returns false" do
+            expect(helper.display_renew_link_for?(result)).to eq(false)
+          end
+        end
+
+        context "when the result has not revoked or refused" do
+          before { result.metaData.status = "ACTIVE" }
+
+          context "when the result cannot be renewed" do
+            before { allow_any_instance_of(WasteCarriersEngine::TransientRegistration).to receive(:can_be_renewed?).and_return(false) }
+
+            it "returns false" do
+              expect(helper.display_renew_link_for?(result)).to eq(false)
+            end
+          end
+
+          context "when the result can be renewed" do
+            before { allow_any_instance_of(WasteCarriersEngine::TransientRegistration).to receive(:can_be_renewed?).and_return(true) }
+
+            it "returns true" do
+              expect(helper.display_renew_link_for?(result)).to eq(true)
+            end
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-704

Let's be honest here... the code in the helper which creates and then checks a transient_registration

```
 @@@@@@   @@@@@@@  @@@  @@@  @@@  @@@  @@@   @@@@@@
@@@@@@@   @@@@@@@  @@@  @@@@ @@@  @@@  @@@  @@@@@@@
!@@         @@!    @@!  @@!@!@@@  @@!  !@@  !@@
!@!         !@!    !@!  !@!!@!@!  !@!  @!!  !@!
!!@@!!      @!!    !!@  @!@ !!@!  @!@@!@!   !!@@!!
 !!@!!!     !!!    !!!  !@!  !!!  !!@!!!     !!@!!!
     !:!    !!:    !!:  !!:  !!!  !!: :!!        !:!
    !:!     :!:    :!:  :!:  !:!  :!:  !:!      !:!
:::: ::      ::     ::   ::   ::   ::  :::  :::: ::
:: : :       :     :    ::    :    :   :::  :: : :
```

But the way we currently determine it is really complicated and needs some proper refactoring, which would bloat the heck out of the PR/story. So this will have to do while I tackle that separately.