### PR TITLE
Remove about this renewal section in registration details page

### DIFF
--- a/app/views/transient_registrations/show.html.erb
+++ b/app/views/transient_registrations/show.html.erb
@@ -403,29 +403,6 @@
             </tbody>
           </table>
         <% end %>
-        <table>
-          <caption class="heading-medium">
-            <%= t(".renewal_information.heading") %>
-          </caption>
-          <tbody>
-            <tr>
-              <td>
-                <%= t(".renewal_information.labels.workflow_state") %>
-              </td>
-              <td>
-                <%= display_current_workflow_state %>
-              </td>
-            </tr>
-            <tr>
-              <td>
-                <%= t(".renewal_information.labels.declaration") %>
-              </td>
-              <td>
-                <%= show_translation_or_filler(:declaration) %>
-              </td>
-            </tr>
-          </tbody>
-        </table>
       </div>
       <div class="column-one-third">
         <div class="actions actions--push-down">

--- a/config/locales/transient_registrations.en.yml
+++ b/config/locales/transient_registrations.en.yml
@@ -123,11 +123,6 @@ en:
         heading: "Registration cards (copy cards)"
         labels:
           temp_cards: "Number of cards ordered"
-      renewal_information:
-        heading: "About this renewal"
-        labels:
-          workflow_state: "Current form"
-          declaration: "Signed declaration?"
       attributes:
         business_type:
           soleTrader: "Individual or sole trader"


### PR DESCRIPTION
Closes: https://eaflood.atlassian.net/browse/RUBY-712

Remove the "About this renewal" section in the registration details page