### PR TITLE
Make 'revert to payment summary' button display

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -39,7 +39,7 @@ class Ability
     can :revoke, WasteCarriersEngine::Registration
     can :cease, WasteCarriersEngine::Registration
 
-    can :revert_to_payment_summary, WasteCarriersEngine::RenewingRegistration
+    can :revert_to_payment_summary, :all
 
     can :transfer_registration, WasteCarriersEngine::Registration
   end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-781

This button was never showing because CanCanCan was expecting a RenewingRegistration but instead received a RenewingRegistrationPresenter.

We don't really need to check the class anyway so we can just change the permissions to accept `:all` instead.