### PR TITLE
Remove convictions link from details page actions

### DIFF
--- a/app/views/transient_registrations/show.html.erb
+++ b/app/views/transient_registrations/show.html.erb
@@ -362,12 +362,6 @@
                 <%= link_to t(".actions_box.links.payment"), transient_registration_payments_path(@transient_registration.reg_identifier) %>
               </li>
             <% end %>
-
-            <% if @transient_registration.pending_manual_conviction_check? %>
-              <li>
-                <%= link_to t(".actions_box.links.convictions"), transient_registration_convictions_path(@transient_registration.reg_identifier) %>
-              </li>
-            <% end %>
           </ul>
         </div>
       <div>

--- a/config/locales/transient_registrations.en.yml
+++ b/config/locales/transient_registrations.en.yml
@@ -4,7 +4,6 @@ en:
       actions_box:
         heading: "Actions for %{reg_identifier}"
         links:
-          convictions: "Process convictions"
           payment: "Process payment"
       title: "Renewal details"
       heading: "Registration %{reg_identifier}"


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-710

We decided that we don't want the convictions link in the actions box any more.