### PR TITLE
Add all action links to details page

### DIFF
--- a/app/assets/stylesheets/partials/_wcr-objects.scss
+++ b/app/assets/stylesheets/partials/_wcr-objects.scss
@@ -1,9 +1,19 @@
 .wcr-actions {
   background-color: #f8f8f8;
-  padding: 0.5em;
+  padding: 10px;
 
   &--push-down {
     margin-top: 45px;
+  }
+
+  li {
+    &:last-child {
+      margin-bottom: 0;
+    }
+
+    &.separated {
+      margin-top: 20px;
+    }
   }
 
   h2:first-child, h3:first-child {

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/ModuleLength
 module ActionLinksHelper
   def details_link_for(resource)
     case resource
@@ -150,3 +151,4 @@ module ActionLinksHelper
     true
   end
 end
+# rubocop:enable Metrics/ModuleLength

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -63,21 +63,52 @@ module ActionLinksHelper
   end
 
   def display_payment_link_for?(resource)
+    display_payment_details_link_for?(resource) && resource.pending_payment?
+  end
+
+  def display_payment_details_link_for?(resource)
     return false unless display_transient_registration_links?(resource) || display_registration_links?(resource)
 
-    resource.pending_payment?
+    resource.upper_tier?
+  end
+
+  def display_revoke_link_for?(resource)
+    return false unless display_registration_links?(resource)
+    return false unless can?(:revoke, WasteCarriersEngine::Registration)
+
+    resource.active?
+  end
+
+  def display_edit_link_for?(resource)
+    return false unless display_registration_links?(resource)
+
+    can?(:update, WasteCarriersEngine::Registration)
+  end
+
+  def display_view_confirmation_letter_link_for?(resource)
+    return false unless display_registration_links?(resource)
+    return false unless can?(:view_certificate, WasteCarriersEngine::Registration)
+
+    resource.active?
+  end
+
+  def display_order_copy_cards_link_for?(resource)
+    return false unless display_registration_links?(resource)
+    return false unless can?(:order_copy_cards, WasteCarriersEngine::Registration)
+
+    resource.active? && resource.upper_tier?
   end
 
   def display_convictions_link_for?(resource)
     return false unless display_transient_registration_links?(resource) || display_registration_links?(resource)
-    return false unless can?(:review_convictions, resource)
+    return false unless can?(:review_convictions, WasteCarriersEngine::Registration)
 
     resource.pending_manual_conviction_check?
   end
 
   def display_renew_link_for?(resource)
     return false unless display_registration_links?(resource)
-    return false unless can?(:renew, resource)
+    return false unless can?(:renew, WasteCarriersEngine::Registration)
 
     resource.can_start_renewal?
   end
@@ -85,7 +116,13 @@ module ActionLinksHelper
   def display_transfer_link_for?(resource)
     return false unless display_registration_links?(resource)
 
-    can?(:transfer, resource)
+    can?(:transfer_registration, WasteCarriersEngine::Registration)
+  end
+
+  def display_cease_link_for?(resource)
+    return false unless display_registration_links?(resource)
+
+    can?(:cease, WasteCarriersEngine::Registration)
   end
 
   private

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -19,12 +19,16 @@ class Ability
     # This covers everything mounted in the engine and used for the assisted digital journey, including WorldPay
     can :update, WasteCarriersEngine::RenewingRegistration
     can :renew, :all
+    can :view_certificate, WasteCarriersEngine::Registration
+    can :order_copy_cards, WasteCarriersEngine::Registration
 
     can :record_cash_payment, WasteCarriersEngine::RenewingRegistration
     can :record_cheque_payment, WasteCarriersEngine::RenewingRegistration
     can :record_postal_order_payment, WasteCarriersEngine::RenewingRegistration
 
     can :review_convictions, :all
+    can :revoke, WasteCarriersEngine::Registration
+    can :cease, WasteCarriersEngine::Registration
 
     can :revert_to_payment_summary, WasteCarriersEngine::RenewingRegistration
 
@@ -32,10 +36,12 @@ class Ability
   end
 
   def permissions_for_finance_user
+    can :view_certificate, WasteCarriersEngine::Registration
     can :record_transfer_payment, WasteCarriersEngine::RenewingRegistration
   end
 
   def permissions_for_finance_admin_user
+    can :view_certificate, WasteCarriersEngine::Registration
     can :record_worldpay_missed_payment, WasteCarriersEngine::RenewingRegistration
   end
 

--- a/app/presenters/registration_presenter.rb
+++ b/app/presenters/registration_presenter.rb
@@ -15,6 +15,26 @@ class RegistrationPresenter < BaseRegistrationPresenter
     "#{Rails.configuration.wcrs_frontend_url}/registrations/#{id}/paymentstatus"
   end
 
+  def edit_link
+    "#{Rails.configuration.wcrs_frontend_url}/registrations/#{id}/edit?edit-process=1"
+  end
+
+  def view_confirmation_letter_link
+    "#{Rails.configuration.wcrs_frontend_url}/registrations/#{id}/view"
+  end
+
+  def order_copy_cards_link
+    "#{Rails.configuration.wcrs_frontend_url}/your-registration/#{id}/order-copy_cards"
+  end
+
+  def revoke_link
+    "#{Rails.configuration.wcrs_frontend_url}/registrations/#{id}/revoke"
+  end
+
+  def cease_link
+    "#{Rails.configuration.wcrs_frontend_url}/registrations/#{id}/confirm_delete"
+  end
+
   def display_registration_status
     metaData.status.titleize
   end

--- a/app/presenters/renewing_registration_presenter.rb
+++ b/app/presenters/renewing_registration_presenter.rb
@@ -13,6 +13,10 @@ class RenewingRegistrationPresenter < BaseRegistrationPresenter
     !renewal_application_submitted?
   end
 
+  def finance_details_link
+    @view.transient_registration_payments_path(reg_identifier)
+  end
+
   private
 
   def current_workflow_state

--- a/app/views/shared/registrations/_action_links_panel.html.erb
+++ b/app/views/shared/registrations/_action_links_panel.html.erb
@@ -10,15 +10,55 @@
       </li>
     <% end %>
 
-    <% if resource.pending_payment? %>
-      <li>
-        <%= link_to t(".actions_box.links.payment"), transient_registration_payments_path(resource.reg_identifier) %>
-      </li>
-    <% end %>
-
     <% if display_renew_link_for?(resource) %>
       <li>
         <%= link_to t(".actions_box.links.renew"), transient_registration_payments_path(resource.reg_identifier) %>
+      </li>
+    <% end %>
+
+    <% if display_transfer_link_for?(resource) %>
+      <li>
+        <%= link_to t(".actions_box.links.transfer"), transfer_link_for(resource) %>
+      </li>
+    <% end %>
+
+    <li class="separated" />
+
+    <% if display_edit_link_for?(resource) %>
+      <li>
+        <%= link_to t(".actions_box.links.edit"), resource.edit_link %>
+      </li>
+    <% end %>
+
+    <% if display_view_confirmation_letter_link_for?(resource) %>
+      <li>
+        <%= link_to t(".actions_box.links.view_confirmation_letter"), resource.view_confirmation_letter_link %>
+      </li>
+    <% end %>
+
+    <li class="separated" />
+
+    <% if display_order_copy_cards_link_for?(resource) %>
+      <li>
+        <%= link_to t(".actions_box.links.order_copy_cards"), resource.order_copy_cards_link %>
+      </li>
+    <% end %>
+
+    <% if display_payment_link_for?(resource) %>
+      <li>
+        <%= link_to t(".actions_box.links.payment_status"), resource.finance_details_link%>
+      </li>
+    <% end %>
+
+    <% if display_revoke_link_for?(resource) %>
+      <li>
+        <%= link_to t(".actions_box.links.revoke"), resource.revoke_link %>
+      </li>
+    <% end %>
+
+    <% if display_cease_link_for?(resource) %>
+      <li>
+        <%= link_to t(".actions_box.links.cease"), resource.cease_link %>
       </li>
     <% end %>
   </ul>

--- a/app/views/shared/registrations/_finance_details.html.erb
+++ b/app/views/shared/registrations/_finance_details.html.erb
@@ -10,7 +10,7 @@
 
 <% if resource.show_finance_details_link? %>
   <p>
-    <%= link_to t(".finance_information.section_link_label"), payment_link_for(resource) %>
+    <%= link_to t(".finance_information.section_link_label"), resource.finance_details_link %>
   </p>
 <% end %>
 

--- a/config/locales/shared/registrations.en.yml
+++ b/config/locales/shared/registrations.en.yml
@@ -5,9 +5,15 @@ en:
         actions_box:
           heading: "Actions for %{reg_identifier}"
           links:
-            payment: "Process payment"
             continue_button: "Continue as assisted digital"
             renew: "Renew"
+            transfer: "Transfer to another account"
+            edit: "Edit registration"
+            view_confirmation_letter: "View confirmation letter"
+            order_copy_cards: "Order copy cards"
+            payment_status: "Payment status"
+            revoke: "Revoke"
+            cease: "De-register"
       finance_details:
         finance_information:
           lower_tier_message: "Lower tier registration - charges are not applicable."

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -279,6 +279,274 @@ RSpec.describe ActionLinksHelper, type: :helper do
     end
   end
 
+  describe "#display_revoke_link_for?" do
+    context "when the resource is a registration" do
+      let(:resource) { build(:registration) }
+
+      before do
+        expect(helper).to receive(:can?).with(:revoke, WasteCarriersEngine::Registration).and_return(can)
+      end
+
+      context "when the user has permission for revoking" do
+        let(:can) { true }
+
+        before do
+          expect(resource).to receive(:active?).and_return(active)
+        end
+
+        context "when the resource is active" do
+          let(:active) { true }
+
+          it "returns true" do
+            expect(helper.display_revoke_link_for?(resource)).to be_truthy
+          end
+        end
+
+        context "when the resource is not active" do
+          let(:active) { false }
+
+          it "returns false" do
+            expect(helper.display_revoke_link_for?(resource)).to be_falsey
+          end
+        end
+      end
+
+      context "when the user has no permission for revoking" do
+        let(:can) { false }
+
+        it "returns false" do
+          expect(helper.display_revoke_link_for?(resource)).to be_falsey
+        end
+      end
+    end
+
+    context "when the resource is a transient registration" do
+      let(:resource) { build(:renewing_registration) }
+
+      it "returns false" do
+        expect(helper.display_revoke_link_for?(resource)).to be_falsey
+      end
+    end
+  end
+
+  describe "#display_edit_link_for?" do
+    context "when the resource is a registration" do
+      let(:resource) { build(:registration) }
+
+      before do
+        expect(helper).to receive(:can?).with(:update, WasteCarriersEngine::Registration).and_return(can)
+      end
+
+      context "when the user has permission for revoking" do
+        let(:can) { true }
+
+        it "returns true" do
+          expect(helper.display_edit_link_for?(resource)).to be_truthy
+        end
+      end
+
+      context "when the user has no permission for revoking" do
+        let(:can) { false }
+
+        it "returns false" do
+          expect(helper.display_edit_link_for?(resource)).to be_falsey
+        end
+      end
+    end
+
+    context "when the resource is a transient registration" do
+      let(:resource) { build(:renewing_registration) }
+
+      it "returns false" do
+        expect(helper.display_edit_link_for?(resource)).to be_falsey
+      end
+    end
+  end
+
+  describe "#display_view_confirmation_letter_link_for?" do
+    context "when the resource is a registration" do
+      let(:resource) { build(:registration) }
+
+      before do
+        expect(helper).to receive(:can?).with(:view_certificate, WasteCarriersEngine::Registration).and_return(can)
+      end
+
+      context "when the user has permission for revoking" do
+        let(:can) { true }
+
+        before do
+          expect(resource).to receive(:active?).and_return(active)
+        end
+
+        context "when the resource is active" do
+          let(:active) { true }
+
+          it "returns true" do
+            expect(helper.display_view_confirmation_letter_link_for?(resource)).to be_truthy
+          end
+        end
+
+        context "when the resource is not active" do
+          let(:active) { false }
+
+          it "returns false" do
+            expect(helper.display_view_confirmation_letter_link_for?(resource)).to be_falsey
+          end
+        end
+      end
+
+      context "when the user has no permission for revoking" do
+        let(:can) { false }
+
+        it "returns false" do
+          expect(helper.display_view_confirmation_letter_link_for?(resource)).to be_falsey
+        end
+      end
+    end
+
+    context "when the resource is a transient registration" do
+      let(:resource) { build(:renewing_registration) }
+
+      it "returns false" do
+        expect(helper.display_view_confirmation_letter_link_for?(resource)).to be_falsey
+      end
+    end
+  end
+
+  describe "#display_order_copy_cards_link_for?" do
+    context "when the resource is a registration" do
+      let(:resource) { build(:registration) }
+
+      before do
+        expect(helper).to receive(:can?).with(:order_copy_cards, WasteCarriersEngine::Registration).and_return(can)
+      end
+
+      context "when the user has permission for revoking" do
+        let(:can) { true }
+
+        before do
+          expect(resource).to receive(:active?).and_return(active)
+        end
+
+        context "when the resource is active" do
+          let(:active) { true }
+
+          before do
+            expect(resource).to receive(:upper_tier?).and_return(upper_tier)
+          end
+
+          context "when the resource is an upper tier" do
+            let(:upper_tier) { true }
+
+            it "returns true" do
+              expect(helper.display_order_copy_cards_link_for?(resource)).to be_truthy
+            end
+          end
+
+          context "when the resource is not an upper tier" do
+            let(:upper_tier) { false }
+
+            it "returns false" do
+              expect(helper.display_order_copy_cards_link_for?(resource)).to be_falsey
+            end
+          end
+        end
+
+        context "when the resource is not active" do
+          let(:active) { false }
+
+          it "returns false" do
+            expect(helper.display_order_copy_cards_link_for?(resource)).to be_falsey
+          end
+        end
+      end
+
+      context "when the user has no permission for revoking" do
+        let(:can) { false }
+
+        it "returns false" do
+          expect(helper.display_order_copy_cards_link_for?(resource)).to be_falsey
+        end
+      end
+    end
+
+    context "when the resource is a transient registration" do
+      let(:resource) { build(:renewing_registration) }
+
+      it "returns false" do
+        expect(helper.display_order_copy_cards_link_for?(resource)).to be_falsey
+      end
+    end
+  end
+
+  describe "#display_cease_link_for?" do
+    context "when the resource is a registration" do
+      let(:resource) { build(:registration) }
+
+      before do
+        expect(helper).to receive(:can?).with(:cease, WasteCarriersEngine::Registration).and_return(can)
+      end
+
+      context "when the user has permission for revoking" do
+        let(:can) { true }
+
+        it "returns true" do
+          expect(helper.display_cease_link_for?(resource)).to be_truthy
+        end
+      end
+
+      context "when the user has no permission for revoking" do
+        let(:can) { false }
+
+        it "returns false" do
+          expect(helper.display_cease_link_for?(resource)).to be_falsey
+        end
+      end
+    end
+
+    context "when the resource is a transient registration" do
+      let(:resource) { build(:renewing_registration) }
+
+      it "returns false" do
+        expect(helper.display_cease_link_for?(resource)).to be_falsey
+      end
+    end
+  end
+
+  describe "#display_payment_details_link_for?" do
+    context "when the result is a Registration" do
+      let(:result) { build(:registration) }
+
+      it "returns true" do
+        expect(helper.display_payment_details_link_for?(result)).to eq(true)
+      end
+
+      context "when the result has been revoked" do
+        before { result.metaData.status = "REVOKED" }
+
+        it "returns false" do
+          expect(helper.display_payment_details_link_for?(result)).to eq(false)
+        end
+      end
+    end
+
+    context "when the result is a RenewingRegistration" do
+      let(:result) { build(:renewing_registration) }
+
+      it "returns true" do
+        expect(helper.display_payment_details_link_for?(result)).to eq(true)
+      end
+
+      context "when the result has been revoked" do
+        before { result.metaData.status = "REVOKED" }
+
+        it "returns false" do
+          expect(helper.display_payment_details_link_for?(result)).to eq(false)
+        end
+      end
+    end
+  end
+
   describe "#display_convictions_link_for?" do
     context "when the result is a Registration" do
       let(:result) { build(:registration) }

--- a/spec/presenters/registration_presenter_spec.rb
+++ b/spec/presenters/registration_presenter_spec.rb
@@ -34,6 +34,66 @@ RSpec.describe RegistrationPresenter do
     end
   end
 
+  describe "#edit_link" do
+    let(:registration) { double(:registration, id: "12345") }
+
+    before do
+      expect(Rails.configuration).to receive(:wcrs_frontend_url).and_return("http://example.com")
+    end
+
+    it "returns a link to the edit page in the old system" do
+      expect(subject.edit_link).to eq("http://example.com/registrations/12345/edit?edit-process=1")
+    end
+  end
+
+  describe "#view_confirmation_letter_link" do
+    let(:registration) { double(:registration, id: "12345") }
+
+    before do
+      expect(Rails.configuration).to receive(:wcrs_frontend_url).and_return("http://example.com")
+    end
+
+    it "returns a link to the confirmation letter page in the old system" do
+      expect(subject.view_confirmation_letter_link).to eq("http://example.com/registrations/12345/view")
+    end
+  end
+
+  describe "#order_copy_cards_link" do
+    let(:registration) { double(:registration, id: "12345") }
+
+    before do
+      expect(Rails.configuration).to receive(:wcrs_frontend_url).and_return("http://example.com")
+    end
+
+    it "returns a link to the order copy cards page in the old system" do
+      expect(subject.order_copy_cards_link).to eq("http://example.com/your-registration/12345/order-copy_cards")
+    end
+  end
+
+  describe "#revoke_link" do
+    let(:registration) { double(:registration, id: "12345") }
+
+    before do
+      expect(Rails.configuration).to receive(:wcrs_frontend_url).and_return("http://example.com")
+    end
+
+    it "returns a link to the revoke feature in the old system" do
+      expect(subject.revoke_link).to eq("http://example.com/registrations/12345/revoke")
+    end
+  end
+
+  describe "#cease_link" do
+    let(:registration) { double(:registration, id: "12345") }
+
+    before do
+      expect(Rails.configuration).to receive(:wcrs_frontend_url).and_return("http://example.com")
+    end
+
+    it "returns a link to the delete feature in the old system" do
+      expect(subject.cease_link).to eq("http://example.com/registrations/12345/confirm_delete")
+    end
+  end
+
   describe "#display_registration_status" do
     let(:metadata) { double(:metadata, status: "PENDING") }
     let(:registration) { double(:registration, metaData: metadata) }

--- a/spec/presenters/renewing_registration_presenter_spec.rb
+++ b/spec/presenters/renewing_registration_presenter_spec.rb
@@ -5,6 +5,18 @@ RSpec.describe RenewingRegistrationPresenter do
   let(:view_context) { double(:view_context) }
   subject { described_class.new(renewing_registration, view_context) }
 
+  describe "#finance_details_link" do
+    it "returns a link to the finance details page" do
+      link = double(:link)
+      reg_identifier = double(:reg_identifier)
+
+      expect(renewing_registration).to receive(:reg_identifier).and_return(reg_identifier)
+      expect(view_context).to receive(:transient_registration_payments_path).with(reg_identifier).and_return(link)
+
+      expect(subject.finance_details_link).to eq(link)
+    end
+  end
+
   describe "#display_current_workflow_state" do
     let(:workflow_state) { "a_workflow_state" }
     let(:renewing_registration) { double(:renewing_registration, workflow_state: workflow_state) }


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-723

Add remaining links to the details page for both renewing registrations and registrations.

<img width="980" alt="Screenshot 2019-11-21 at 11 11 51" src="https://user-images.githubusercontent.com/1385397/69340074-91280680-0c5e-11ea-83d9-814cfa01d3d7.png">
<img width="943" alt="Screenshot 2019-11-21 at 11 20 21" src="https://user-images.githubusercontent.com/1385397/69340075-91280680-0c5e-11ea-9774-aa753fc47a22.png">
