### PR TITLE
Display 'expired' instead of 'expires' if expired

### DIFF
--- a/app/presenters/base_registration_presenter.rb
+++ b/app/presenters/base_registration_presenter.rb
@@ -38,6 +38,16 @@ class BaseRegistrationPresenter < WasteCarriersEngine::BasePresenter
     finance_details&.orders&.first
   end
 
+  def display_expiry_text
+    return unless upper_tier?
+
+    if expired?
+      I18n.t(".shared.registrations.labels.expired", formatted_date: display_expiry_date)
+    else
+      I18n.t(".shared.registrations.labels.expires", formatted_date: display_expiry_date)
+    end
+  end
+
   private
 
   def show_translation_or_filler(attribute)

--- a/app/views/registrations/show.html.erb
+++ b/app/views/registrations/show.html.erb
@@ -54,12 +54,8 @@
             <% end %>
           </p>
           <p>
-            <% if @registration.upper_tier? %>
-              <% if @registration.expired? %>
-                <%= t(".labels.expired", formatted_date: @registration.display_expiry_date) %>
-              <% else %>
-                <%= t(".labels.expires", formatted_date: @registration.display_expiry_date) %>
-              <% end %>
+            <% if @registration.display_expiry_text.present? %>
+              <%= @registration.display_expiry_text %>
               <br>
             <% end %>
             <%= t(".labels.account", email: @registration.account_email) %>

--- a/app/views/registrations/show.html.erb
+++ b/app/views/registrations/show.html.erb
@@ -55,7 +55,11 @@
           </p>
           <p>
             <% if @registration.upper_tier? %>
-              <%= t(".labels.expires", formatted_date: @registration.display_expiry_date) %>
+              <% if @registration.expired? %>
+                <%= t(".labels.expired", formatted_date: @registration.display_expiry_date) %>
+              <% else %>
+                <%= t(".labels.expires", formatted_date: @registration.display_expiry_date) %>
+              <% end %>
               <br>
             <% end %>
             <%= t(".labels.account", email: @registration.account_email) %>

--- a/app/views/renewing_registrations/show.html.erb
+++ b/app/views/renewing_registrations/show.html.erb
@@ -85,12 +85,10 @@
             <% end %>
           </p>
           <p>
-            <% if @transient_registration.expired? %>
-              <%= t(".labels.expired", formatted_date: @transient_registration.display_expiry_date) %>
-            <% else %>
-              <%= t(".labels.expires", formatted_date: @transient_registration.display_expiry_date) %>
+            <% if @transient_registration.display_expiry_text.present? %>
+              <%= @transient_registration.display_expiry_text %>
+              <br>
             <% end %>
-            <br>
             <%= t(".labels.account", email: @transient_registration.account_email) %>
           </p>
         </div>

--- a/app/views/renewing_registrations/show.html.erb
+++ b/app/views/renewing_registrations/show.html.erb
@@ -85,7 +85,11 @@
             <% end %>
           </p>
           <p>
-            <%= t(".labels.expires", formatted_date: @transient_registration.display_expiry_date) %>
+            <% if @transient_registration.expired? %>
+              <%= t(".labels.expired", formatted_date: @transient_registration.display_expiry_date) %>
+            <% else %>
+              <%= t(".labels.expires", formatted_date: @transient_registration.display_expiry_date) %>
+            <% end %>
             <br>
             <%= t(".labels.account", email: @transient_registration.account_email) %>
           </p>

--- a/config/locales/registrations.en.yml
+++ b/config/locales/registrations.en.yml
@@ -32,8 +32,6 @@ en:
         lower: Lower tier
       labels:
         account: "Account: %{email}"
-        expires: "Expires: %{formatted_date}"
-        expired: "Expired: %{formatted_date}"
       business_information:
         heading: "Business information"
         labels:

--- a/config/locales/renewing_registrations.en.yml
+++ b/config/locales/renewing_registrations.en.yml
@@ -32,8 +32,6 @@ en:
         lower: Lower tier
       labels:
         account: "Account: %{email}"
-        expires: "Expires: %{formatted_date}"
-        expired: "Expired: %{formatted_date}"
       business_information:
         heading: "Business information"
         labels:

--- a/config/locales/shared/registrations.en.yml
+++ b/config/locales/shared/registrations.en.yml
@@ -7,6 +7,9 @@ en:
           links:
             payment: "Process payment"
             continue_button: "Continue as assisted digital"
+      labels:
+        expires: "Expires: %{formatted_date}"
+        expired: "Expired: %{formatted_date}"
       finance_details:
         finance_information:
           lower_tier_message: "Lower tier registration - charges are not applicable."

--- a/spec/presenters/base_registration_presenter_spec.rb
+++ b/spec/presenters/base_registration_presenter_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "rails_helper"
+
 RSpec.describe BaseRegistrationPresenter do
   let(:registration) { double(:registration) }
   let(:view_context) { double(:view_context) }

--- a/spec/presenters/base_registration_presenter_spec.rb
+++ b/spec/presenters/base_registration_presenter_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe BaseRegistrationPresenter do
       expect(subject).to_not be_in_progress
     end
   end
+
   describe "#order" do
     let(:order) { double(:order) }
     let(:registration) do
@@ -204,6 +205,47 @@ RSpec.describe BaseRegistrationPresenter do
           message = "This registration application is still in progress, so there is no conviction match data yet."
 
           expect(subject.display_convictions_check_message).to eq(message)
+        end
+      end
+    end
+  end
+
+  describe "#display_expiry_text" do
+    let(:upper_tier) { false }
+    let(:expired) { false }
+    let(:registration) do
+      double(
+        :registration,
+        expired?: expired,
+        upper_tier?: upper_tier,
+        display_expiry_date: "1 January 2020"
+      )
+    end
+
+    context "when the registration is not upper tier" do
+      it "returns nil" do
+        expect(subject.display_expiry_text).to eq(nil)
+      end
+    end
+
+    context "when the registration is upper tier" do
+      let(:upper_tier) { true }
+
+      context "when it is not expired" do
+        it "displays the 'expires' message" do
+          message = "Expires: 1 January 2020"
+
+          expect(subject.display_expiry_text).to eq(message)
+        end
+      end
+
+      context "when it is expired" do
+        let(:expired) { true }
+
+        it "displays the 'expired' message" do
+          message = "Expired: 1 January 2020"
+
+          expect(subject.display_expiry_text).to eq(message)
         end
       end
     end

--- a/spec/presenters/registration_presenter_spec.rb
+++ b/spec/presenters/registration_presenter_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "rails_helper"
+
 RSpec.describe RegistrationPresenter do
   let(:registration) { double(:registration) }
   let(:view_context) { double(:view_context) }

--- a/spec/presenters/renewing_registration_presenter_spec.rb
+++ b/spec/presenters/renewing_registration_presenter_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "rails_helper"
+
 RSpec.describe RenewingRegistrationPresenter do
   let(:renewing_registration) { double(:renewing_registration) }
   let(:view_context) { double(:view_context) }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-755

This updates the registration and transient_registration details pages to say 'expired' instead of 'expires' when the resource has already expired.