### PR TITLE
Apply role permissions to dashboard links

### DIFF
--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -33,7 +33,9 @@ module ActionLinksHelper
   end
 
   def display_transfer_link_for?(resource)
-    display_registration_links?(resource)
+    return false unless display_registration_links?(resource)
+
+    can?(:transfer, resource)
   end
 
   private

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -10,7 +10,7 @@ module ActionLinksHelper
     return false if resource.renewal_application_submitted?
     return false if resource.workflow_state == "worldpay_form"
 
-    can?(:update, resource)
+    can?(:renew, resource)
   end
 
   def display_payment_link_for?(resource)
@@ -28,6 +28,7 @@ module ActionLinksHelper
 
   def display_renew_link_for?(resource)
     return false unless display_registration_links?(resource)
+    return false unless can?(:renew, resource)
 
     resource.can_start_renewal?
   end

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -21,6 +21,7 @@ module ActionLinksHelper
 
   def display_convictions_link_for?(resource)
     return false unless display_transient_registration_links?(resource)
+    return false unless can?(:review_convictions, resource)
 
     resource.pending_manual_conviction_check?
   end

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -10,7 +10,7 @@ module ActionLinksHelper
     return false if resource.renewal_application_submitted?
     return false if resource.workflow_state == "worldpay_form"
 
-    true
+    can?(:update, resource)
   end
 
   def display_payment_link_for?(resource)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -18,6 +18,7 @@ class Ability
   def permissions_for_agency_user_group
     # This covers everything mounted in the engine and used for the assisted digital journey, including WorldPay
     can :update, WasteCarriersEngine::TransientRegistration
+    can :renew, :all
 
     can :record_cash_payment, WasteCarriersEngine::TransientRegistration
     can :record_cheque_payment, WasteCarriersEngine::TransientRegistration

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -24,7 +24,7 @@ class Ability
     can :record_cheque_payment, WasteCarriersEngine::TransientRegistration
     can :record_postal_order_payment, WasteCarriersEngine::TransientRegistration
 
-    can :review_convictions, WasteCarriersEngine::TransientRegistration
+    can :review_convictions, :all
 
     can :revert_to_payment_summary, WasteCarriersEngine::TransientRegistration
 

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -219,8 +219,20 @@ RSpec.describe ActionLinksHelper, type: :helper do
         context "when the result is not revoked or refused" do
           before { result.metaData.status = %w[ACTIVE EXPIRED PENDING].sample }
 
-          it "returns true" do
-            expect(helper.display_transfer_link_for?(result)).to eq(true)
+          context "when the user does not have permission" do
+            before { allow(helper).to receive(:can?).and_return(false) }
+
+            it "returns false" do
+              expect(helper.display_transfer_link_for?(result)).to eq(false)
+            end
+          end
+
+          context "when the user has permission" do
+            before { allow(helper).to receive(:can?).and_return(true) }
+
+            it "returns true" do
+              expect(helper.display_transfer_link_for?(result)).to eq(true)
+            end
           end
         end
       end

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -178,19 +178,31 @@ RSpec.describe ActionLinksHelper, type: :helper do
       context "when the result is a Registration" do
         let(:result) { build(:registration) }
 
-        context "when the result cannot begin a renewal" do
-          before { allow(result).to receive(:can_start_renewal?).and_return(false) }
+        context "when the user does not have permission" do
+          before { allow(helper).to receive(:can?).and_return(false) }
 
           it "returns false" do
             expect(helper.display_renew_link_for?(result)).to eq(false)
           end
         end
 
-        context "when the result can begin a renewal" do
-          before { allow(result).to receive(:can_start_renewal?).and_return(true) }
+        context "when the user has permission" do
+          before { allow(helper).to receive(:can?).and_return(true) }
 
-          it "returns true" do
-            expect(helper.display_renew_link_for?(result)).to eq(true)
+          context "when the result cannot begin a renewal" do
+            before { allow(result).to receive(:can_start_renewal?).and_return(false) }
+
+            it "returns false" do
+              expect(helper.display_renew_link_for?(result)).to eq(false)
+            end
+          end
+
+          context "when the result can begin a renewal" do
+            before { allow(result).to receive(:can_start_renewal?).and_return(true) }
+
+            it "returns true" do
+              expect(helper.display_renew_link_for?(result)).to eq(true)
+            end
           end
         end
       end

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -60,8 +60,20 @@ RSpec.describe ActionLinksHelper, type: :helper do
       context "when the result is in a resumable state" do
         before { result.workflow_state = "location_form" }
 
