### PR TITLE
Display correct date on search results

### DIFF
--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -18,4 +18,11 @@ module DashboardsHelper
   def status_tags(result)
     StatusTagService.run(resource: result)
   end
+
+  def result_date(result)
+    I18n.t(".dashboards.index.results.date.started", date: result.metaData
+                                                                 .last_modified
+                                                                 .in_time_zone("London")
+                                                                 .strftime("%d/%m/%Y"))
+  end
 end

--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -46,9 +46,9 @@ module DashboardsHelper
   end
 
   def last_modified_date(result)
-    I18n.t(".dashboards.index.results.date.started", date: result.metaData
-                                                                 .last_modified
-                                                                 .in_time_zone("London")
-                                                                 .strftime("%d/%m/%Y"))
+    I18n.t(".dashboards.index.results.date.last_modified", date: result.metaData
+                                                                       .last_modified
+                                                                       .in_time_zone("London")
+                                                                       .strftime("%d/%m/%Y"))
   end
 end

--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -22,6 +22,7 @@ module DashboardsHelper
   def result_date(result)
     return if refused_or_revoked?(result)
     return expired_date(result) if result.metaData.EXPIRED?
+    return will_expire_date(result) if result.is_a?(WasteCarriersEngine::Registration)
 
     last_modified_date(result)
   end
@@ -36,6 +37,12 @@ module DashboardsHelper
     I18n.t(".dashboards.index.results.date.expired", date: result.expires_on
                                                                  .in_time_zone("London")
                                                                  .strftime("%d/%m/%Y"))
+  end
+
+  def will_expire_date(result)
+    I18n.t(".dashboards.index.results.date.will_expire", date: result.expires_on
+                                                                     .in_time_zone("London")
+                                                                     .strftime("%d/%m/%Y"))
   end
 
   def last_modified_date(result)

--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -21,7 +21,8 @@ module DashboardsHelper
 
   def result_date(result)
     return if refused_or_revoked?(result)
-    return expired_date(result) if result.metaData.EXPIRED?
+
+    return expired_date(result) if result.expired?
     return will_expire_date(result) if result.is_a?(WasteCarriersEngine::Registration)
 
     last_modified_date(result)
@@ -30,7 +31,7 @@ module DashboardsHelper
   private
 
   def refused_or_revoked?(result)
-    %w[REFUSED REVOKED].include?(result.metaData.status)
+    result.refused? || result.revoked?
   end
 
   def expired_date(result)

--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -20,7 +20,7 @@ module DashboardsHelper
   end
 
   def result_date(result)
-    return if refused_or_revoked?(result)
+    return if deactivated?(result)
 
     return expired_date(result) if result.expired?
     return will_expire_date(result) if result.is_a?(WasteCarriersEngine::Registration)
@@ -30,8 +30,8 @@ module DashboardsHelper
 
   private
 
-  def refused_or_revoked?(result)
-    result.refused? || result.revoked?
+  def deactivated?(result)
+    result.inactive? || result.refused? || result.revoked?
   end
 
   def expired_date(result)

--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -35,21 +35,19 @@ module DashboardsHelper
   end
 
   def expired_date(result)
-    I18n.t(".dashboards.index.results.date.expired", date: result.expires_on
-                                                                 .in_time_zone("London")
-                                                                 .strftime("%d/%m/%Y"))
+    formatted_date(:expired, result.expires_on)
   end
 
   def will_expire_date(result)
-    I18n.t(".dashboards.index.results.date.will_expire", date: result.expires_on
-                                                                     .in_time_zone("London")
-                                                                     .strftime("%d/%m/%Y"))
+    formatted_date(:will_expire, result.expires_on)
   end
 
   def last_modified_date(result)
-    I18n.t(".dashboards.index.results.date.last_modified", date: result.metaData
-                                                                       .last_modified
-                                                                       .in_time_zone("London")
-                                                                       .strftime("%d/%m/%Y"))
+    formatted_date(:last_modified, result.metaData.last_modified)
+  end
+
+  def formatted_date(text, date)
+    date = date.in_time_zone("London").to_formatted_s(:day_month_year_slashes)
+    I18n.t(".dashboards.index.results.date.#{text}", date: date)
   end
 end

--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -20,6 +20,18 @@ module DashboardsHelper
   end
 
   def result_date(result)
