### PR TITLE
Match details top page with wireframes

### DIFF
--- a/app/views/transient_registrations/show.html.erb
+++ b/app/views/transient_registrations/show.html.erb
@@ -17,23 +17,28 @@
             </p>
           </div>
         <% elsif @transient_registration.renewal_application_submitted? %>
-          <div class="panel">
-            <h2 class="heading-medium">
-              <%= t(".status.headings.submitted") %>
-            </h2>
-            <% if @transient_registration.pending_payment? && @transient_registration.pending_manual_conviction_check? %>
+          <% if @transient_registration.pending_manual_conviction_check? %>
+            <div class="panel">
+              <h2 class="heading-medium">
+                <%= t(".status.headings.pending_convictions") %>
+              </h2>
               <p>
-                <%= t(".status.messages.pending_payment_and_convictions_check") %>
+                <%= t(".status.messages.pending_convictions_check") %>
+              </p>
+            </div>
+          <% end %>
+
+          <% if @transient_registration.pending_payment? %>
+            <div class="panel">
+              <h2 class="heading-medium">
+                <%= t(".status.headings.pending_payment") %>
+              </h2>
+              <p>
+                <%= t(".status.messages.pending_payment", total: display_pence_as_pounds(@transient_registration.finance_details.balance)) %>
               </p>
               <%= link_to t(".status.actions.payment_button"), transient_registration_payments_path(@transient_registration.reg_identifier), class: 'button' %>
-              <%= link_to t(".status.actions.convictions_check_button"), transient_registration_convictions_path(@transient_registration.reg_identifier), class: 'button' %>
-            <% elsif @transient_registration.pending_payment? %>
-              <p>
-                <%= t(".status.messages.pending_payment") %>
-              </p>
-              <%= link_to t(".status.actions.payment_button"), transient_registration_payments_path(@transient_registration.reg_identifier), class: 'button' %>
-            <% end %>
-          </div>
+            </div>
+          <% end %>
         <% else %>
           <div class="panel">
             <h2 class="heading-medium">

--- a/config/locales/transient_registrations.en.yml
+++ b/config/locales/transient_registrations.en.yml
@@ -14,11 +14,12 @@ en:
           in_progress: "Application in progress"
           submitted: "Application submitted"
           rejected: "Application rejected"
+          pending_convictions: "Conviction check required"
+          pending_payment: "Payment required"
         messages:
           in_progress: "The current form is"
-          pending_payment: "Payment is required before this registration can be renewed."
-          pending_convictions_check: "A convictions check is required before this registration can be renewed."
-          pending_payment_and_convictions_check: "Payment and a convictions check are required before this registration can be renewed."
+          pending_payment: "£%{total} to pay"
+          pending_convictions_check: "A convictions check is required before this registration can be approved."
           rejected: "This renewal was rejected during a convictions check and cannot be completed. The current registration will remain active until it expires."
           worldpay:
             paragraph_1: "The user is currently attempting to pay by WorldPay."


### PR DESCRIPTION
Part of: https://eaflood.atlassian.net/browse/RUBY-711
Part of: https://eaflood.atlassian.net/browse/RUBY-709

Match style of messages on top of registration details page to match the wireframe in concern of Finance and Conviction checks.

Since the tickets didn't mention the top bits I did address only the bottom information for these two sections, but since we don't have a separate ticket to deal with them, I am assuming the top section shows have to be covered with these tickets. 

Open question on what to do when Ceased or Revoked.

<img width="689" alt="Screenshot 2019-10-31 at 17 49 41" src="https://user-images.githubusercontent.com/1385397/67972814-4be85a00-fc07-11e9-910b-baf141571cec.png">
