### PR TITLE
Move company details panel to partial

### DIFF
--- a/app/views/registrations/show.html.erb
+++ b/app/views/registrations/show.html.erb
@@ -43,24 +43,8 @@
           <% end %>
         <% end %>
 
-        <div class="panel wcr-panel wcr-panel-border-all">
-          <h2 class="heading-medium">
-            <%= @registration.company_name %>
-          </h2>
-          <p class="lede">
-            <%= t(".tier.#{@registration.tier.downcase}") %>
-            <% if @registration.registration_type.present? %>
-              - <%= I18n.t(".registrations.show.attributes.registration_type.#{@registration.registration_type}") %>
-            <% end %>
-          </p>
-          <p>
-            <% if @registration.display_expiry_text.present? %>
-              <%= @registration.display_expiry_text %>
-              <br>
-            <% end %>
-            <%= t(".labels.account", email: @registration.account_email) %>
-          </p>
-        </div>
+        <%= render "shared/registrations/company_details_panel", resource: @registration %>
+
         <div class="grid-row">
           <div class="column-one-half wcr-side-info-box">
             <h2 class="heading-medium">

--- a/app/views/renewing_registrations/show.html.erb
+++ b/app/views/renewing_registrations/show.html.erb
@@ -74,24 +74,8 @@
           </div>
         <% end %>
 
-        <div class="panel wcr-panel wcr-panel-border-all">
-          <h2 class="heading-medium">
-            <%= @transient_registration.company_name %>
-          </h2>
-          <p class="lede">
-            <%= t(".tier.#{@transient_registration.tier.downcase}") %>
-            <% if @transient_registration.registration_type.present? %>
-              - <%= I18n.t(".renewing_registrations.show.attributes.registration_type.#{@transient_registration.registration_type}") %>
-            <% end %>
-          </p>
-          <p>
-            <% if @transient_registration.display_expiry_text.present? %>
-              <%= @transient_registration.display_expiry_text %>
-              <br>
-            <% end %>
-            <%= t(".labels.account", email: @transient_registration.account_email) %>
-          </p>
-        </div>
+        <%= render "shared/registrations/company_details_panel", resource: @transient_registration %>
+
         <div class="grid-row">
           <div class="column-one-half wcr-side-info-box">
             <h2 class="heading-medium">
@@ -197,7 +181,7 @@
         <% end %>
       </div>
       <div class="column-one-third">
-        <%= render "shared/registrations/action_links_panel", resource: @transient_registration%>
+        <%= render "shared/registrations/action_links_panel", resource: @transient_registration %>
       </div>
     </div>
   </div>

--- a/app/views/shared/registrations/_company_details_panel.html.erb
+++ b/app/views/shared/registrations/_company_details_panel.html.erb
@@ -1,0 +1,18 @@
+<div class="panel wcr-panel wcr-panel-border-all">
+  <h2 class="heading-medium">
+    <%= resource.company_name %>
+  </h2>
+  <p class="lede">
+    <%= t(".tier.#{resource.tier.downcase}") %>
+    <% if resource.registration_type.present? %>
+      - <%= t(".attributes.registration_type.#{resource.registration_type}") %>
+    <% end %>
+  </p>
+  <p>
+    <% if resource.display_expiry_text.present? %>
+      <%= resource.display_expiry_text %>
+      <br>
+    <% end %>
+    <%= t(".labels.account", email: resource.account_email) %>
+  </p>
+</div>

--- a/config/locales/registrations.en.yml
+++ b/config/locales/registrations.en.yml
@@ -27,11 +27,6 @@ en:
           convictions_check_button: "Check conviction matches"
           revert_to_payment_summary_button: "Send back to payment summary"
           missed_worldpay_payment_button: "Add a missed WorldPay payment"
-      tier:
-        upper: Upper tier
-        lower: Lower tier
-      labels:
-        account: "Account: %{email}"
       business_information:
         heading: "Business information"
         labels:
@@ -105,10 +100,3 @@ en:
         key_person:
           conviction_search_result:
             pending: "No data yet"
-        registration_type:
-          carrier_dealer: "Carrier and dealer"
-          broker_dealer: "Broker and dealer"
-          carrier_broker_dealer: "Carrier, broker and dealer"
-        tier:
-          UPPER: "Upper"
-          LOWER: "Lower"

--- a/config/locales/renewing_registrations.en.yml
+++ b/config/locales/renewing_registrations.en.yml
@@ -27,11 +27,6 @@ en:
           convictions_check_button: "Check conviction matches"
           revert_to_payment_summary_button: "Send back to payment summary"
           missed_worldpay_payment_button: "Add a missed WorldPay payment"
-      tier:
-        upper: Upper tier
-        lower: Lower tier
-      labels:
-        account: "Account: %{email}"
       business_information:
         heading: "Business information"
         labels:
@@ -101,10 +96,3 @@ en:
         key_person:
           conviction_search_result:
             pending: "No data yet"
-        registration_type:
-          carrier_dealer: "Carrier and dealer"
-          broker_dealer: "Broker and dealer"
-          carrier_broker_dealer: "Carrier, broker and dealer"
-        tier:
-          UPPER: "Upper"
-          LOWER: "Lower"

--- a/config/locales/shared/registrations.en.yml
+++ b/config/locales/shared/registrations.en.yml
@@ -1,6 +1,17 @@
 en:
   shared:
     registrations:
+      company_details_panel:
+        tier:
+          upper: Upper tier
+          lower: Lower tier
+        labels:
+          account: "Account: %{email}"
+        attributes:
+          registration_type:
+            carrier_dealer: "Carrier and dealer"
+            broker_dealer: "Broker and dealer"
+            carrier_broker_dealer: "Carrier, broker and dealer"
       action_links_panel:
         actions_box:
           heading: "Actions for %{reg_identifier}"


### PR DESCRIPTION
In order to keep our detail pages readable, we want to make sure we create partial on all parts of the details page that transient and non-transient registrations share.