### PR TITLE
Remove expire information for Lower tier

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ gem "kaminari-mongoid", "~> 1.0"
 # Use the waste carriers engine for the user journey
 gem "waste_carriers_engine",
     git: "https://github.com/DEFRA/waste-carriers-engine",
-    branch: "master"
+    branch: "add-lower-and-upper-tier-methods-to-reg"
 
 # Allows us to automatically generate the change log from the tags, issues,
 # labels and pull requests on GitHub. Added as a dependency so all dev's have

--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ gem "kaminari-mongoid", "~> 1.0"
 # Use the waste carriers engine for the user journey
 gem "waste_carriers_engine",
     git: "https://github.com/DEFRA/waste-carriers-engine",
-    branch: "add-lower-and-upper-tier-methods-to-reg"
+    branch: "master"
 
 # Allows us to automatically generate the change log from the tags, issues,
 # labels and pull requests on GitHub. Added as a dependency so all dev's have

--- a/app/views/registrations/show.html.erb
+++ b/app/views/registrations/show.html.erb
@@ -54,8 +54,10 @@
             <% end %>
           </p>
           <p>
-            <%= t(".labels.expires", formatted_date: @registration.display_expiry_date) %>
-            <br>
+            <% if @registration.upper_tier? %>
+              <%= t(".labels.expires", formatted_date: @registration.display_expiry_date) %>
+              <br>
+            <% end %>
             <%= t(".labels.account", email: @registration.account_email) %>
           </p>
         </div>


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-715

Do not show expire information for lower tier registration. They never expire.

<img width="578" alt="Screenshot 2019-11-18 at 17 30 23" src="https://user-images.githubusercontent.com/1385397/69075377-3063b880-0a29-11ea-8d99-d6b448af9365.png">
