### PR TITLE
Add 'inactive' tag text

### DIFF
--- a/app/assets/stylesheets/partials/_tags.scss
+++ b/app/assets/stylesheets/partials/_tags.scss
@@ -28,6 +28,10 @@
   background-color: #005ea5;
 }
 
+.status-tag--inactive {
+  background-color: #6f777b;
+}
+
 .status-tag--pending_conviction_check {
   background-color: #d4351c;
 }

--- a/config/locales/dashboard.en.yml
+++ b/config/locales/dashboard.en.yml
@@ -28,6 +28,7 @@ en:
         statuses:
           active: "active"
           expired: "expired"
+          inactive: "inactive"
           in_progress: "in progress"
           pending_conviction_check: "convictions"
           pending_payment: "payment needed"


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-704

Our tags didn't account for the existence of the 'inactive' status, which some existing registrations have. This was causing an I18n error, which this PR fixes.