### PR TITLE
Return empty string if no date available

### DIFF
--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -48,6 +48,8 @@ module DashboardsHelper
   end
 
   def formatted_date(text, date)
+    return unless date
+
     date = date.in_time_zone("London").to_formatted_s(:day_month_year_slashes)
     I18n.t(".dashboards.index.results.date.#{text}", date: date)
   end

--- a/spec/helpers/dashboards_helper_spec.rb
+++ b/spec/helpers/dashboards_helper_spec.rb
@@ -77,6 +77,14 @@ RSpec.describe DashboardsHelper, type: :helper do
           date = result.expires_on.strftime("%d/%m/%Y")
           expect(helper.result_date(result)).to eq("Expires #{date}")
         end
+
+        context "when the result has no expire date" do
+          it "returns nil" do
+            result.expires_on = nil
+
+            expect(helper.result_date(result)).to be_nil
+          end
+        end
       end
 
       context "when the result is a transient_registration" do


### PR DESCRIPTION
From: https://eaflood.atlassian.net/jira/software/projects/RUBY/boards/374?selectedIssue=RUBY-750

If a resulting registration is missing a date, we want to return an empty string rather than an error