### PR TITLE
Refactor UserMigrationService to inherit from BaseService

### DIFF
--- a/app/controllers/user_migrations_controller.rb
+++ b/app/controllers/user_migrations_controller.rb
@@ -23,9 +23,7 @@ class UserMigrationsController < ApplicationController
   end
 
   def migrate_users
-    user_migration_service = UserMigrationService.new
-    user_migration_service.sync
-    user_migration_service.results
+    UserMigrationService.run
   end
 
   def parse_results(results)

--- a/app/services/user_migration_service.rb
+++ b/app/services/user_migration_service.rb
@@ -1,15 +1,13 @@
 # frozen_string_literal: true
 
-class UserMigrationService
-  attr_reader :results
-
-  def initialize
+class UserMigrationService < ::WasteCarriersEngine::BaseService
+  def run
     @results = []
-  end
 
-  def sync
     sync_admin
     sync_agency
+
+    @results
   end
 
   private

--- a/spec/services/user_migration_service_spec.rb
+++ b/spec/services/user_migration_service_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe UserMigrationService do
-  subject do
+  let(:service) do
     UserMigrationService.run
   end
 
@@ -15,7 +15,7 @@ RSpec.describe UserMigrationService do
     context "when there are no backend users" do
       it "does not modify the back office users" do
         users_before_sync = User.all
-        subject
+        service
         expect(User.all).to eq(users_before_sync)
       end
     end
@@ -26,17 +26,17 @@ RSpec.describe UserMigrationService do
 
       it "creates a new back office user" do
         number_of_users_before_sync = User.all.count
-        subject
+        service
         expect(User.all.count).to eq(number_of_users_before_sync + 1)
       end
 
       it "uses the correct email" do
-        subject
+        service
         expect(matching_back_office_user.email).to eq(agency_user.email)
       end
 
       it "uses the correct role" do
-        subject
+        service
         expect(matching_back_office_user.role).to eq("agency")
       end
 
@@ -47,7 +47,7 @@ RSpec.describe UserMigrationService do
         end
 
         it "uses the correct role" do
-          subject
+          service
           expect(matching_back_office_user.role).to eq("agency_with_refund")
         end
       end
@@ -59,7 +59,7 @@ RSpec.describe UserMigrationService do
         end
 
         it "uses the correct role" do
-          subject
+          service
           expect(matching_back_office_user.role).to eq("finance")
         end
       end
@@ -71,7 +71,7 @@ RSpec.describe UserMigrationService do
         end
 
         it "uses the correct role" do
-          subject
+          service
           expect(matching_back_office_user.role).to eq("finance_admin")
         end
       end
@@ -83,7 +83,7 @@ RSpec.describe UserMigrationService do
           role: "agency"
         }
 
-        expect(subject).to include(result)
+        expect(service).to include(result)
       end
     end
 
@@ -93,17 +93,17 @@ RSpec.describe UserMigrationService do
 
       it "creates a new back office user" do
         number_of_users_before_sync = User.all.count
-        subject
+        service
         expect(User.all.count).to eq(number_of_users_before_sync + 1)
       end
 
       it "uses the correct email" do
-        subject
+        service
         expect(matching_back_office_user.email).to eq(admin.email)
       end
 
       it "uses the correct role" do
-        subject
+        service
         expect(matching_back_office_user.role).to eq("agency_super")
       end
 
@@ -114,7 +114,7 @@ RSpec.describe UserMigrationService do
         end
 
         it "uses the correct role" do
-          subject
+          service
           expect(matching_back_office_user.role).to eq("finance_super")
         end
       end
@@ -126,7 +126,7 @@ RSpec.describe UserMigrationService do
           role: "agency_super"
         }
 
-        expect(subject).to include(result)
+        expect(service).to include(result)
       end
     end
 
@@ -137,7 +137,7 @@ RSpec.describe UserMigrationService do
       context "when the role is the same" do
         it "does not modify the back office user" do
           back_office_user_before = back_office_user
-          subject
+          service
           back_office_user_after = back_office_user.reload
           expect(back_office_user_before).to eq(back_office_user_after)
         end
@@ -149,7 +149,7 @@ RSpec.describe UserMigrationService do
             role: "agency"
           }
 
-          expect(subject).to include(result)
+          expect(service).to include(result)
         end
       end
 
@@ -160,7 +160,7 @@ RSpec.describe UserMigrationService do
 
         it "updates the back office user role" do
           role_before = back_office_user.role
-          subject
+          service
           role_after = back_office_user.reload.role
           expect(role_before).to_not eq(role_after)
         end
