### PR TITLE
Display 'new registration' for pending new regs

### DIFF
--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -12,7 +12,8 @@ module DashboardsHelper
   end
 
   def result_type(result)
-    return "renewal" if result.is_a?(WasteCarriersEngine::TransientRegistration)
+    return :renewal if result.is_a?(WasteCarriersEngine::TransientRegistration)
+    return :new_registration if result.pending?
   end
 
   def status_tags(result)

--- a/config/locales/dashboard.en.yml
+++ b/config/locales/dashboard.en.yml
@@ -25,6 +25,7 @@ en:
           actions: "Actions"
         classes:
           renewal: "Renewal"
+          new_registration: "New registration"
         statuses:
           active: "active"
           expired: "expired"

--- a/spec/helpers/dashboards_helper_spec.rb
+++ b/spec/helpers/dashboards_helper_spec.rb
@@ -27,16 +27,26 @@ RSpec.describe DashboardsHelper, type: :helper do
     context "when the result is a TransientRegistration" do
       let(:result) { build(:transient_registration) }
 
-      it "returns 'renewal'" do
-        expect(helper.result_type(result)).to eq("renewal")
+      it "returns :renewal" do
+        expect(helper.result_type(result)).to eq(:renewal)
       end
     end
 
     context "when the result is not a TransientRegistration" do
       let(:result) { build(:registration) }
 
-      it "returns nil" do
-        expect(helper.result_type(result)).to eq(nil)
+      context "when the result is pending" do
+        before { result.metaData.status = "PENDING" }
+
+        it "returns :new_registraton" do
+          expect(helper.result_type(result)).to eq(:new_registration)
+        end
+      end
+
+      context "when the result is not pending" do
+        it "returns nil" do
+          expect(helper.result_type(result)).to eq(nil)
+        end
       end
     end
   end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-704

Just as we display a little 'renewal' text label on in-progress renewals, we should have one for not-yet-approved new registrations.