### PR TITLE
Move action link paths to helper

### DIFF
--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -1,6 +1,42 @@
 # frozen_string_literal: true
 
 module ActionLinksHelper
+  def details_link_for(resource)
+    return "#" unless resource.is_a?(WasteCarriersEngine::TransientRegistration)
+
+    transient_registration_path(resource.reg_identifier)
+  end
+
+  def resume_link_for(resource)
+    return "#" unless resource.is_a?(WasteCarriersEngine::TransientRegistration)
+
+    WasteCarriersEngine::Engine.routes.url_helpers.new_renewal_start_form_path(resource.reg_identifier)
+  end
+
+  def payment_link_for(resource)
+    return "#" unless resource.is_a?(WasteCarriersEngine::TransientRegistration)
+
+    transient_registration_payments_path(resource.reg_identifier)
+  end
+
+  def convictions_link_for(resource)
+    return "#" unless resource.is_a?(WasteCarriersEngine::TransientRegistration)
+
+    transient_registration_convictions_path(resource.reg_identifier)
+  end
+
+  def renew_link_for(resource)
+    return "#" unless resource.is_a?(WasteCarriersEngine::Registration)
+
+    WasteCarriersEngine::Engine.routes.url_helpers.new_renewal_start_form_path(resource.reg_identifier)
+  end
+
+  def transfer_link_for(resource)
+    return "#" unless resource.is_a?(WasteCarriersEngine::Registration)
+
+    new_registration_transfer_path(resource.reg_identifier)
+  end
+
   def display_details_link_for?(resource)
     resource.is_a?(WasteCarriersEngine::TransientRegistration)
   end

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -96,7 +96,7 @@
                 <ul>
                   <% if display_details_link_for?(result) %>
                     <li>
