### PR TITLE
Use classes instead of objects in ability specs

### DIFF
--- a/spec/support/shared_examples/abilities/agency_examples.rb
+++ b/spec/support/shared_examples/abilities/agency_examples.rb
@@ -4,49 +4,49 @@ RSpec.shared_examples "agency examples" do
   # All agency users should be able to do this:
 
   it "should be able to update a transient registration" do
-    should be_able_to(:update, WasteCarriersEngine::RenewingRegistration.new)
+    should be_able_to(:update, WasteCarriersEngine::RenewingRegistration)
   end
 
   it "should be able to renew" do
-    should be_able_to(:renew, WasteCarriersEngine::RenewingRegistration.new)
-    should be_able_to(:renew, WasteCarriersEngine::Registration.new)
+    should be_able_to(:renew, WasteCarriersEngine::RenewingRegistration)
+    should be_able_to(:renew, WasteCarriersEngine::Registration)
   end
 
   it "should be able to review convictions" do
-    should be_able_to(:review_convictions, WasteCarriersEngine::RenewingRegistration.new)
+    should be_able_to(:review_convictions, WasteCarriersEngine::RenewingRegistration)
   end
 
   it "should be able to transfer a registration" do
-    should be_able_to(:transfer_registration, WasteCarriersEngine::Registration.new)
+    should be_able_to(:transfer_registration, WasteCarriersEngine::Registration)
   end
 
   it "should be able to revert to payment summary" do
-    should be_able_to(:revert_to_payment_summary, WasteCarriersEngine::RenewingRegistration.new)
+    should be_able_to(:revert_to_payment_summary, WasteCarriersEngine::RenewingRegistration)
   end
 
   it "should be able to record a cash payment" do
-    should be_able_to(:record_cash_payment, WasteCarriersEngine::RenewingRegistration.new)
+    should be_able_to(:record_cash_payment, WasteCarriersEngine::RenewingRegistration)
   end
 
   it "should be able to record a cheque payment" do
-    should be_able_to(:record_cheque_payment, WasteCarriersEngine::RenewingRegistration.new)
+    should be_able_to(:record_cheque_payment, WasteCarriersEngine::RenewingRegistration)
   end
 
   it "should be able to record a postal order payment" do
-    should be_able_to(:record_postal_order_payment, WasteCarriersEngine::RenewingRegistration.new)
+    should be_able_to(:record_postal_order_payment, WasteCarriersEngine::RenewingRegistration)
   end
 
   # All agency users should NOT be able to do this:
 
   it "should not be able to create an agency_with_refund user" do
-    should_not be_able_to(:create_agency_with_refund_user, User.new)
+    should_not be_able_to(:create_agency_with_refund_user, User)
   end
 
   it "should not be able to create a finance user" do
-    should_not be_able_to(:create_finance_user, User.new)
+    should_not be_able_to(:create_finance_user, User)
   end
 
   it "should not be able to create a finance admin user" do
-    should_not be_able_to(:create_finance_admin_user, User.new)
+    should_not be_able_to(:create_finance_admin_user, User)
   end
 end

--- a/spec/support/shared_examples/abilities/agency_super_examples.rb
+++ b/spec/support/shared_examples/abilities/agency_super_examples.rb
@@ -2,10 +2,10 @@
 
 RSpec.shared_examples "agency_super examples" do
   it "should be able to manage back office users" do
-    should be_able_to(:manage_back_office_users, User.new)
+    should be_able_to(:manage_back_office_users, User)
   end
 
   it "should be able to create an agency user" do
-    should be_able_to(:create_agency_user, User.new)
+    should be_able_to(:create_agency_user, User)
   end
 end

--- a/spec/support/shared_examples/abilities/agency_with_refund_examples.rb
+++ b/spec/support/shared_examples/abilities/agency_with_refund_examples.rb
@@ -2,6 +2,6 @@
 
 RSpec.shared_examples "agency_with_refund examples" do
   it "should be able to view revoked reasons" do
-    should be_able_to(:view_revoked_reasons, WasteCarriersEngine::RenewingRegistration.new)
+    should be_able_to(:view_revoked_reasons, WasteCarriersEngine::RenewingRegistration)
   end
 end

--- a/spec/support/shared_examples/abilities/below_agency_super_examples.rb
+++ b/spec/support/shared_examples/abilities/below_agency_super_examples.rb
@@ -2,10 +2,10 @@
 
 RSpec.shared_examples "below agency_super examples" do
   it "should not be able to manage back office users" do
-    should_not be_able_to(:manage_back_office_users, User.new)
+    should_not be_able_to(:manage_back_office_users, User)
   end
 
   it "should not be able to create an agency user" do
-    should_not be_able_to(:create_agency_user, User.new)
+    should_not be_able_to(:create_agency_user, User)
   end
 end

