### PR TITLE
Show correct messag when finance information is missing

### DIFF
--- a/app/views/transient_registrations/show.html.erb
+++ b/app/views/transient_registrations/show.html.erb
@@ -279,6 +279,8 @@
         <h2 class="heading-medium">
           <% if @transient_registration.unpaid_balance? %>
             <%= t(".finance_information.heading_with_amount_owned", amount: display_pence_as_pounds(@transient_registration.finance_details.balance)) %>
+          <% elsif @transient_registration.finance_details.blank? %>
+            <%= t(".finance_information.balance.no_data") %>
           <% else %>
             <%= t(".finance_information.heading") %>
           <% end %>
@@ -286,10 +288,6 @@
 
         <% if @transient_registration.finance_details %>
           <%= link_to t(".finance_information.section_link_label"), "#TODO_UNKNOWN"%>
-        <% else %>
-          <div class="panel">
-            <%= t(".finance_information.balance.no_data") %>
-          </div>
         <% end %>
 
         <% if @transient_registration.finance_details&.orders&.any? %>


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-711

Update the style of the message shown when there is no finance information available as per wireframe

BEFORE: 
<img width="686" alt="Screenshot 2019-10-31 at 18 04 51" src="https://user-images.githubusercontent.com/1385397/67973931-5572c180-fc09-11e9-81a5-af669a556b0f.png">

AFTER:
<img width="682" alt="Screenshot 2019-10-31 at 18 04 33" src="https://user-images.githubusercontent.com/1385397/67973929-5572c180-fc09-11e9-8620-9808b94626fb.png">
