### PR TITLE
Display 'renew' action on renewable reg results

### DIFF
--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -25,6 +25,12 @@ module ActionLinksHelper
     resource.pending_manual_conviction_check?
   end
 
+  def display_renew_link_for?(resource)
+    return false unless display_registration_links?(resource)
+
+    resource.can_start_renewal?
+  end
+
   def display_transfer_link_for?(resource)
     display_registration_links?(resource)
   end

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -141,6 +141,17 @@
                       <% end %>
                     </li>
                   <% end %>
+                  <% if display_renew_link_for?(result) %>
+                    <li>
+                      <%= link_to WasteCarriersEngine::Engine.routes.url_helpers.new_renewal_start_form_path(result.reg_identifier) do %>
+                        <%= t(".results.actions.renew.link_text") %>
+                        <span class="visually-hidden">
+                          <%= t(".results.actions.renew.visually_hidden_text",
+                                name: result.company_name) %>
+                        </span>
+                      <% end %>
+                    </li>
+                    <% end %>
                   <% if display_transfer_link_for?(result) %>
                     <li>
                       <%= link_to new_registration_transfer_path(result.reg_identifier) do %>

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -142,6 +142,36 @@ RSpec.describe ActionLinksHelper, type: :helper do
       end
     end
 
+    describe "#display_renew_link_for?" do
+      context "when the result is not a Registration" do
+        let(:result) { build(:transient_registration) }
+
+        it "returns false" do
+          expect(helper.display_renew_link_for?(result)).to eq(false)
+        end
+      end
+
+      context "when the result is a Registration" do
+        let(:result) { build(:registration) }
+
+        context "when the result cannot begin a renewal" do
+          before { allow(result).to receive(:can_start_renewal?).and_return(false) }
+
+          it "returns false" do
+            expect(helper.display_renew_link_for?(result)).to eq(false)
+          end
+        end
+
+        context "when the result can begin a renewal" do
+          before { allow(result).to receive(:can_start_renewal?).and_return(true) }
+
+          it "returns true" do
+            expect(helper.display_renew_link_for?(result)).to eq(true)
+          end
+        end
+      end
+    end
+
     describe "#display_transfer_link_for?" do
       context "when the result is not a Registration" do
         let(:result) { build(:transient_registration) }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-704

Now we have a nice method in the engine to check whether a renewal can be started, so this is a lot easier to check than it was in stinky https://github.com/DEFRA/waste-carriers-back-office/pull/385