### PR TITLE
Add conviction check link for new registrations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ gem "kaminari-mongoid", "~> 1.0"
 # Use the waste carriers engine for the user journey
 gem "waste_carriers_engine",
     git: "https://github.com/DEFRA/waste-carriers-engine",
-    branch: "master"
+    branch: "feature/reg-conviction-check"
 
 # Allows us to automatically generate the change log from the tags, issues,
 # labels and pull requests on GitHub. Added as a dependency so all dev's have

--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ gem "kaminari-mongoid", "~> 1.0"
 # Use the waste carriers engine for the user journey
 gem "waste_carriers_engine",
     git: "https://github.com/DEFRA/waste-carriers-engine",
-    branch: "feature/reg-conviction-check"
+    branch: "master"
 
 # Allows us to automatically generate the change log from the tags, issues,
 # labels and pull requests on GitHub. Added as a dependency so all dev's have

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: 410af01437fc49cd8e461947b38b40675c130f84
-  branch: feature/reg-conviction-check
+  revision: 3a35c7a9deefe3875a3262bd5f668dee0fa725ce
+  branch: master
   specs:
     waste_carriers_engine (0.0.1)
       aasm (~> 4.12)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: 49586c1336b5658dd50c8c3bdb013987f50f4905
-  branch: master
+  revision: 410af01437fc49cd8e461947b38b40675c130f84
+  branch: feature/reg-conviction-check
   specs:
     waste_carriers_engine (0.0.1)
       aasm (~> 4.12)

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -60,7 +60,7 @@ module ActionLinksHelper
   end
 
   def display_convictions_link_for?(resource)
-    return false unless display_transient_registration_links?(resource)
+    return false unless display_transient_registration_links?(resource) || display_registration_links?(resource)
     return false unless can?(:review_convictions, resource)
 
     resource.pending_manual_conviction_check?

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -20,9 +20,13 @@ module ActionLinksHelper
   end
 
   def convictions_link_for(resource)
-    return "#" unless resource.is_a?(WasteCarriersEngine::TransientRegistration)
-
-    transient_registration_convictions_path(resource.reg_identifier)
+    if resource.is_a?(WasteCarriersEngine::TransientRegistration)
+      transient_registration_convictions_path(resource.reg_identifier)
+    elsif resource.is_a?(WasteCarriersEngine::Registration)
+      "#{Rails.configuration.wcrs_frontend_url}/registrations/#{resource.id}/approve"
+    else
+      "#"
+    end
   end
 
   def renew_link_for(resource)

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -66,8 +66,17 @@ RSpec.describe ActionLinksHelper, type: :helper do
       end
     end
 
-    context "when the resource is not a transient_registration" do
+    context "when the resource is a registration" do
       let(:resource) { build(:registration) }
+
+      it "returns the correct path" do
+        path = "#{Rails.configuration.wcrs_frontend_url}/registrations/#{resource.id}/approve"
+        expect(helper.convictions_link_for(resource)).to eq(path)
+      end
+    end
+
+    context "when the resource is not a registration or a transient_registration" do
+      let(:resource) { nil }
 
       it "returns the correct path" do
         expect(helper.convictions_link_for(resource)).to eq("#")


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-704

Currently we only display the conviction links for renewals. This PR will add the link for relevant new registrations too.