### PR TITLE
Remove conviction details link in dashboard

### DIFF
--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -127,17 +127,6 @@
                       <% end %>
                     </li>
                   <% end %>
-                  <% if display_convictions_link_for?(result) %>
-                    <li>
-                      <%= link_to convictions_link_for(result) do %>
-                        <%= t(".results.actions.convictions.link_text") %>
-                        <span class="visually-hidden">
-                          <%= t(".results.actions.convictions.visually_hidden_text",
-                                name: result.company_name) %>
-                        </span>
-                      <% end %>
-                    </li>
-                  <% end %>
                   <% if display_renew_link_for?(result) %>
                     <li>
                       <%= link_to renew_link_for(result) do %>


### PR DESCRIPTION
NCCC have confirmed they would prefer conviction checks to only be managed from the conviction checks dashboard we built them as part of renewals.

So we have already removed links to a registrations conviction details from the view details screen. But we just spotted we still show a link in the dashboard search results.

So this is a minor change to the view to remove the link.