--- a/spec/support/shared_examples/abilities/below_agency_with_refund_examples.rb
+++ b/spec/support/shared_examples/abilities/below_agency_with_refund_examples.rb
@@ -2,6 +2,6 @@
 
 RSpec.shared_examples "below agency_with_refund examples" do
   it "should not be able to view revoked reasons" do
-    should_not be_able_to(:view_revoked_reasons, WasteCarriersEngine::RenewingRegistration.new)
+    should_not be_able_to(:view_revoked_reasons, WasteCarriersEngine::RenewingRegistration)
   end
 end

--- a/spec/support/shared_examples/abilities/finance_admin_examples.rb
+++ b/spec/support/shared_examples/abilities/finance_admin_examples.rb
@@ -3,73 +3,73 @@
 RSpec.shared_examples "finance_admin examples" do
   # Finance admin users can only do two things:
   it "should be able to record a worldpay payment" do
-    should be_able_to(:record_worldpay_missed_payment, WasteCarriersEngine::RenewingRegistration.new)
+    should be_able_to(:record_worldpay_missed_payment, WasteCarriersEngine::RenewingRegistration)
   end
 
   it "should be able to view the certificate" do
-    should be_able_to(:view_certificate, WasteCarriersEngine::Registration.new)
+    should be_able_to(:view_certificate, WasteCarriersEngine::Registration)
   end
 
   # Everything else is off-limits.
 
   it "should not be able to update a transient registration" do
-    should_not be_able_to(:update, WasteCarriersEngine::RenewingRegistration.new)
+    should_not be_able_to(:update, WasteCarriersEngine::RenewingRegistration)
   end
 
   it "should not be able to renew" do
-    should_not be_able_to(:renew, WasteCarriersEngine::RenewingRegistration.new)
-    should_not be_able_to(:renew, WasteCarriersEngine::Registration.new)
+    should_not be_able_to(:renew, WasteCarriersEngine::RenewingRegistration)
+    should_not be_able_to(:renew, WasteCarriersEngine::Registration)
   end
 
   it "should not be able to record a cash payment" do
-    should_not be_able_to(:record_cash_payment, WasteCarriersEngine::RenewingRegistration.new)
+    should_not be_able_to(:record_cash_payment, WasteCarriersEngine::RenewingRegistration)
   end
 
   it "should not be able to record a cheque payment" do
-    should_not be_able_to(:record_cheque_payment, WasteCarriersEngine::RenewingRegistration.new)
+    should_not be_able_to(:record_cheque_payment, WasteCarriersEngine::RenewingRegistration)
   end
 
   it "should not be able to record a postal order payment" do
-    should_not be_able_to(:record_postal_order_payment, WasteCarriersEngine::RenewingRegistration.new)
+    should_not be_able_to(:record_postal_order_payment, WasteCarriersEngine::RenewingRegistration)
   end
 
   it "should not be able to record a transfer payment" do
-    should_not be_able_to(:record_transfer_payment, WasteCarriersEngine::RenewingRegistration.new)
+    should_not be_able_to(:record_transfer_payment, WasteCarriersEngine::RenewingRegistration)
   end
 
   it "should not be able to review convictions" do
-    should_not be_able_to(:review_convictions, WasteCarriersEngine::RenewingRegistration.new)
+    should_not be_able_to(:review_convictions, WasteCarriersEngine::RenewingRegistration)
   end
 
   it "should not be able to view revoked reasons" do
-    should_not be_able_to(:view_revoked_reasons, WasteCarriersEngine::RenewingRegistration.new)
+    should_not be_able_to(:view_revoked_reasons, WasteCarriersEngine::RenewingRegistration)
   end
 
   it "should not be able to revert to payment summary" do
-    should_not be_able_to(:revert_to_payment_summary, WasteCarriersEngine::RenewingRegistration.new)
+    should_not be_able_to(:revert_to_payment_summary, WasteCarriersEngine::RenewingRegistration)
   end
 
   it "should not be able to manage back office users" do
-    should_not be_able_to(:manage_back_office_users, User.new)
+    should_not be_able_to(:manage_back_office_users, User)
   end
 
   it "should not be able to create an agency user" do
-    should_not be_able_to(:create_agency_user, User.new)
+    should_not be_able_to(:create_agency_user, User)
   end
 
   it "should not be able to create an agency_with_refund user" do
-    should_not be_able_to(:create_agency_with_refund_user, User.new)
+    should_not be_able_to(:create_agency_with_refund_user, User)
   end
 
   it "should not be able to create a finance user" do
-    should_not be_able_to(:create_finance_user, User.new)
+    should_not be_able_to(:create_finance_user, User)
   end
 
   it "should not be able to create a finance admin user" do
