### PR TITLE
Details page - Fixes

### DIFF
--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -45,12 +45,6 @@ module ActionLinksHelper
     WasteCarriersEngine::Engine.routes.url_helpers.new_renewal_start_form_path(resource.reg_identifier)
   end
 
-  def transfer_link_for(resource)
-    return "#" unless resource.is_a?(WasteCarriersEngine::Registration)
-
-    new_registration_transfer_path(resource.reg_identifier)
-  end
-
   def display_details_link_for?(resource)
     resource.is_a?(WasteCarriersEngine::RenewingRegistration) || resource.is_a?(WasteCarriersEngine::Registration)
   end

--- a/app/presenters/registration_presenter.rb
+++ b/app/presenters/registration_presenter.rb
@@ -26,7 +26,7 @@ class RegistrationPresenter < BaseRegistrationPresenter
   end
 
   def order_copy_cards_link
-    "#{Rails.configuration.wcrs_frontend_url}/your-registration/#{id}/order-copy_cards"
+    "#{Rails.configuration.wcrs_frontend_url}/your-registration/#{id}/order/order-copy_cards"
   end
 
   def revoke_link

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -140,7 +140,7 @@
                     <% end %>
                   <% if display_transfer_link_for?(result) %>
                     <li>
-                      <%= link_to transfer_link_for(result) do %>
+                      <%= link_to new_registration_transfer_path(result.reg_identifier) do %>
                         <%= t(".results.actions.transfer.link_text") %>
                         <span class="visually-hidden">
                           <%= t(".results.actions.transfer.visually_hidden_text",

--- a/app/views/registrations/show.html.erb
+++ b/app/views/registrations/show.html.erb
@@ -9,16 +9,14 @@
           <%= t(".heading", reg_identifier: @registration.reg_identifier) %>
         </h1>
 
-        <% if @registration.pending? %>
-          <% if @registration.pending_manual_conviction_check? %>
-            <%= render "shared/registrations/pending_convictions_panel", resource: @registration %>
-          <% elsif @registration.rejected_conviction_checks? %>
-            <%= render "shared/registrations/rejected_conviction_checks_details", resource: @registration %>
-          <% end %>
+        <% if @registration.pending_manual_conviction_check? %>
+          <%= render "shared/registrations/pending_convictions_panel", resource: @registration %>
+        <% elsif @registration.rejected_conviction_checks? %>
+          <%= render "shared/registrations/rejected_conviction_checks_details", resource: @registration %>
+        <% end %>
 
-          <% if @registration.pending_payment? %>
-            <%= render "shared/registrations/pending_payment_panel", resource: @registration %>
-          <% end %>
+        <% if @registration.pending_payment? %>
+          <%= render "shared/registrations/pending_payment_panel", resource: @registration %>
         <% end %>
 
         <% if @registration.show_ceased_revoked_panel? %>

--- a/app/views/shared/registrations/_action_links_panel.html.erb
+++ b/app/views/shared/registrations/_action_links_panel.html.erb
@@ -18,7 +18,7 @@
 
     <% if display_transfer_link_for?(resource) %>
       <li>
-        <%= link_to t(".actions_box.links.transfer"), transfer_link_for(resource) %>
+        <%= link_to t(".actions_box.links.transfer"), new_registration_transfer_path(resource.reg_identifier) %>
       </li>
     <% end %>
 

--- a/config/locales/shared/registrations.en.yml
+++ b/config/locales/shared/registrations.en.yml
@@ -17,6 +17,7 @@ en:
             overseas: "Business owner details"
             partnership: "Partners details"
             soleTrader: "Business owner details"
+            publicBody: "Public body"
       contact_and_business_details_panels:
         contact_information:
           heading: "Contact details"
@@ -66,7 +67,7 @@ en:
             renew: "Renew"
             transfer: "Transfer to another account"
             edit: "Edit registration"
-            view_confirmation_letter: "View confirmation letter"
+            view_confirmation_letter: "View certificate"
             order_copy_cards: "Order copy cards"
             payment_status: "Payment status"
             revoke: "Revoke"
@@ -117,4 +118,4 @@ en:
         approved: "This registration was approved after a review of the matching or declared convictions."
         rejected: "This registration was rejected after a review of the matching or declared convictions."
         unknown: "This registration application is still in progress, so there is no conviction match data yet."
-        lower_tier: "Lower tier registration - convictions are not applicable"
+        lower_tier: "Lower tier registration - convictions are not applicable."

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -119,24 +119,6 @@ RSpec.describe ActionLinksHelper, type: :helper do
     end
   end
 
-  describe "transfer_link_for" do
-    context "when the resource is a registration" do
-      let(:resource) { create(:registration) }
-
-      it "returns the correct path" do
-        expect(helper.transfer_link_for(resource)).to eq(new_registration_transfer_path(resource.reg_identifier))
-      end
-    end
-
-    context "when the resource is not a registration" do
-      let(:resource) { create(:renewing_registration) }
-
-      it "returns the correct path" do
-        expect(helper.transfer_link_for(resource)).to eq("#")
-      end
-    end
-  end
-
   describe "#display_details_link_for?" do
     context "when the result is a Registration" do
       let(:result) { build(:registration) }

--- a/spec/presenters/base_registration_presenter_spec.rb
+++ b/spec/presenters/base_registration_presenter_spec.rb
@@ -211,7 +211,7 @@ RSpec.describe BaseRegistrationPresenter do
       let(:registration) { double(:registration, lower_tier?: true) }
 
       it "returns the lower tier text" do
-        message = "Lower tier registration - convictions are not applicable"
+        message = "Lower tier registration - convictions are not applicable."
 
         expect(subject.display_convictions_check_message).to eq(message)
       end

--- a/spec/presenters/registration_presenter_spec.rb
+++ b/spec/presenters/registration_presenter_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe RegistrationPresenter do
     end
 
     it "returns a link to the order copy cards page in the old system" do
-      expect(subject.order_copy_cards_link).to eq("http://example.com/your-registration/12345/order-copy_cards")
+      expect(subject.order_copy_cards_link).to eq("http://example.com/your-registration/12345/order/order-copy_cards")
     end
   end
 


### PR DESCRIPTION
This includes:
 - Correct url for order copy cards from details to old system feature
 - Be consistent with link name of certificate page on old and new syetem
 - Add missing Public Body translation
 - Use correct url for transfer registration functionality
 - Make sure we always show a `pending payment` message when a payment has to be made