### PR TITLE
Add payment link for new registrations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: 49586c1336b5658dd50c8c3bdb013987f50f4905
+  revision: 31aff6a0c33a24aace5d8bfe2c6c4d9ff810e705
   branch: master
   specs:
     waste_carriers_engine (0.0.1)

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -14,9 +14,13 @@ module ActionLinksHelper
   end
 
   def payment_link_for(resource)
-    return "#" unless resource.is_a?(WasteCarriersEngine::TransientRegistration)
-
-    transient_registration_payments_path(resource.reg_identifier)
+    if resource.is_a?(WasteCarriersEngine::TransientRegistration)
+      transient_registration_payments_path(resource.reg_identifier)
+    elsif resource.is_a?(WasteCarriersEngine::Registration)
+      "#{Rails.configuration.wcrs_frontend_url}/registrations/#{resource.id}/paymentstatus"
+    else
+      "#"
+    end
   end
 
   def convictions_link_for(resource)

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -54,7 +54,7 @@ module ActionLinksHelper
   end
 
   def display_payment_link_for?(resource)
-    return false unless display_transient_registration_links?(resource)
+    return false unless display_transient_registration_links?(resource) || display_registration_links?(resource)
 
     resource.pending_payment?
   end

--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -22,5 +22,13 @@ FactoryBot.define do
       metaData { build(:metaData, status: :ACTIVE) }
       expires_on { 2.months.from_now }
     end
+
+    trait :pending_payment do
+      finance_details { build(:finance_details, :positive_balance) }
+    end
+
+    trait :no_pending_payment do
+      finance_details { build(:finance_details, :zero_balance) }
+    end
   end
 end

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -197,11 +197,31 @@ RSpec.describe ActionLinksHelper, type: :helper do
   end
 
   describe "#display_payment_link_for?" do
-    context "when the result is not a TransientRegistration" do
+    context "when the result is a Registration" do
       let(:result) { build(:registration) }
 
-      it "returns false" do
-        expect(helper.display_payment_link_for?(result)).to eq(false)
+      context "when the result has been revoked" do
+        before { result.metaData.status = "REVOKED" }
+
+        it "returns false" do
+          expect(helper.display_payment_link_for?(result)).to eq(false)
+        end
+      end
+
+      context "when the result has no pending payment" do
+        let(:result) { build(:registration, :no_pending_payment) }
+
+        it "returns false" do
+          expect(helper.display_payment_link_for?(result)).to eq(false)
+        end
+      end
+
+      context "when the result has a pending payment" do
+        let(:result) { build(:registration, :pending_payment) }
+
+        it "returns true" do
+          expect(helper.display_payment_link_for?(result)).to eq(true)
+        end
       end
     end
 

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -48,8 +48,17 @@ RSpec.describe ActionLinksHelper, type: :helper do
       end
     end
 
-    context "when the resource is not a transient_registration" do
+    context "when the resource is a registration" do
       let(:resource) { build(:registration) }
+
+      it "returns the correct path" do
+        path = "#{Rails.configuration.wcrs_frontend_url}/registrations/#{resource.id}/paymentstatus"
+        expect(helper.payment_link_for(resource)).to eq(path)
+      end
+    end
+
+    context "when the resource is not a registration or a transient_registration" do
+      let(:resource) { nil }
 
       it "returns the correct path" do
         expect(helper.payment_link_for(resource)).to eq("#")


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-704

Currently we only display the payment links for renewals. This PR will add the link for relevant new registrations too.