### PR TITLE
Refactor RegistrationTransferService to inherit from BaseService

### DIFF
--- a/app/forms/registration_transfer_form.rb
+++ b/app/forms/registration_transfer_form.rb
@@ -22,8 +22,7 @@ class RegistrationTransferForm < WasteCarriersEngine::BaseForm
   validate :registration_transferred_successfully?
 
   def registration_transferred_successfully?
-    registration_transfer_service = RegistrationTransferService.new(registration)
-    result = registration_transfer_service.transfer_to_user(email)
+    result = RegistrationTransferService.run(registration: registration, email: email)
 
     return true if %i[success_existing_user
                       success_new_user].include?(result)

--- a/spec/forms/registration_transfer_form_spec.rb
+++ b/spec/forms/registration_transfer_form_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe RegistrationTransferForm, type: :model do
       end
 
       before do
-        allow_any_instance_of(RegistrationTransferService).to receive(:transfer_to_user).and_return(:success_existing_user)
+        allow(RegistrationTransferService).to receive(:run).and_return(:success_existing_user)
       end
 
       it "should submit" do
@@ -96,7 +96,7 @@ RSpec.describe RegistrationTransferForm, type: :model do
   describe "#registration_transferred_successfully?" do
     context "when the RegistrationTransferService returns :success_existing_user" do
       before do
-        allow_any_instance_of(RegistrationTransferService).to receive(:transfer_to_user).and_return(:success_existing_user)
+        allow(RegistrationTransferService).to receive(:run).and_return(:success_existing_user)
       end
 
       it "is valid" do
@@ -106,7 +106,7 @@ RSpec.describe RegistrationTransferForm, type: :model do
 
     context "when the RegistrationTransferService returns :success_new_user" do
       before do
-        allow_any_instance_of(RegistrationTransferService).to receive(:transfer_to_user).and_return(:success_new_user)
+        allow(RegistrationTransferService).to receive(:run).and_return(:success_new_user)
       end
 
       it "is valid" do
@@ -116,7 +116,7 @@ RSpec.describe RegistrationTransferForm, type: :model do
 
     context "when the RegistrationTransferService returns :no_matching_user" do
       before do
-        allow_any_instance_of(RegistrationTransferService).to receive(:transfer_to_user).and_return(:no_matching_user)
+        allow(RegistrationTransferService).to receive(:run).and_return(:no_matching_user)
       end
 
       it "is not valid" do

--- a/spec/services/registration_transfer_service_spec.rb
+++ b/spec/services/registration_transfer_service_spec.rb
@@ -3,68 +3,51 @@
 require "rails_helper"
 
 RSpec.describe RegistrationTransferService do
-  let(:transient_registration) do
-    create(:renewing_registration, :ready_to_renew)
+  let(:registration) { create(:registration) }
+  let(:recipient_email) { external_user.email }
+
+  let(:service) do
+    RegistrationTransferService.run(registration: registration, email: recipient_email)
   end
 
-  let(:registration) do
-    WasteCarriersEngine::Registration.where(reg_identifier: transient_registration.reg_identifier).first
-  end
-
-  let(:registration_transfer_service) do
-    RegistrationTransferService.new(registration)
-  end
-
-  describe "#initialize" do
-    context "when a transient_registration exists" do
-      it "sets @transient_registration" do
-        instance_var = registration_transfer_service.instance_variable_get(:@transient_registration)
-        expect(instance_var).to eq(transient_registration)
-      end
-    end
-
-    context "when no transient_registration exists" do
-      let(:registration_transfer_service) do
-        RegistrationTransferService.new(create(:registration))
-      end
-
-      it "sets @transient_registration to nil" do
-        instance_var = registration_transfer_service.instance_variable_get(:@transient_registration)
-        expect(instance_var).to eq(nil)
-      end
-    end
-  end
-
-  describe "#transfer_to_user" do
+  describe "#run" do
     let(:external_user) { create(:external_user) }
-    let(:recipient_email) { external_user.email }
-    let(:transfer_to_user) { registration_transfer_service.transfer_to_user(recipient_email) }
 
     context "when there is an external user with a matching email" do
       it "updates the registration's account_email" do
-        transfer_to_user
+        service
         expect(registration.reload.account_email).to eq(recipient_email)
       end
 
-      it "updates the transient_registration's account_email" do
-        transfer_to_user
-        expect(transient_registration.reload.account_email).to eq(recipient_email)
+      context "when there is a transient_registration" do
+        let(:transient_registration) do
+          create(:renewing_registration, :ready_to_renew)
+        end
+
+        let(:registration) do
+          WasteCarriersEngine::Registration.where(reg_identifier: transient_registration.reg_identifier).first
+        end
+
+        it "updates the transient_registration's account_email" do
+          service
+          expect(transient_registration.reload.account_email).to eq(recipient_email)
+        end
       end
 
       it "sends an email" do
         old_emails_sent_count = ActionMailer::Base.deliveries.count
-        transfer_to_user
+        service
         expect(ActionMailer::Base.deliveries.count).to eq(old_emails_sent_count + 1)
       end
 
       it "sends an email to the correct address" do
-        transfer_to_user
+        service
         last_delivery = ActionMailer::Base.deliveries.last
         expect(last_delivery.header["to"].value).to eq(recipient_email)
       end
 
       it "returns :success_existing_user" do
-        expect(transfer_to_user).to eq(:success_existing_user)
+        expect(service).to eq(:success_existing_user)
       end
 
       context "when the mailer encounters an error" do
@@ -73,7 +56,7 @@ RSpec.describe RegistrationTransferService do
         end
 
         it "returns :success_existing_user" do
-          expect(transfer_to_user).to eq(:success_existing_user)
+          expect(service).to eq(:success_existing_user)
         end
       end
     end