+    return if refused_or_revoked?(result)
+
+    last_modified_date(result)
+  end
+
+  private
+
+  def refused_or_revoked?(result)
+    %w[REFUSED REVOKED].include?(result.metaData.status)
+  end
+
+  def last_modified_date(result)
     I18n.t(".dashboards.index.results.date.started", date: result.metaData
                                                                  .last_modified
                                                                  .in_time_zone("London")

--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -21,6 +21,7 @@ module DashboardsHelper
 
   def result_date(result)
     return if refused_or_revoked?(result)
+    return expired_date(result) if result.metaData.EXPIRED?
 
     last_modified_date(result)
   end
@@ -29,6 +30,12 @@ module DashboardsHelper
 
   def refused_or_revoked?(result)
     %w[REFUSED REVOKED].include?(result.metaData.status)
+  end
+
+  def expired_date(result)
+    I18n.t(".dashboards.index.results.date.expired", date: result.expires_on
+                                                                 .in_time_zone("London")
+                                                                 .strftime("%d/%m/%Y"))
   end
 
   def last_modified_date(result)

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -90,10 +90,7 @@
                 <% end %>
               </td>
               <td>
-                <%= t(".results.date.started", date: result.metaData
-                                                           .last_modified
-                                                           .in_time_zone("London")
-                                                           .strftime("%d/%m/%Y")) %>
+                <%= result_date(result) %>
               </td>
               <td>
                 <ul>

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+Time::DATE_FORMATS[:day_month_year_slashes] = "%d/%m/%Y"

--- a/config/locales/dashboard.en.yml
+++ b/config/locales/dashboard.en.yml
@@ -38,6 +38,7 @@ en:
         date:
           expired: "Expired %{date}"
           started: "Started %{date}"
+          will_expire: "Expires %{date}"
         actions:
           convictions:
             link_text: "Conviction details"

--- a/config/locales/dashboard.en.yml
+++ b/config/locales/dashboard.en.yml
@@ -37,7 +37,7 @@ en:
           stuck: "stuck"
         date:
           expired: "Expired %{date}"
-          started: "Started %{date}"
+          last_modified: "Last updated %{date}"
           will_expire: "Expires %{date}"
         actions:
           convictions:

--- a/config/locales/dashboard.en.yml
+++ b/config/locales/dashboard.en.yml
@@ -37,7 +37,7 @@ en:
           stuck: "stuck"
         date:
           expired: "Expired %{date}"
-          last_modified: "Last updated %{date}"
+          last_modified: "Updated %{date}"
           will_expire: "Expires %{date}"
         actions:
           convictions:

--- a/config/locales/dashboard.en.yml
+++ b/config/locales/dashboard.en.yml
@@ -36,6 +36,7 @@ en:
           revoked: "revoked"
           stuck: "stuck"
         date:
+          expired: "Expired %{date}"
           started: "Started %{date}"
         actions:
           convictions:

--- a/spec/helpers/dashboards_helper_spec.rb
+++ b/spec/helpers/dashboards_helper_spec.rb
@@ -42,9 +42,21 @@ RSpec.describe DashboardsHelper, type: :helper do
   end
 
   describe "#result_date" do
-    it "returns the expected text" do
-      date = Date.today.strftime("%d/%m/%Y")
-      expect(helper.result_date(result)).to eq("Started #{date}")
+    context "when the result is refused or revoked" do
+      before { result.metaData.status = %w[REFUSED REVOKED].sample }
+
+      it "returns nil" do
+        expect(helper.result_date(result)).to eq(nil)
+      end
+    end
+
+    context "when the result is active" do
+      before { result.metaData.status = "ACTIVE" }
+
+      it "returns the expected text" do
+        date = Date.today.strftime("%d/%m/%Y")
+        expect(helper.result_date(result)).to eq("Started #{date}")
+      end
     end
   end
 end

--- a/spec/helpers/dashboards_helper_spec.rb
+++ b/spec/helpers/dashboards_helper_spec.rb
@@ -50,6 +50,15 @@ RSpec.describe DashboardsHelper, type: :helper do
       end
     end
 
+    context "when the result is expired" do
+      before { result.metaData.status = "EXPIRED" }
+
+      it "returns the expected text" do
+        date = result.expires_on.strftime("%d/%m/%Y")
+        expect(helper.result_date(result)).to eq("Expired #{date}")
+      end
+    end
+
     context "when the result is active" do
       before { result.metaData.status = "ACTIVE" }
 

--- a/spec/helpers/dashboards_helper_spec.rb
+++ b/spec/helpers/dashboards_helper_spec.rb
@@ -60,11 +60,22 @@ RSpec.describe DashboardsHelper, type: :helper do
     end
 
     context "when the result is active" do
-      before { result.metaData.status = "ACTIVE" }
+      context "when the result is a registration" do
+        let(:result) { build(:registration, :expires_soon) }
 
-      it "returns the expected text" do
-        date = Date.today.strftime("%d/%m/%Y")
-        expect(helper.result_date(result)).to eq("Started #{date}")
+        it "returns the expected text" do
+          date = result.expires_on.strftime("%d/%m/%Y")
+          expect(helper.result_date(result)).to eq("Expires #{date}")
+        end
+      end
+
+      context "when the result is a transient_registration" do
+        let(:result) { build(:transient_registration) }
+
+        it "returns the expected text" do
+          date = Date.today.strftime("%d/%m/%Y")
+          expect(helper.result_date(result)).to eq("Last updated #{date}")
+        end
       end
     end
   end

--- a/spec/helpers/dashboards_helper_spec.rb
+++ b/spec/helpers/dashboards_helper_spec.rb
@@ -40,4 +40,11 @@ RSpec.describe DashboardsHelper, type: :helper do
       end
     end
   end
+
+  describe "#result_date" do
+    it "returns the expected text" do
+      date = Date.today.strftime("%d/%m/%Y")
+      expect(helper.result_date(result)).to eq("Started #{date}")
+    end
+  end
 end

--- a/spec/helpers/dashboards_helper_spec.rb
+++ b/spec/helpers/dashboards_helper_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe DashboardsHelper, type: :helper do
 
         it "returns the expected text" do
           date = Date.today.strftime("%d/%m/%Y")
-          expect(helper.result_date(result)).to eq("Last updated #{date}")
+          expect(helper.result_date(result)).to eq("Updated #{date}")
         end
       end
     end

--- a/spec/helpers/dashboards_helper_spec.rb
+++ b/spec/helpers/dashboards_helper_spec.rb
@@ -42,8 +42,8 @@ RSpec.describe DashboardsHelper, type: :helper do
   end
 
   describe "#result_date" do
-    context "when the result is refused or revoked" do
-      before { result.metaData.status = %w[REFUSED REVOKED].sample }
+    context "when the result is inactive, refused or revoked" do
+      before { result.metaData.status = %w[INACTIVE REFUSED REVOKED].sample }
 
       it "returns nil" do
         expect(helper.result_date(result)).to eq(nil)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-704

All search results should have something in the 'date' column, but what this is and how it is displayed varies based on the result type and its current status.