### PR TITLE
Display correct number of results on dashboard

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -7,6 +7,14 @@ class DashboardsController < ApplicationController
 
   def index
     @term = params[:term]
-    @results = SearchService.run(page: params[:page], term: @term)
+    search_and_count_results(params[:page])
+  end
+
+  private
+
+  def search_and_count_results(page)
+    result_data = SearchService.run(page: page, term: @term)
+    @result_count = result_data[:count]
+    @results = result_data[:results]
   end
 end

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -2,21 +2,34 @@
 
 class SearchService < ::WasteCarriersEngine::BaseService
   def run(page:, term:)
-    return [] if term.blank?
+    return response_hash([]) if term.blank?
 
-    @term = term
-    Kaminari.paginate_array(combined_results).page(page)
+    @page = page
+    @term = Regexp.escape(term)
+
+    response_hash(search_results)
   end
 
   private
 
-  def combined_results
-    search(WasteCarriersEngine::TransientRegistration) + search(WasteCarriersEngine::Registration)
+  def response_hash(results)
+    {
+      count: results.count,
+      results: Kaminari.paginate_array(results).page(@page)
+    }
+  end
+
+  def search_results
+    @_search_results ||= matching_resources.sort_by(&:reg_identifier)
+  end
+
+  def matching_resources
+    search(WasteCarriersEngine::Registration) + search(WasteCarriersEngine::TransientRegistration)
   end
 
   def search(model)
     model.search_term(@term)
-         .order_by("metaData.lastModified": :desc)
+         .limit(100)
          .read(mode: :secondary)
   end
 end

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -5,7 +5,7 @@ class SearchService < ::WasteCarriersEngine::BaseService
     return response_hash([]) if term.blank?
 
     @page = page
-    @term = Regexp.escape(term)
+    @term = term
 
     response_hash(search_results)
   end

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -52,7 +52,7 @@
       <table class="results">
         <caption>
           <h2 class="heading-medium">
-            <%= t(".results.caption", count: @results.count) %>
+            <%= t(".results.caption", count: @result_count) %>
           </h2>
         </caption>
         <thead>

--- a/spec/services/search_service_spec.rb
+++ b/spec/services/search_service_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe SearchService do
 
   context "when there is no search term" do
     it "returns no results" do
-      expect(service).to eq([])
+      expect(service).to eq(count: 0, results: [])
     end
   end
 
@@ -28,92 +28,120 @@ RSpec.describe SearchService do
     context "when there is a match on a reg_identifier" do
       let(:term) { matching_renewal.reg_identifier }
 
+      it "returns the correct count" do
+        expect(service[:count]).to eq(2)
+      end
+
       it "displays the matching transient_registration" do
-        expect(service).to include(matching_renewal)
+        expect(service[:results]).to include(matching_renewal)
       end
 
       it "displays the matching registration" do
-        expect(service).to include(matching_registration)
+        expect(service[:results]).to include(matching_registration)
       end
 
       it "does not display a non-matching transient_registration" do
-        expect(service).to_not include(non_matching_renewal)
+        expect(service[:results]).to_not include(non_matching_renewal)
       end
 
       it "does not display a non-matching registration" do
-        expect(service).to_not include(non_matching_registration)
+        expect(service[:results]).to_not include(non_matching_registration)
       end
     end
 
     context "when there is a match on a company_name" do
       let(:term) { matching_renewal.company_name }
 
+      it "returns the correct count" do
+        expect(service[:count]).to eq(2)
+      end
+
       it "displays the matching transient_registration" do
-        expect(service).to include(matching_renewal)
+        expect(service[:results]).to include(matching_renewal)
       end
 
       it "displays the matching registration" do
-        expect(service).to include(matching_registration)
+        expect(service[:results]).to include(matching_registration)
       end
     end
 
     context "when there is a match on a last_name" do
       let(:term) { matching_renewal.last_name }
 
+      it "returns the correct count" do
+        expect(service[:count]).to eq(2)
+      end
+
       it "displays the matching transient_registration" do
-        expect(service).to include(matching_renewal)
+        expect(service[:results]).to include(matching_renewal)
       end
 
       it "displays the matching registration" do
-        expect(service).to include(matching_registration)
+        expect(service[:results]).to include(matching_registration)
       end
     end
 
     context "when there is a match on a postcode" do
       let(:term) { matching_renewal.addresses.first.postcode }
 
+      it "returns the correct count" do
+        expect(service[:count]).to eq(2)
+      end
+
       it "displays the matching transient_registration" do
-        expect(service).to include(matching_renewal)
+        expect(service[:results]).to include(matching_renewal)
       end
 
       it "displays the matching registration" do
-        expect(service).to include(matching_registration)
+        expect(service[:results]).to include(matching_registration)
       end
     end
 
     context "when the term has a case-insensitive match" do
       let(:term) { matching_renewal.reg_identifier.downcase }
 
+      it "returns the correct count" do
+        expect(service[:count]).to eq(2)
+      end
+
       it "displays the matching transient_registration" do
-        expect(service).to include(matching_renewal)
+        expect(service[:results]).to include(matching_renewal)
       end
 
       it "displays the matching registration" do
-        expect(service).to include(matching_registration)
+        expect(service[:results]).to include(matching_registration)
       end
     end
 
     context "when there is a partial match on the reg_identifier" do
       let(:term) { matching_renewal.reg_identifier.chop }
 
+      it "returns the correct count" do
+        expect(service[:count]).to eq(0)
+      end
+
       it "does not include the partially-matching transient_registration" do
-        expect(service).to_not include(matching_renewal)
+        expect(service[:results]).to_not include(matching_renewal)
       end
 
       it "does not include the partially-matching registration" do
-        expect(service).to_not include(matching_registration)
+        expect(service[:results]).to_not include(matching_registration)
       end
     end
 
     context "when there is a partial match on the last_name" do
       let(:term) { matching_renewal.last_name.chop }
 
+      it "returns the correct count" do
+        expect(service[:count]).to eq(2)
+      end
+
       it "includes the partially-matching transient_registration" do
-        expect(service).to include(matching_renewal)
+        expect(service[:results]).to include(matching_renewal)
       end
 
       it "includes the partially-matching registration" do
-        expect(service).to include(matching_registration)
+        expect(service[:results]).to include(matching_registration)
       end
     end
   end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-696

This fixes a bug found in QA. The result count in the table caption was showing the number on the page, not the total number.

To fix this, we move pagination into the controller and out of the service, which is probably a better fit anyway.