-        it "returns true" do
-          expect(helper.display_resume_link_for?(result)).to eq(true)
+        context "when the user does not have permission" do
+          before { allow(helper).to receive(:can?).and_return(false) }
+
+          it "returns false" do
+            expect(helper.display_resume_link_for?(result)).to eq(false)
+          end
+        end
+
+        context "when the user has permission" do
+          before { allow(helper).to receive(:can?).and_return(true) }
+
+          it "returns true" do
+            expect(helper.display_resume_link_for?(result)).to eq(true)
+          end
         end
       end
     end

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -137,19 +137,31 @@ RSpec.describe ActionLinksHelper, type: :helper do
         end
       end
 
-      context "when the result has no pending convictions check" do
-        let(:result) { build(:transient_registration, :does_not_require_conviction_check) }
+      context "when the user does not have permission" do
+        before { allow(helper).to receive(:can?).and_return(false) }
 
         it "returns false" do
           expect(helper.display_convictions_link_for?(result)).to eq(false)
         end
       end
 
-      context "when the result has a pending convictions check" do
-        let(:result) { build(:transient_registration, :requires_conviction_check) }
+      context "when the user has permission" do
+        before { allow(helper).to receive(:can?).and_return(true) }
 
-        it "returns true" do
-          expect(helper.display_convictions_link_for?(result)).to eq(true)
+        context "when the result has no pending convictions check" do
+          let(:result) { build(:transient_registration, :does_not_require_conviction_check) }
+
+          it "returns false" do
+            expect(helper.display_convictions_link_for?(result)).to eq(false)
+          end
+        end
+
+        context "when the result has a pending convictions check" do
+          let(:result) { build(:transient_registration, :requires_conviction_check) }
+
+          it "returns true" do
+            expect(helper.display_convictions_link_for?(result)).to eq(true)
+          end
         end
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -68,6 +68,11 @@ RSpec.describe User, type: :model do
         should be_able_to(:update, transient_registration)
       end
 
+      it "should be able to renew" do
+        should be_able_to(:renew, transient_registration)
+        should be_able_to(:renew, registration)
+      end
+
       it "should be able to record a cash payment" do
         should be_able_to(:record_cash_payment, transient_registration)
       end
@@ -126,6 +131,11 @@ RSpec.describe User, type: :model do
 
       it "should be able to update a transient registration" do
         should be_able_to(:update, transient_registration)
+      end
+
+      it "should be able to renew" do
+        should be_able_to(:renew, transient_registration)
+        should be_able_to(:renew, registration)
       end
 
       it "should be able to record a cash payment" do
@@ -188,6 +198,11 @@ RSpec.describe User, type: :model do
         should_not be_able_to(:update, transient_registration)
       end
 
+      it "should not be able to renew" do
+        should_not be_able_to(:renew, transient_registration)
+        should_not be_able_to(:renew, registration)
+      end
+
       it "should not be able to record a cash payment" do
         should_not be_able_to(:record_cash_payment, transient_registration)
       end
@@ -246,6 +261,11 @@ RSpec.describe User, type: :model do
 
       it "should not be able to update a transient registration" do
         should_not be_able_to(:update, transient_registration)
+      end
+
+      it "should not be able to renew" do
+        should_not be_able_to(:renew, transient_registration)
+        should_not be_able_to(:renew, registration)
       end
 
       it "should not be able to record a cash payment" do
@@ -308,6 +328,11 @@ RSpec.describe User, type: :model do
         should be_able_to(:update, transient_registration)
       end
 
+      it "should be able to renew" do
+        should be_able_to(:renew, transient_registration)
+        should be_able_to(:renew, registration)
+      end
+
       it "should be able to record a cash payment" do
         should be_able_to(:record_cash_payment, transient_registration)
       end
@@ -366,6 +391,11 @@ RSpec.describe User, type: :model do
 
       it "should not be able to update a transient registration" do
         should_not be_able_to(:update, transient_registration)
+      end
+
+      it "should_not be able to renew" do
+        should_not be_able_to(:renew, transient_registration)
+        should_not be_able_to(:renew, registration)
       end
 
       it "should not be able to record a cash payment" do


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-704

Agency users vs finance users have different abilities for what tasks they can and cannot do. So we shouldn't display links to actions which aren't possible or relevant.