-    should_not be_able_to(:create_finance_admin_user, User.new)
+    should_not be_able_to(:create_finance_admin_user, User)
   end
 
   it "should not be able to transfer a registration" do
-    should_not be_able_to(:transfer_registration, WasteCarriersEngine::Registration.new)
+    should_not be_able_to(:transfer_registration, WasteCarriersEngine::Registration)
   end
 end

--- a/spec/support/shared_examples/abilities/finance_examples.rb
+++ b/spec/support/shared_examples/abilities/finance_examples.rb
@@ -3,73 +3,73 @@
 RSpec.shared_examples "finance examples" do
   # Finance users can only do two things:
   it "should be able to record a transfer payment" do
-    should be_able_to(:record_transfer_payment, WasteCarriersEngine::RenewingRegistration.new)
+    should be_able_to(:record_transfer_payment, WasteCarriersEngine::RenewingRegistration)
   end
 
   it "should be able to view the certificate" do
-    should be_able_to(:view_certificate, WasteCarriersEngine::Registration.new)
+    should be_able_to(:view_certificate, WasteCarriersEngine::Registration)
   end
 
   # Everything else is off-limits.
 
   it "should not be able to update a transient registration" do
-    should_not be_able_to(:update, WasteCarriersEngine::RenewingRegistration.new)
+    should_not be_able_to(:update, WasteCarriersEngine::RenewingRegistration)
   end
 
   it "should not be able to renew" do
-    should_not be_able_to(:renew, WasteCarriersEngine::RenewingRegistration.new)
-    should_not be_able_to(:renew, WasteCarriersEngine::Registration.new)
+    should_not be_able_to(:renew, WasteCarriersEngine::RenewingRegistration)
+    should_not be_able_to(:renew, WasteCarriersEngine::Registration)
   end
 
   it "should not be able to record a cash payment" do
-    should_not be_able_to(:record_cash_payment, WasteCarriersEngine::RenewingRegistration.new)
+    should_not be_able_to(:record_cash_payment, WasteCarriersEngine::RenewingRegistration)
   end
 
   it "should not be able to record a cheque payment" do
-    should_not be_able_to(:record_cheque_payment, WasteCarriersEngine::RenewingRegistration.new)
+    should_not be_able_to(:record_cheque_payment, WasteCarriersEngine::RenewingRegistration)
   end
 
   it "should not be able to record a postal order payment" do
-    should_not be_able_to(:record_postal_order_payment, WasteCarriersEngine::RenewingRegistration.new)
+    should_not be_able_to(:record_postal_order_payment, WasteCarriersEngine::RenewingRegistration)
   end
 
   it "should not be able to record a worldpay payment" do
-    should_not be_able_to(:record_worldpay_missed_payment, WasteCarriersEngine::RenewingRegistration.new)
+    should_not be_able_to(:record_worldpay_missed_payment, WasteCarriersEngine::RenewingRegistration)
   end
 
   it "should not be able to review convictions" do
-    should_not be_able_to(:review_convictions, WasteCarriersEngine::RenewingRegistration.new)
+    should_not be_able_to(:review_convictions, WasteCarriersEngine::RenewingRegistration)
   end
 
   it "should not be able to view revoked reasons" do
-    should_not be_able_to(:view_revoked_reasons, WasteCarriersEngine::RenewingRegistration.new)
+    should_not be_able_to(:view_revoked_reasons, WasteCarriersEngine::RenewingRegistration)
   end
 
   it "should not be able to revert to payment summary" do
-    should_not be_able_to(:revert_to_payment_summary, WasteCarriersEngine::RenewingRegistration.new)
+    should_not be_able_to(:revert_to_payment_summary, WasteCarriersEngine::RenewingRegistration)
   end
 
   it "should not be able to manage back office users" do
-    should_not be_able_to(:manage_back_office_users, User.new)
+    should_not be_able_to(:manage_back_office_users, User)
   end
 
   it "should not be able to create an agency user" do
-    should_not be_able_to(:create_agency_user, User.new)
+    should_not be_able_to(:create_agency_user, User)
   end
 
   it "should not be able to create an agency_with_refund user" do
-    should_not be_able_to(:create_agency_with_refund_user, User.new)
+    should_not be_able_to(:create_agency_with_refund_user, User)
   end
 
   it "should not be able to create a finance user" do
-    should_not be_able_to(:create_finance_user, User.new)
+    should_not be_able_to(:create_finance_user, User)
   end
 
   it "should not be able to create a finance admin user" do
-    should_not be_able_to(:create_finance_admin_user, User.new)
+    should_not be_able_to(:create_finance_admin_user, User)
   end
 
   it "should not be able to transfer a registration" do
