### PR TITLE
Display payment tag for new registrations

### DIFF
--- a/app/services/status_tag_service.rb
+++ b/app/services/status_tag_service.rb
@@ -43,7 +43,7 @@ class StatusTagService < ::WasteCarriersEngine::BaseService
   end
 
   def pending_payment
-    :pending_payment if submitted_renewal? && @resource.pending_payment?
+    :pending_payment if registration_or_submitted_renewal? && @resource.pending_payment?
   end
 
   def stuck
@@ -56,5 +56,9 @@ class StatusTagService < ::WasteCarriersEngine::BaseService
 
   def submitted_renewal?
     @_submitted_renewal ||= transient? && @resource.renewal_application_submitted?
+  end
+
+  def registration_or_submitted_renewal?
+    @_registration_or_submitted_renewal ||= submitted_renewal? || !transient?
   end
 end

--- a/spec/services/status_tag_service_spec.rb
+++ b/spec/services/status_tag_service_spec.rb
@@ -32,8 +32,20 @@ RSpec.describe StatusTagService do
       expect(service).to_not include(:pending_conviction_check)
     end
 
-    it "does not include :pending_payment in the response" do
-      expect(service).to_not include(:pending_payment)
+    context "when there is a pending payment" do
+      before { allow(resource).to receive(:pending_payment?).and_return(true) }
+
+      it "includes :pending_payment in the response" do
+        expect(service).to include(:pending_payment)
+      end
+    end
+
+    context "when there is not a pending payment" do
+      before { allow(resource).to receive(:pending_payment?).and_return(false) }
+
+      it "does not include :pending_payment in the response" do
+        expect(service).to_not include(:pending_payment)
+      end
     end
 
     it "does not include :stuck in the response" do


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-704

There's no 'submitted' state for a new registration at the moment, so we will display this tag as soon as the registration is in the database and has an unpaid balance. So slightly different behaviour from renewals for now but this will be aligned.