### PR TITLE
Display convictions tag for new registrations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ gem "kaminari-mongoid", "~> 1.0"
 # Use the waste carriers engine for the user journey
 gem "waste_carriers_engine",
     git: "https://github.com/DEFRA/waste-carriers-engine",
-    branch: "master"
+    branch: "feature/reg-conviction-check"
 
 # Allows us to automatically generate the change log from the tags, issues,
 # labels and pull requests on GitHub. Added as a dependency so all dev's have

--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ gem "kaminari-mongoid", "~> 1.0"
 # Use the waste carriers engine for the user journey
 gem "waste_carriers_engine",
     git: "https://github.com/DEFRA/waste-carriers-engine",
-    branch: "feature/reg-conviction-check"
+    branch: "master"
 
 # Allows us to automatically generate the change log from the tags, issues,
 # labels and pull requests on GitHub. Added as a dependency so all dev's have

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: 410af01437fc49cd8e461947b38b40675c130f84
-  branch: feature/reg-conviction-check
+  revision: 3a35c7a9deefe3875a3262bd5f668dee0fa725ce
+  branch: master
   specs:
     waste_carriers_engine (0.0.1)
       aasm (~> 4.12)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: fc1acadc11fae5e890a4ba0eb9610dbc41da055a
-  branch: master
+  revision: 410af01437fc49cd8e461947b38b40675c130f84
+  branch: feature/reg-conviction-check
   specs:
     waste_carriers_engine (0.0.1)
       aasm (~> 4.12)

--- a/app/services/status_tag_service.rb
+++ b/app/services/status_tag_service.rb
@@ -17,6 +17,8 @@ class StatusTagService < ::WasteCarriersEngine::BaseService
 
   private
 
+  # Metadata status
+
   def metadata_status
     return :revoked if @resource.metaData.REVOKED?
     return :refused if @resource.metaData.REFUSED?
@@ -38,17 +40,37 @@ class StatusTagService < ::WasteCarriersEngine::BaseService
     @resource.metaData.status.downcase.to_sym
   end
 
+  # Conviction checks
+
   def pending_conviction_check
-    :pending_conviction_check if submitted_renewal? && @resource.pending_manual_conviction_check?
+    if transient?
+      transient_reg_pending_conviction_check
+    else
+      reg_pending_conviction_check
+    end
   end
+
+  def transient_reg_pending_conviction_check
+    :pending_conviction_check if @resource.pending_manual_conviction_check?
+  end
+
+  def reg_pending_conviction_check
+    :pending_conviction_check if @resource.conviction_check_required?
+  end
+
+  # Payments
 
   def pending_payment
     :pending_payment if submitted_renewal? && @resource.pending_payment?
   end
 
+  # Stuck
+
   def stuck
     :stuck if transient? && @resource.stuck?
   end
+
+  # Helper methods
 
   def transient?
     @_transient ||= @resource.is_a?(WasteCarriersEngine::TransientRegistration)

--- a/app/services/status_tag_service.rb
+++ b/app/services/status_tag_service.rb
@@ -43,19 +43,7 @@ class StatusTagService < ::WasteCarriersEngine::BaseService
   # Conviction checks
 
   def pending_conviction_check
-    if transient?
-      transient_reg_pending_conviction_check
-    else
-      reg_pending_conviction_check
-    end
-  end
-
-  def transient_reg_pending_conviction_check
-    :pending_conviction_check if @resource.pending_manual_conviction_check?
-  end
-
-  def reg_pending_conviction_check
-    :pending_conviction_check if @resource.conviction_check_required?
+    :pending_conviction_check if registration_or_submitted_renewal? && @resource.pending_manual_conviction_check?
   end
 
   # Payments
@@ -78,5 +66,9 @@ class StatusTagService < ::WasteCarriersEngine::BaseService
 
   def submitted_renewal?
     @_submitted_renewal ||= transient? && @resource.renewal_application_submitted?
+  end
+
+  def registration_or_submitted_renewal?
+    @_registration_or_submitted_renewal ||= submitted_renewal? || !transient?
   end
 end

--- a/spec/services/status_tag_service_spec.rb
+++ b/spec/services/status_tag_service_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe StatusTagService do
     end
 
     context "when there is a pending conviction check" do
-      before { allow(resource).to receive(:conviction_check_required?).and_return(true) }
+      before { allow(resource).to receive(:pending_manual_conviction_check?).and_return(true) }
 
       it "includes :pending_conviction_check in the response" do
         expect(service).to include(:pending_conviction_check)
@@ -37,7 +37,7 @@ RSpec.describe StatusTagService do
     end
 
     context "when there is not a pending conviction check" do
-      before { allow(resource).to receive(:conviction_check_required?).and_return(false) }
+      before { allow(resource).to receive(:pending_manual_conviction_check?).and_return(false) }
 
       it "does not include :pending_conviction_check in the response" do
         expect(service).to_not include(:pending_conviction_check)

--- a/spec/services/status_tag_service_spec.rb
+++ b/spec/services/status_tag_service_spec.rb
@@ -28,8 +28,20 @@ RSpec.describe StatusTagService do
       end
     end
 
-    it "does not include :pending_conviction_check in the response" do
-      expect(service).to_not include(:pending_conviction_check)
+    context "when there is a pending conviction check" do
+      before { allow(resource).to receive(:conviction_check_required?).and_return(true) }
+
+      it "includes :pending_conviction_check in the response" do
+        expect(service).to include(:pending_conviction_check)
+      end
+    end
+
+    context "when there is not a pending conviction check" do
+      before { allow(resource).to receive(:conviction_check_required?).and_return(false) }
+
+      it "does not include :pending_conviction_check in the response" do
+        expect(service).to_not include(:pending_conviction_check)
+      end
     end
 
     it "does not include :pending_payment in the response" do


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-704

There's no 'submitted' state for a new registration at the moment, so we will display this tag as soon as the registration is in the database and is known to require a convictions check. So slightly different behaviour from renewals for now but this will be aligned.