### PR TITLE
Add prefix to CSS wcr specific objects

### DIFF
--- a/app/assets/stylesheets/partials/_wcr-objects.scss
+++ b/app/assets/stylesheets/partials/_wcr-objects.scss
@@ -1,4 +1,4 @@
-.actions {
+.wcr-actions {
   background-color: #f8f8f8;
   padding: 0.5em;
 

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -32,7 +32,7 @@
   </div>
 
   <div class="column-one-third">
-    <div class="actions">
+    <div class="wcr-actions">
       <h2 class="heading-small">
         <%= t(".actions.subheading") %>
       </h2>

--- a/app/views/transient_registrations/show.html.erb
+++ b/app/views/transient_registrations/show.html.erb
@@ -428,7 +428,7 @@
         </table>
       </div>
       <div class="column-one-third">
-        <div class="actions actions--push-down">
+        <div class="wcr-actions wcr-actions--push-down">
           <h3 class="heading-medium">
             <%= t(".actions_box.heading", reg_identifier: @transient_registration.reg_identifier) %>
           </h3>


### PR DESCRIPTION
Closes: https://eaflood.atlassian.net/browse/RUBY-735

The background on the start button comes from class names clashing. Hence I have added a `wcr` prefix on our classes from the `wcr-objects` partial, in-line with Iris fix.