### PR TITLE
Improve contrast on 'expired' tag

### DIFF
--- a/app/assets/stylesheets/partials/_tags.scss
+++ b/app/assets/stylesheets/partials/_tags.scss
@@ -22,6 +22,7 @@
 
 .status-tag--expired {
   background-color: #b58840;
+  color: $black;
 }
 
 .status-tag--in_progress {
@@ -33,8 +34,8 @@
 }
 
 .status-tag--pending_payment {
-  color: $black;
   background-color: #f47738;
+  color: $black;
 }
 
 .status-tag--refused {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-696

The previous white text didn't have enough contrast with the background, so we switch it to black. This fixes an accessibility issue flagged during QA.