### PR TITLE
Move link down in conviction section

### DIFF
--- a/app/views/transient_registrations/show.html.erb
+++ b/app/views/transient_registrations/show.html.erb
@@ -147,12 +147,13 @@
               <%= t(".conviction_search_text.rejected") %>
             </p>
           <% elsif @transient_registration.conviction_search_result.present? %>
-            <% if @transient_registration.conviction_check_required? %>
-              <%= link_to t(".conviction_link"), transient_registration_convictions_path(@transient_registration.reg_identifier), class: "pull-up" %>
-            <% end %>
             <p>
               <%= t(".conviction_search_text.#{@transient_registration.conviction_check_required?}") %>
             </p>
+
+            <% if @transient_registration.conviction_check_required? %>
+              <%= link_to t(".conviction_link"), transient_registration_convictions_path(@transient_registration.reg_identifier), class: "pull-up" %>
+            <% end %>
           <% else %>
             <p>
               <%= t(".conviction_search_text.unknown") %>


### PR DESCRIPTION
From: https://eaflood.atlassian.net/jira/software/projects/RUBY/boards/374?selectedIssue=RUBY-709

Move link in conviction section below the shown message
<img width="725" alt="Screenshot 2019-10-31 at 17 56 31" src="https://user-images.githubusercontent.com/1385397/67973411-5fe08b80-fc08-11e9-8c4d-ab08ea140af2.png">
<img width="687" alt="Screenshot 2019-10-31 at 17 58 22" src="https://user-images.githubusercontent.com/1385397/67973412-5fe08b80-fc08-11e9-82a9-fae83491768c.png">