@@ -83,34 +66,44 @@ RSpec.describe RegistrationTransferService do
 
       it "creates a new user" do
         old_matching_user_count = ExternalUser.where(email: recipient_email).length
-        transfer_to_user
+        service
         expect(ExternalUser.where(email: recipient_email).length).to eq(old_matching_user_count + 1)
       end
 
       it "updates the registration's account_email" do
-        transfer_to_user
+        service
         expect(registration.reload.account_email).to eq(recipient_email)
       end
 
-      it "updates the transient_registration's account_email" do
-        transfer_to_user
-        expect(transient_registration.reload.account_email).to eq(recipient_email)
+      context "when there is a transient_registration" do
+        let(:transient_registration) do
+          create(:renewing_registration, :ready_to_renew)
+        end
+
+        let(:registration) do
+          WasteCarriersEngine::Registration.where(reg_identifier: transient_registration.reg_identifier).first
+        end
+
+        it "updates the transient_registration's account_email" do
+          service
+          expect(transient_registration.reload.account_email).to eq(recipient_email)
+        end
       end
 
       it "sends an email" do
         old_emails_sent_count = ActionMailer::Base.deliveries.count
-        transfer_to_user
+        service
         expect(ActionMailer::Base.deliveries.count).to eq(old_emails_sent_count + 1)
       end
 
       it "sends an email to the correct address" do
-        transfer_to_user
+        service
         last_delivery = ActionMailer::Base.deliveries.last
         expect(last_delivery.header["to"].value).to eq(recipient_email)
       end
 
       it "returns :success_new_user" do
-        expect(transfer_to_user).to eq(:success_new_user)
+        expect(service).to eq(:success_new_user)
       end
     end
 
@@ -118,7 +111,7 @@ RSpec.describe RegistrationTransferService do
       let(:recipient_email) { nil }
 
       it "returns :no_matching_user" do
-        expect(registration_transfer_service.transfer_to_user(recipient_email)).to eq(:no_matching_user)
+        expect(service).to eq(:no_matching_user)
       end
     end
   end

--- a/spec/services/registration_transfer_service_spec.rb
+++ b/spec/services/registration_transfer_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe RegistrationTransferService do
   let(:registration) { create(:registration) }
   let(:recipient_email) { external_user.email }
 
-  let(:service) do
+  let(:run_service) do
     RegistrationTransferService.run(registration: registration, email: recipient_email)
   end
 
@@ -15,7 +15,7 @@ RSpec.describe RegistrationTransferService do
 
     context "when there is an external user with a matching email" do
       it "updates the registration's account_email" do
-        service
+        run_service
         expect(registration.reload.account_email).to eq(recipient_email)
       end
 
@@ -29,25 +29,25 @@ RSpec.describe RegistrationTransferService do
         end
 
         it "updates the transient_registration's account_email" do
-          service
+          run_service
           expect(transient_registration.reload.account_email).to eq(recipient_email)
         end
       end
 
       it "sends an email" do
         old_emails_sent_count = ActionMailer::Base.deliveries.count
-        service
+        run_service
         expect(ActionMailer::Base.deliveries.count).to eq(old_emails_sent_count + 1)
       end
 
       it "sends an email to the correct address" do
-        service
+        run_service
         last_delivery = ActionMailer::Base.deliveries.last
         expect(last_delivery.header["to"].value).to eq(recipient_email)
       end
 
       it "returns :success_existing_user" do
-        expect(service).to eq(:success_existing_user)
+        expect(run_service).to eq(:success_existing_user)
       end
 
       context "when the mailer encounters an error" do
@@ -56,7 +56,7 @@ RSpec.describe RegistrationTransferService do
         end
 
         it "returns :success_existing_user" do
-          expect(service).to eq(:success_existing_user)
+          expect(run_service).to eq(:success_existing_user)
         end
       end
     end
@@ -66,12 +66,12 @@ RSpec.describe RegistrationTransferService do
 
       it "creates a new user" do
         old_matching_user_count = ExternalUser.where(email: recipient_email).length
-        service
+        run_service
         expect(ExternalUser.where(email: recipient_email).length).to eq(old_matching_user_count + 1)
       end
 
       it "updates the registration's account_email" do
-        service
+        run_service
         expect(registration.reload.account_email).to eq(recipient_email)
       end
 
@@ -85,25 +85,25 @@ RSpec.describe RegistrationTransferService do
         end
 
         it "updates the transient_registration's account_email" do
-          service
+          run_service
           expect(transient_registration.reload.account_email).to eq(recipient_email)
         end
       end
 
       it "sends an email" do
         old_emails_sent_count = ActionMailer::Base.deliveries.count
-        service
+        run_service
         expect(ActionMailer::Base.deliveries.count).to eq(old_emails_sent_count + 1)
       end
 
       it "sends an email to the correct address" do
-        service
+        run_service
         last_delivery = ActionMailer::Base.deliveries.last
         expect(last_delivery.header["to"].value).to eq(recipient_email)
       end
 
       it "returns :success_new_user" do
-        expect(service).to eq(:success_new_user)
+        expect(run_service).to eq(:success_new_user)
       end
     end
 
@@ -111,7 +111,7 @@ RSpec.describe RegistrationTransferService do
       let(:recipient_email) { nil }
 
       it "returns :no_matching_user" do
-        expect(service).to eq(:no_matching_user)
+        expect(run_service).to eq(:no_matching_user)
       end
     end
   end


### PR DESCRIPTION
We want to refactor our services to all follow a similar format. This means we can now just call `RegistrationTransferService.run` instead of instantiating a new service and then calling several methods on it.

Also some minor tweaks to the RegistrationTransferForm which calls it.