-                      <%= link_to transient_registration_path(result.reg_identifier) do %>
+                      <%= link_to details_link_for(result) do %>
                         <%= t(".results.actions.details.link_text") %>
                         <span class="visually-hidden">
                           <%= t(".results.actions.details.visually_hidden_text",
@@ -107,7 +107,7 @@
                   <% end %>
                   <% if display_resume_link_for?(result) %>
                     <li>
-                      <%= link_to WasteCarriersEngine::Engine.routes.url_helpers.new_renewal_start_form_path(result.reg_identifier) do %>
+                      <%= link_to resume_link_for(result) do %>
                         <%= t(".results.actions.resume.link_text") %>
                         <span class="visually-hidden">
                           <%= t(".results.actions.resume.visually_hidden_text",
@@ -118,7 +118,7 @@
                   <% end %>
                   <% if display_payment_link_for?(result) %>
                     <li>
-                      <%= link_to transient_registration_payments_path(result.reg_identifier) do %>
+                      <%= link_to payment_link_for(result) do %>
                         <%= t(".results.actions.payment.link_text") %>
                         <span class="visually-hidden">
                           <%= t(".results.actions.payment.visually_hidden_text",
@@ -129,7 +129,7 @@
                   <% end %>
                   <% if display_convictions_link_for?(result) %>
                     <li>
-                      <%= link_to transient_registration_convictions_path(result.reg_identifier) do %>
+                      <%= link_to convictions_link_for(result) do %>
                         <%= t(".results.actions.convictions.link_text") %>
                         <span class="visually-hidden">
                           <%= t(".results.actions.convictions.visually_hidden_text",
@@ -140,7 +140,7 @@
                   <% end %>
                   <% if display_renew_link_for?(result) %>
                     <li>
-                      <%= link_to WasteCarriersEngine::Engine.routes.url_helpers.new_renewal_start_form_path(result.reg_identifier) do %>
+                      <%= link_to renew_link_for(result) do %>
                         <%= t(".results.actions.renew.link_text") %>
                         <span class="visually-hidden">
                           <%= t(".results.actions.renew.visually_hidden_text",
@@ -151,7 +151,7 @@
                     <% end %>
                   <% if display_transfer_link_for?(result) %>
                     <li>
-                      <%= link_to new_registration_transfer_path(result.reg_identifier) do %>
+                      <%= link_to transfer_link_for(result) do %>
                         <%= t(".results.actions.transfer.link_text") %>
                         <span class="visually-hidden">
                           <%= t(".results.actions.transfer.visually_hidden_text",

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -3,6 +3,114 @@
 require "rails_helper"
 
 RSpec.describe ActionLinksHelper, type: :helper do
+  describe "details_link_for" do
+    context "when the resource is a transient_registration" do
+      let(:resource) { build(:transient_registration) }
+
+      it "returns the correct path" do
+        expect(helper.details_link_for(resource)).to eq(transient_registration_path(resource.reg_identifier))
+      end
+    end
+
+    context "when the resource is not a transient_registration" do
+      let(:resource) { build(:registration) }
+
+      it "returns the correct path" do
+        expect(helper.details_link_for(resource)).to eq("#")
+      end
+    end
+  end
+
+  describe "resume_link_for" do
+    context "when the resource is a transient_registration" do
+      let(:resource) { build(:transient_registration) }
+
+      it "returns the correct path" do
+        expect(helper.resume_link_for(resource)).to eq(WasteCarriersEngine::Engine.routes.url_helpers.new_renewal_start_form_path(resource.reg_identifier))
+      end
+    end
+
+    context "when the resource is not a transient_registration" do
+      let(:resource) { build(:registration) }
+
+      it "returns the correct path" do
+        expect(helper.resume_link_for(resource)).to eq("#")
+      end
+    end
+  end
+
+  describe "payment_link_for" do
+    context "when the resource is a transient_registration" do
+      let(:resource) { build(:transient_registration) }
+
+      it "returns the correct path" do
+        expect(helper.payment_link_for(resource)).to eq(transient_registration_payments_path(resource.reg_identifier))
+      end
+    end
+
+    context "when the resource is not a transient_registration" do
+      let(:resource) { build(:registration) }
+
+      it "returns the correct path" do
+        expect(helper.payment_link_for(resource)).to eq("#")
+      end
+    end
+  end
+
+  describe "convictions_link_for" do
+    context "when the resource is a transient_registration" do
+      let(:resource) { build(:transient_registration) }
+
+      it "returns the correct path" do
+        expect(helper.convictions_link_for(resource)).to eq(transient_registration_convictions_path(resource.reg_identifier))
+      end
+    end
+
+    context "when the resource is not a transient_registration" do
+      let(:resource) { build(:registration) }
+
+      it "returns the correct path" do
+        expect(helper.convictions_link_for(resource)).to eq("#")
+      end
+    end
+  end
+
+  describe "renew_link_for" do
+    context "when the resource is a registration" do
+      let(:resource) { create(:registration) }
+
+      it "returns the correct path" do
+        expect(helper.renew_link_for(resource)).to eq(WasteCarriersEngine::Engine.routes.url_helpers.new_renewal_start_form_path(resource.reg_identifier))
+      end
+    end
+
+    context "when the resource is not a registration" do
+      let(:resource) { create(:transient_registration) }
+
+      it "returns the correct path" do
+        expect(helper.renew_link_for(resource)).to eq("#")
+      end
+    end
+  end
+
+  describe "transfer_link_for" do
+    context "when the resource is a registration" do
+      let(:resource) { create(:registration) }
+
+      it "returns the correct path" do
+        expect(helper.transfer_link_for(resource)).to eq(new_registration_transfer_path(resource.reg_identifier))
+      end
+    end
+
+    context "when the resource is not a registration" do
+      let(:resource) { create(:transient_registration) }
+
+      it "returns the correct path" do
+        expect(helper.transfer_link_for(resource)).to eq("#")
+      end
+    end
+  end
+
   describe "#display_details_link_for?" do
     context "when the result is not a TransientRegistration" do
       let(:result) { build(:registration) }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-704

This is more in line with WEX. It also means that when we start having different routes for registrations vs transient_registrations, we can handle that in the helper without messing up the view.