### PR TITLE
Add Unknown status to conviction cheks view details

### DIFF
--- a/app/views/registrations/show.html.erb
+++ b/app/views/registrations/show.html.erb
@@ -243,7 +243,7 @@
                   <td>
                     <% if person.conviction_check_required? %>
                       <div class="bold-xsmall">
-                        <%= t(".person_information.has_convictions.yes") %>
+                        <%= t(".person_information.has_convictions.#{person.conviction_search_result.match_result}") %>
                       </div>
                     <% else %>
                       <%= t(".person_information.has_convictions.no") %>

--- a/app/views/renewing_registrations/show.html.erb
+++ b/app/views/renewing_registrations/show.html.erb
@@ -274,7 +274,7 @@
                   <td>
                     <% if person.conviction_check_required? %>
                       <div class="bold-small">
-                        <%= t(".person_information.has_convictions.yes") %>
+                        <%= t(".person_information.has_convictions.#{person.conviction_search_result.match_result}") %>
                       </div>
                     <% else %>
                       <%= t(".person_information.has_convictions.no") %>

--- a/config/locales/registrations.en.yml
+++ b/config/locales/registrations.en.yml
@@ -59,7 +59,7 @@ en:
         convictions: "Convictions"
         has_convictions:
           "YES": "Yes"
-          "NO": "No"
+          "no": "No"
           "UNKNOWN": "Unknown"
         heading:
           localAuthority: "Chief executive details"

--- a/config/locales/registrations.en.yml
+++ b/config/locales/registrations.en.yml
@@ -58,8 +58,9 @@ en:
         dob: "Date of birth"
         convictions: "Convictions"
         has_convictions:
-          "yes": "Yes"
-          "no": "No"
+          "YES": "Yes"
+          "NO": "No"
+          "UNKNOWN": "Unknown"
         heading:
           localAuthority: "Chief executive details"
           limitedCompany: "Company director details"

--- a/config/locales/renewing_registrations.en.yml
+++ b/config/locales/renewing_registrations.en.yml
@@ -59,7 +59,7 @@ en:
         convictions: "Convictions"
         has_convictions:
           "YES": "Yes"
-          "NO": "No"
+          "no": "No"
           "UNKNOWN": "Unknown"
         heading:
           localAuthority: "Chief executive details"

--- a/config/locales/renewing_registrations.en.yml
+++ b/config/locales/renewing_registrations.en.yml
@@ -58,8 +58,9 @@ en:
         dob: "Date of birth"
         convictions: "Convictions"
         has_convictions:
-          "yes": "Yes"
-          "no": "No"
+          "YES": "Yes"
+          "NO": "No"
+          "UNKNOWN": "Unknown"
         heading:
           localAuthority: "Chief executive details"
           limitedCompany: "Company director details"


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-751

Add `UNKNOWN` specific status on registrations detail pages