@@ -172,7 +172,7 @@ RSpec.describe UserMigrationService do
             role: "agency"
           }
 
-          expect(subject).to include(result)
+          expect(service).to include(result)
         end
       end
     end

--- a/spec/services/user_migration_service_spec.rb
+++ b/spec/services/user_migration_service_spec.rb
@@ -3,17 +3,11 @@
 require "rails_helper"
 
 RSpec.describe UserMigrationService do
-  let(:user_migration_service) do
-    UserMigrationService.new
+  subject do
+    UserMigrationService.run
   end
 
-  describe "#initialize" do
-    it "should set the correct value to @results" do
-      expect(user_migration_service.results).to eq([])
-    end
-  end
-
-  describe "#sync" do
+  describe "#run" do
     before do
       create(:role)
     end
@@ -21,7 +15,7 @@ RSpec.describe UserMigrationService do
     context "when there are no backend users" do
       it "does not modify the back office users" do
         users_before_sync = User.all
-        user_migration_service.sync
+        subject
         expect(User.all).to eq(users_before_sync)
       end
     end
@@ -32,17 +26,17 @@ RSpec.describe UserMigrationService do
 
       it "creates a new back office user" do
         number_of_users_before_sync = User.all.count
-        user_migration_service.sync
+        subject
         expect(User.all.count).to eq(number_of_users_before_sync + 1)
       end
 
       it "uses the correct email" do
-        user_migration_service.sync
+        subject
         expect(matching_back_office_user.email).to eq(agency_user.email)
       end
 
       it "uses the correct role" do
-        user_migration_service.sync
+        subject
         expect(matching_back_office_user.role).to eq("agency")
       end
 
@@ -53,7 +47,7 @@ RSpec.describe UserMigrationService do
         end
 
         it "uses the correct role" do
-          user_migration_service.sync
+          subject
           expect(matching_back_office_user.role).to eq("agency_with_refund")
         end
       end
@@ -65,7 +59,7 @@ RSpec.describe UserMigrationService do
         end
 
         it "uses the correct role" do
-          user_migration_service.sync
+          subject
           expect(matching_back_office_user.role).to eq("finance")
         end
       end
@@ -77,19 +71,19 @@ RSpec.describe UserMigrationService do
         end
 
         it "uses the correct role" do
-          user_migration_service.sync
+          subject
           expect(matching_back_office_user.role).to eq("finance_admin")
         end
       end
 
-      it "adds the correct value to @results" do
+      it "adds the correct value to the results" do
         result = {
           action: :create,
           email: agency_user.email,
           role: "agency"
         }
-        user_migration_service.sync
-        expect(user_migration_service.results).to include(result)
+
+        expect(subject).to include(result)
       end
     end
 
@@ -99,17 +93,17 @@ RSpec.describe UserMigrationService do
 
       it "creates a new back office user" do
         number_of_users_before_sync = User.all.count
-        user_migration_service.sync
+        subject
         expect(User.all.count).to eq(number_of_users_before_sync + 1)
       end
 
       it "uses the correct email" do
-        user_migration_service.sync
+        subject
         expect(matching_back_office_user.email).to eq(admin.email)
       end
 
       it "uses the correct role" do
-        user_migration_service.sync
+        subject
         expect(matching_back_office_user.role).to eq("agency_super")
       end
 
@@ -120,19 +114,19 @@ RSpec.describe UserMigrationService do
         end
 
         it "uses the correct role" do
-          user_migration_service.sync
+          subject
           expect(matching_back_office_user.role).to eq("finance_super")
         end
       end
 
-      it "adds the correct value to @results" do
+      it "adds the correct value to the results" do
         result = {
           action: :create,
           email: admin.email,
           role: "agency_super"
         }
-        user_migration_service.sync
-        expect(user_migration_service.results).to include(result)
+
+        expect(subject).to include(result)
       end
     end
 
@@ -143,19 +137,19 @@ RSpec.describe UserMigrationService do
       context "when the role is the same" do
         it "does not modify the back office user" do
           back_office_user_before = back_office_user
-          user_migration_service.sync
+          subject
           back_office_user_after = back_office_user.reload
           expect(back_office_user_before).to eq(back_office_user_after)
         end
 
-        it "adds the correct value to @results" do
+        it "adds the correct value to the results" do
           result = {
             action: :skip,
             email: agency_user.email,
             role: "agency"
           }
-          user_migration_service.sync
-          expect(user_migration_service.results).to include(result)
+
+          expect(subject).to include(result)
         end
       end
 
@@ -166,19 +160,19 @@ RSpec.describe UserMigrationService do
 
         it "updates the back office user role" do
           role_before = back_office_user.role
