### PR TITLE
Remove conviction links

### DIFF
--- a/app/views/registrations/show.html.erb
+++ b/app/views/registrations/show.html.erb
@@ -113,12 +113,10 @@
         <h2 class="heading-medium"><%= t(".conviction_heading") %></h2>
         <div>
           <% if @registration.conviction_check_approved? %>
-            <%= link_to t(".conviction_link"), "#TODO!", class: "pull-up"  %>
             <p>
               <%= t(".conviction_search_text.approved") %>
             </p>
           <% elsif @registration.rejected_conviction_checks? %>
-            <%= link_to t(".conviction_link"), "#TODO!", class: "pull-up"  %>
             <p>
               <%= t(".conviction_search_text.rejected") %>
             </p>
@@ -126,10 +124,6 @@
             <p>
               <%= t(".conviction_search_text.#{@registration.conviction_check_required?}") %>
             </p>
-
-            <% if @registration.conviction_check_required? %>
-              <%= link_to t(".conviction_link"), "#TODO!", class: "pull-up" %>
-            <% end %>
           <% else %>
             <p>
               <%= t(".conviction_search_text.unknown") %>

--- a/app/views/renewing_registrations/show.html.erb
+++ b/app/views/renewing_registrations/show.html.erb
@@ -144,12 +144,10 @@
         <h2 class="heading-medium"><%= t(".conviction_heading") %></h2>
         <div>
           <% if @transient_registration.conviction_check_approved? %>
-            <%= link_to t(".conviction_link"), transient_registration_convictions_path(@transient_registration.reg_identifier), class: "pull-up"  %>
             <p>
               <%= t(".conviction_search_text.approved") %>
             </p>
           <% elsif @transient_registration.rejected_conviction_checks? %>
-            <%= link_to t(".conviction_link"), transient_registration_convictions_path(@transient_registration.reg_identifier), class: "pull-up"  %>
             <p>
               <%= t(".conviction_search_text.rejected") %>
             </p>
@@ -157,10 +155,6 @@
             <p>
               <%= t(".conviction_search_text.#{@transient_registration.conviction_check_required?}") %>
             </p>
-
-            <% if @transient_registration.conviction_check_required? %>
-              <%= link_to t(".conviction_link"), transient_registration_convictions_path(@transient_registration.reg_identifier), class: "pull-up" %>
-            <% end %>
           <% else %>
             <p>
               <%= t(".conviction_search_text.unknown") %>


### PR DESCRIPTION
As per feedback from NCCC we decided to not put any link to conviction checks anywhere in the details page. This PR removes the existing links for all details page views.