### PR TITLE
Convictions message for lower tier registrations

### DIFF
--- a/app/presenters/base_registration_presenter.rb
+++ b/app/presenters/base_registration_presenter.rb
@@ -4,16 +4,30 @@ class BaseRegistrationPresenter < WasteCarriersEngine::BasePresenter
   def displayable_location
     location = show_translation_or_filler(:location)
 
-    I18n.t(".shared.registrations.show.business_information.labels.location", location: location)
+    I18n.t(".shared.registrations.business_information.labels.location", location: location)
+  end
+
+  def display_convictions_check_message
+    if lower_tier?
+      I18n.t(".shared.registrations.conviction_search_text.lower_tier")
+    elsif conviction_check_approved?
+      I18n.t(".shared.registrations.conviction_search_text.approved")
+    elsif rejected_conviction_checks?
+      I18n.t(".shared.registrations.conviction_search_text.rejected")
+    elsif conviction_search_result.present?
+      I18n.t(".shared.registrations.conviction_search_text.#{conviction_check_required?}")
+    else
+      I18n.t(".shared.registrations.conviction_search_text.unknown")
+    end
   end
 
   private
 
   def show_translation_or_filler(attribute)
     if send(attribute).present?
-      I18n.t(".shared.registrations.show.attributes.#{attribute}.#{send(attribute)}")
+      I18n.t(".shared.registrations.attributes.#{attribute}.#{send(attribute)}")
     else
-      I18n.t(".shared.registrations.show.filler")
+      I18n.t(".shared.registrations.filler")
     end
   end
 end

--- a/app/presenters/registration_presenter.rb
+++ b/app/presenters/registration_presenter.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 class RegistrationPresenter < BaseRegistrationPresenter
+  def displayable_location
+    location = show_translation_or_filler(:location)
+
+    I18n.t(".registrations.show.business_information.labels.location", location: location)
+  end
+
   def display_expiry_date
     expires_on&.to_date
   end

--- a/app/views/registrations/show.html.erb
+++ b/app/views/registrations/show.html.erb
@@ -111,26 +111,14 @@
             </p>
           </div>
         </div>
+
         <hr/>
+
         <h2 class="heading-medium"><%= t(".conviction_heading") %></h2>
         <div>
-          <% if @registration.conviction_check_approved? %>
-            <p>
-              <%= t(".conviction_search_text.approved") %>
-            </p>
-          <% elsif @registration.rejected_conviction_checks? %>
-            <p>
-              <%= t(".conviction_search_text.rejected") %>
-            </p>
-          <% elsif @registration.conviction_search_result.present? %>
-            <p>
-              <%= t(".conviction_search_text.#{@registration.conviction_check_required?}") %>
-            </p>
-          <% else %>
-            <p>
-              <%= t(".conviction_search_text.unknown") %>
-            </p>
-          <% end %>
+          <p>
+            <%= @registration.display_convictions_check_message %>
+          </p>
         </div>
 
         <hr>

--- a/app/views/renewing_registrations/show.html.erb
+++ b/app/views/renewing_registrations/show.html.erb
@@ -141,25 +141,12 @@
           </div>
         </div>
         <hr/>
+
         <h2 class="heading-medium"><%= t(".conviction_heading") %></h2>
         <div>
-          <% if @transient_registration.conviction_check_approved? %>
-            <p>
-              <%= t(".conviction_search_text.approved") %>
-            </p>
-          <% elsif @transient_registration.rejected_conviction_checks? %>
-            <p>
-              <%= t(".conviction_search_text.rejected") %>
-            </p>
-          <% elsif @transient_registration.conviction_search_result.present? %>
-            <p>
-              <%= t(".conviction_search_text.#{@transient_registration.conviction_check_required?}") %>
-            </p>
-          <% else %>
-            <p>
-              <%= t(".conviction_search_text.unknown") %>
-            </p>
-          <% end %>
+          <p>
+            <%= @transient_registration.display_convictions_check_message %>
+          </p>
         </div>
 
         <hr>

--- a/config/locales/registrations.en.yml
+++ b/config/locales/registrations.en.yml
@@ -69,12 +69,6 @@ en:
           partnership: "Partners details"
           soleTrader: "Business owner details"
       conviction_heading: "Convictions"
-      conviction_search_text:
-        "true": "This registration has matching or declared convictions."
-        "false": "There are no matching or declared convictions for this registration."
-        approved: "This registration was approved after a review of the matching or declared convictions."
-        rejected: "This registration was rejected after a review of the matching or declared convictions."
-        unknown: "This registration application is still in progress, so there is no conviction match data yet."
       conviction_link: "Conviction details"
       conviction_information:
         heading: "Conviction overview"

--- a/config/locales/renewing_registrations.en.yml
+++ b/config/locales/renewing_registrations.en.yml
@@ -69,12 +69,6 @@ en:
           partnership: "Partners details"
           soleTrader: "Business owner details"
       conviction_heading: "Convictions"
