### PR TITLE
Display 'transfer' link on registration results

### DIFF
--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -21,9 +21,24 @@ module ActionLinksHelper
     resource.pending_manual_conviction_check?
   end
 
+  def display_transfer_link_for?(resource)
+    display_registration_links?(resource)
+  end
+
   private
 
   def display_transient_registration_links?(resource)
-    resource.is_a?(WasteCarriersEngine::TransientRegistration) && !resource.metaData.REVOKED?
+    resource.is_a?(WasteCarriersEngine::TransientRegistration) && not_revoked_or_refused?(resource)
+  end
+
+  def display_registration_links?(resource)
+    resource.is_a?(WasteCarriersEngine::Registration) && not_revoked_or_refused?(resource)
+  end
+
+  def not_revoked_or_refused?(resource)
+    return false if resource.metaData.REVOKED?
+    return false if resource.metaData.REFUSED?
+
+    true
   end
 end

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -159,6 +159,17 @@
                       <% end %>
                     </li>
                   <% end %>
+                  <% if display_transfer_link_for?(result) %>
+                    <li>
+                      <%= link_to new_registration_transfer_path(result.reg_identifier) do %>
+                        <%= t(".results.actions.transfer.link_text") %>
+                        <span class="visually-hidden">
+                          <%= t(".results.actions.transfer.visually_hidden_text",
+                                name: result.company_name) %>
+                        </span>
+                      <% end %>
+                    </li>
+                  <% end %>
                 </ul>
               </td>
             </tr>

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -123,5 +123,23 @@ RSpec.describe ActionLinksHelper, type: :helper do
         end
       end
     end
+
+    describe "#display_transfer_link_for?" do
+      context "when the result is not a Registration" do
+        let(:result) { build(:transient_registration) }
+
+        it "returns false" do
+          expect(helper.display_transfer_link_for?(result)).to eq(false)
+        end
+      end
+
+      context "when the result is a Registration" do
+        let(:result) { build(:registration) }
+
+        it "returns true" do
+          expect(helper.display_transfer_link_for?(result)).to eq(true)
+        end
+      end
+    end
   end
 end

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -154,8 +154,20 @@ RSpec.describe ActionLinksHelper, type: :helper do
       context "when the result is a Registration" do
         let(:result) { build(:registration) }
 
-        it "returns true" do
-          expect(helper.display_transfer_link_for?(result)).to eq(true)
+        context "when the result has been revoked or refused" do
+          before { result.metaData.status = %w[REVOKED REFUSED].sample }
+
+          it "returns false" do
+            expect(helper.display_transfer_link_for?(result)).to eq(false)
+          end
+        end
+
+        context "when the result is not revoked or refused" do
+          before { result.metaData.status = %w[ACTIVE EXPIRED PENDING].sample }
+
+          it "returns true" do
+            expect(helper.display_transfer_link_for?(result)).to eq(true)
+          end
         end
       end
     end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-704

All registrations should show the transfer link unless they have been revoked or refused, as no more actions are possible then.