-          user_migration_service.sync
+          subject
           role_after = back_office_user.reload.role
           expect(role_before).to_not eq(role_after)
         end
 
-        it "adds the correct value to @results" do
+        it "adds the correct value to the results" do
           result = {
             action: :update,
             email: agency_user.email,
             role: "agency"
           }
-          user_migration_service.sync
-          expect(user_migration_service.results).to include(result)
+
+          expect(subject).to include(result)
         end
       end
     end

--- a/spec/services/user_migration_service_spec.rb
+++ b/spec/services/user_migration_service_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe UserMigrationService do
-  let(:service) do
+  let(:run_service) do
     UserMigrationService.run
   end
 
@@ -15,7 +15,7 @@ RSpec.describe UserMigrationService do
     context "when there are no backend users" do
       it "does not modify the back office users" do
         users_before_sync = User.all
-        service
+        run_service
         expect(User.all).to eq(users_before_sync)
       end
     end
@@ -26,17 +26,17 @@ RSpec.describe UserMigrationService do
 
       it "creates a new back office user" do
         number_of_users_before_sync = User.all.count
-        service
+        run_service
         expect(User.all.count).to eq(number_of_users_before_sync + 1)
       end
 
       it "uses the correct email" do
-        service
+        run_service
         expect(matching_back_office_user.email).to eq(agency_user.email)
       end
 
       it "uses the correct role" do
-        service
+        run_service
         expect(matching_back_office_user.role).to eq("agency")
       end
 
@@ -47,7 +47,7 @@ RSpec.describe UserMigrationService do
         end
 
         it "uses the correct role" do
-          service
+          run_service
           expect(matching_back_office_user.role).to eq("agency_with_refund")
         end
       end
@@ -59,7 +59,7 @@ RSpec.describe UserMigrationService do
         end
 
         it "uses the correct role" do
-          service
+          run_service
           expect(matching_back_office_user.role).to eq("finance")
         end
       end
@@ -71,7 +71,7 @@ RSpec.describe UserMigrationService do
         end
 
         it "uses the correct role" do
-          service
+          run_service
           expect(matching_back_office_user.role).to eq("finance_admin")
         end
       end
@@ -83,7 +83,7 @@ RSpec.describe UserMigrationService do
           role: "agency"
         }
 
-        expect(service).to include(result)
+        expect(run_service).to include(result)
       end
     end
 
@@ -93,17 +93,17 @@ RSpec.describe UserMigrationService do
 
       it "creates a new back office user" do
         number_of_users_before_sync = User.all.count
-        service
+        run_service
         expect(User.all.count).to eq(number_of_users_before_sync + 1)
       end
 
       it "uses the correct email" do
-        service
+        run_service
         expect(matching_back_office_user.email).to eq(admin.email)
       end
 
       it "uses the correct role" do
-        service
+        run_service
         expect(matching_back_office_user.role).to eq("agency_super")
       end
 
@@ -114,7 +114,7 @@ RSpec.describe UserMigrationService do
         end
 
         it "uses the correct role" do
-          service
+          run_service
           expect(matching_back_office_user.role).to eq("finance_super")
         end
       end
@@ -126,7 +126,7 @@ RSpec.describe UserMigrationService do
           role: "agency_super"
         }
 
-        expect(service).to include(result)
+        expect(run_service).to include(result)
       end
     end
 
@@ -137,7 +137,7 @@ RSpec.describe UserMigrationService do
       context "when the role is the same" do
         it "does not modify the back office user" do
           back_office_user_before = back_office_user
-          service
+          run_service
           back_office_user_after = back_office_user.reload
           expect(back_office_user_before).to eq(back_office_user_after)
         end
@@ -149,7 +149,7 @@ RSpec.describe UserMigrationService do
             role: "agency"
           }
 
-          expect(service).to include(result)
+          expect(run_service).to include(result)
         end
       end
 
@@ -160,7 +160,7 @@ RSpec.describe UserMigrationService do
 
         it "updates the back office user role" do
           role_before = back_office_user.role
-          service
+          run_service
           role_after = back_office_user.reload.role
           expect(role_before).to_not eq(role_after)
         end
@@ -172,7 +172,7 @@ RSpec.describe UserMigrationService do
             role: "agency"
           }
 
-          expect(service).to include(result)
+          expect(run_service).to include(result)
         end
       end
     end


### PR DESCRIPTION
We want to refactor our services to all follow a similar format. This means we can now just call UserMigrationService.run instead of instatiating a new service and then calling several methods on it.

Plus minor tweaks to the UserMigrationsController which calls it.