### PR TITLE
Move rejected message status into partial

### DIFF
--- a/app/presenters/registration_presenter.rb
+++ b/app/presenters/registration_presenter.rb
@@ -7,6 +7,14 @@ class RegistrationPresenter < BaseRegistrationPresenter
     I18n.t(".registrations.show.business_information.labels.location", location: location)
   end
 
+  def rejected_header
+    I18n.t(".registrations.show.status.headings.rejected")
+  end
+
+  def rejected_message
+    I18n.t(".registrations.show.status.messages.rejected")
+  end
+
   def display_expiry_date
     expires_on&.to_date
   end

--- a/app/presenters/renewing_registration_presenter.rb
+++ b/app/presenters/renewing_registration_presenter.rb
@@ -5,6 +5,14 @@ class RenewingRegistrationPresenter < BaseRegistrationPresenter
     "#{I18n.t('.renewing_registrations.show.status.messages.in_progress')} \"#{current_workflow_state}\""
   end
 
+  def rejected_header
+    I18n.t(".renewing_registrations.show.status.headings.rejected")
+  end
+
+  def rejected_message
+    I18n.t(".renewing_registrations.show.status.messages.rejected")
+  end
+
   def display_expiry_date
     registration.expires_on&.to_date
   end

--- a/app/views/registrations/show.html.erb
+++ b/app/views/registrations/show.html.erb
@@ -20,14 +20,7 @@
               </p>
             </div>
           <% elsif @registration.rejected_conviction_checks? %>
-            <div class="panel">
-              <h2 class="heading-medium">
-                <%= t(".status.headings.rejected") %>
-              </h2>
-              <p>
-                <%= t(".status.messages.rejected") %>
-              </p>
-            </div>
+            <%= render "shared/registrations/rejected_conviction_checks_details", resource: @registration %>
           <% end %>
 
           <% if @registration.pending_payment? %>

--- a/app/views/renewing_registrations/show.html.erb
+++ b/app/views/renewing_registrations/show.html.erb
@@ -10,14 +10,7 @@
         </h1>
 
         <% if @transient_registration.rejected_conviction_checks? %>
-          <div class="panel">
-            <h2 class="heading-medium">
-              <%= t(".status.headings.rejected") %>
-            </h2>
-            <p>
-              <%= t(".status.messages.rejected") %>
-            </p>
-          </div>
+          <%= render "shared/registrations/rejected_conviction_checks_details", resource: @transient_registration %>
         <% elsif @transient_registration.renewal_application_submitted? %>
           <% if @transient_registration.pending_manual_conviction_check? %>
             <div class="panel">

--- a/app/views/shared/registrations/_rejected_conviction_checks_details.html.erb
+++ b/app/views/shared/registrations/_rejected_conviction_checks_details.html.erb
@@ -1,0 +1,9 @@
+<div class="panel">
+  <h2 class="heading-medium">
+    <%= resource.rejected_header %>
+  </h2>
+
+  <p>
+    <%= resource.rejected_message %>
+  </p>
+</div>

--- a/spec/presenters/registration_presenter_spec.rb
+++ b/spec/presenters/registration_presenter_spec.rb
@@ -24,6 +24,28 @@ RSpec.describe RegistrationPresenter do
     end
   end
 
+  describe "#rejected_header" do
+    it "returns a translated message" do
+      translated_header = double(:translated_header)
+      key = ".registrations.show.status.headings.rejected"
+
+      expect(I18n).to receive(:t).with(key).and_return(translated_header)
+
+      expect(subject.rejected_header).to eq(translated_header)
+    end
+  end
+
+  describe "#rejected_message" do
+    it "returns a translated message" do
+      translated_message = double(:translated_message)
+      key = ".registrations.show.status.messages.rejected"
+
+      expect(I18n).to receive(:t).with(key).and_return(translated_message)
+
+      expect(subject.rejected_message).to eq(translated_message)
+    end
+  end
+
   describe "#finance_details_link" do
     let(:registration) { double(:registration, id: "12345") }
 

--- a/spec/presenters/renewing_registration_presenter_spec.rb
+++ b/spec/presenters/renewing_registration_presenter_spec.rb
@@ -18,6 +18,28 @@ RSpec.describe RenewingRegistrationPresenter do
     end
   end
 
+  describe "#rejected_header" do
+    it "returns a translated message" do
+      translated_header = double(:translated_header)
+      key = ".renewing_registrations.show.status.headings.rejected"
+
+      expect(I18n).to receive(:t).with(key).and_return(translated_header)
+
+      expect(subject.rejected_header).to eq(translated_header)
+    end
+  end
+
+  describe "#rejected_message" do
+    it "returns a translated message" do
+      translated_message = double(:translated_message)
+      key = ".renewing_registrations.show.status.messages.rejected"
+
+      expect(I18n).to receive(:t).with(key).and_return(translated_message)
+
+      expect(subject.rejected_message).to eq(translated_message)
+    end
+  end
+
   describe "#in_progress?" do
     let(:renewing_registration) { double(:renewing_registration, renewal_application_submitted?: submitted) }
 


### PR DESCRIPTION
This moves the rejected message status, used by both details page, into a shared partial.
The trnaslated messages are implemented in presenters as they depends on the type of registration.