### PR TITLE
Remove dupe BaseService

### DIFF
--- a/app/services/waste_carriers_engine/base_service.rb
+++ b/app/services/waste_carriers_engine/base_service.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-module WasteCarriersEngine
-  class BaseService
-    def self.run(attrs = nil)
-      new.run(attrs)
-    end
-  end
-end


### PR DESCRIPTION
This was only in place until the BaseService had been added to the engine. Now that it's there, we no longer need this file.