-    should_not be_able_to(:transfer_registration, WasteCarriersEngine::Registration.new)
+    should_not be_able_to(:transfer_registration, WasteCarriersEngine::Registration)
   end
 end

--- a/spec/support/shared_examples/abilities/finance_super_examples.rb
+++ b/spec/support/shared_examples/abilities/finance_super_examples.rb
@@ -3,73 +3,73 @@
 RSpec.shared_examples "finance_super examples" do
   # Finance super users can only manage users:
   it "should be able to manage back office users" do
-    should be_able_to(:manage_back_office_users, User.new)
+    should be_able_to(:manage_back_office_users, User)
   end
 
   it "should be able to create an agency user" do
-    should be_able_to(:create_agency_user, User.new)
+    should be_able_to(:create_agency_user, User)
   end
 
   it "should be able to create an agency_with_refund user" do
-    should be_able_to(:create_agency_with_refund_user, User.new)
+    should be_able_to(:create_agency_with_refund_user, User)
   end
 
   it "should be able to create a finance user" do
-    should be_able_to(:create_finance_user, User.new)
+    should be_able_to(:create_finance_user, User)
   end
 
   it "should be able to create a finance admin user" do
-    should be_able_to(:create_finance_admin_user, User.new)
+    should be_able_to(:create_finance_admin_user, User)
   end
 
   # Everything else is off-limits.
 
   it "should not be able to view the certificate" do
-    should_not be_able_to(:view_certificate, WasteCarriersEngine::Registration.new)
+    should_not be_able_to(:view_certificate, WasteCarriersEngine::Registration)
   end
 
   it "should not be able to update a transient registration" do
-    should_not be_able_to(:update, WasteCarriersEngine::RenewingRegistration.new)
+    should_not be_able_to(:update, WasteCarriersEngine::RenewingRegistration)
   end
 
   it "should not be able to renew" do
-    should_not be_able_to(:renew, WasteCarriersEngine::RenewingRegistration.new)
-    should_not be_able_to(:renew, WasteCarriersEngine::Registration.new)
+    should_not be_able_to(:renew, WasteCarriersEngine::RenewingRegistration)
+    should_not be_able_to(:renew, WasteCarriersEngine::Registration)
   end
 
   it "should not be able to record a cash payment" do
-    should_not be_able_to(:record_cash_payment, WasteCarriersEngine::RenewingRegistration.new)
+    should_not be_able_to(:record_cash_payment, WasteCarriersEngine::RenewingRegistration)
   end
 
   it "should not be able to record a cheque payment" do
-    should_not be_able_to(:record_cheque_payment, WasteCarriersEngine::RenewingRegistration.new)
+    should_not be_able_to(:record_cheque_payment, WasteCarriersEngine::RenewingRegistration)
   end
 
   it "should not be able to record a postal order payment" do
-    should_not be_able_to(:record_postal_order_payment, WasteCarriersEngine::RenewingRegistration.new)
+    should_not be_able_to(:record_postal_order_payment, WasteCarriersEngine::RenewingRegistration)
   end
 
   it "should not be able to record a transfer payment" do
-    should_not be_able_to(:record_transfer_payment, WasteCarriersEngine::RenewingRegistration.new)
+    should_not be_able_to(:record_transfer_payment, WasteCarriersEngine::RenewingRegistration)
   end
 
   it "should not be able to record a worldpay payment" do
-    should_not be_able_to(:record_worldpay_missed_payment, WasteCarriersEngine::RenewingRegistration.new)
+    should_not be_able_to(:record_worldpay_missed_payment, WasteCarriersEngine::RenewingRegistration)
   end
 
   it "should not be able to review convictions" do
-    should_not be_able_to(:review_convictions, WasteCarriersEngine::RenewingRegistration.new)
+    should_not be_able_to(:review_convictions, WasteCarriersEngine::RenewingRegistration)
   end
 
   it "should not be able to view revoked reasons" do
-    should_not be_able_to(:view_revoked_reasons, WasteCarriersEngine::RenewingRegistration.new)
+    should_not be_able_to(:view_revoked_reasons, WasteCarriersEngine::RenewingRegistration)
   end
 
   it "should not be able to revert to payment summary" do
-    should_not be_able_to(:revert_to_payment_summary, WasteCarriersEngine::RenewingRegistration.new)
+    should_not be_able_to(:revert_to_payment_summary, WasteCarriersEngine::RenewingRegistration)
   end
 
   it "should not be able to transfer a registration" do
-    should_not be_able_to(:transfer_registration, WasteCarriersEngine::Registration.new)
+    should_not be_able_to(:transfer_registration, WasteCarriersEngine::Registration)
   end
 end


### PR DESCRIPTION
CanCanCan will accept a class instead of an instance of that class when checking abilities, so switching to this as it saves us instantiating a bunch of objects.