-      conviction_search_text:
-        "true": "This registration has matching or declared convictions."
-        "false": "There are no matching or declared convictions for this registration."
-        approved: "This renewal was approved after a review of the matching or declared convictions."
-        rejected: "This renewal was rejected after a review of the matching or declared convictions."
-        unknown: "This renewal application is still in progress, so there is no conviction match data yet."
       conviction_link: "Conviction details"
       conviction_information:
         heading: "Conviction overview"

--- a/config/locales/shared/registrations.en.yml
+++ b/config/locales/shared/registrations.en.yml
@@ -1,15 +1,21 @@
 en:
   shared:
     registrations:
-      show:
-        filler: "–"
-        attributes:
-          location:
-            england: "England"
-            wales: "Wales"
-            scotland: "Scotland"
-            northern_ireland: "Northern Ireland"
-            overseas: "Not in the United Kingdom"
-        business_information:
-          labels:
-            location: "Place of business: %{location}"
+      filler: "–"
+      conviction_search_text:
+        "true": "This registration has matching or declared convictions."
+        "false": "There are no convictions for this registration."
+        approved: "This registration was approved after a review of the matching or declared convictions."
+        rejected: "This registration was rejected after a review of the matching or declared convictions."
+        unknown: "This registration application is still in progress, so there is no conviction match data yet."
+        lower_tier: "Lower tier registration - convictions are not applicable"
+      attributes:
+        location:
+          england: "England"
+          wales: "Wales"
+          scotland: "Scotland"
+          northern_ireland: "Northern Ireland"
+          overseas: "Not in the United Kingdom"
+      business_information:
+        labels:
+          location: "Place of business: %{location}"

--- a/spec/presenters/base_registration_presenter_spec.rb
+++ b/spec/presenters/base_registration_presenter_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe BaseRegistrationPresenter do
     end
   end
 
-    describe "#display_convictions_check_message" do
+  describe "#display_convictions_check_message" do
     context "when the registration is a lower tier registration" do
       let(:registration) { double(:registration, lower_tier?: true) }
 

--- a/spec/presenters/base_registration_presenter_spec.rb
+++ b/spec/presenters/base_registration_presenter_spec.rb
@@ -24,4 +24,94 @@ RSpec.describe BaseRegistrationPresenter do
       end
     end
   end
+
+    describe "#display_convictions_check_message" do
+    context "when the registration is a lower tier registration" do
+      let(:registration) { double(:registration, lower_tier?: true) }
+
+      it "returns the lower tier text" do
+        message = "Lower tier registration - convictions are not applicable"
+
+        expect(subject.display_convictions_check_message).to eq(message)
+      end
+    end
+
+    context "when the registration has convictions checks approved" do
+      let(:registration) { double(:registration, conviction_check_approved?: true, lower_tier?: false) }
+
+      it "returns the convictions checks approved message" do
+        message = "This registration was approved after a review of the matching or declared convictions."
+
+        expect(subject.display_convictions_check_message).to eq(message)
+      end
+    end
+
+    context "when the registration has convictions checks rejected" do
+      let(:registration) do
+        double(
+          :registration,
+          conviction_check_approved?: false,
+          lower_tier?: false,
+          rejected_conviction_checks?: true
+        )
+      end
+
+      it "returns the convictions checks rejected message" do
+        message = "This registration was rejected after a review of the matching or declared convictions."
+
+        expect(subject.display_convictions_check_message).to eq(message)
+      end
+    end
+
+    context "when the registration has convictions checks results" do
+      let(:registration) do
+        double(
+          :registration,
+          conviction_check_approved?: false,
+          lower_tier?: false,
+          rejected_conviction_checks?: false,
+          conviction_search_result: double(:conviction_search_result),
+          conviction_check_required?: conviction_check_required
+        )
+      end
+
+      context "when a convictions check is required" do
+        let(:conviction_check_required) { true }
+
+        it "returns the convictions checks required message" do
+          message = "This registration has matching or declared convictions."
+
+          expect(subject.display_convictions_check_message).to eq(message)
+        end
+      end
+
+      context "when a convictions check is not required" do
+        let(:conviction_check_required) { false }
+
+        it "returns the convictions checks not required message" do
+          message = "There are no convictions for this registration."
+
+          expect(subject.display_convictions_check_message).to eq(message)
+        end
+      end
+
+      context "when we are unable to determine the status of convictions checks" do
+        let(:registration) do
+          double(
+            :registration,
+            conviction_check_approved?: false,
+            lower_tier?: false,
+            rejected_conviction_checks?: false,
+            conviction_search_result: nil
+          )
+        end
+
+        it "returns an unknown message" do
+          message = "This registration application is still in progress, so there is no conviction match data yet."
+
+          expect(subject.display_convictions_check_message).to eq(message)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This carries on some refactoring around the registration details pages in regard of externalizing the logic around conviction checks messages in the shared presenter interface.
It also adds the logic of a message to display on lower tier registrations.