### PR TITLE
Changes to finance details

### DIFF
--- a/app/presenters/base_registration_presenter.rb
+++ b/app/presenters/base_registration_presenter.rb
@@ -50,8 +50,8 @@ class BaseRegistrationPresenter < WasteCarriersEngine::BasePresenter
     finance_details&.orders&.any? && upper_tier?
   end
 
-  def order
-    finance_details&.orders&.first
+  def latest_order
+    finance_details&.orders&.order_by(dateCreated: :desc)&.first
   end
 
   def display_expiry_text

--- a/app/views/shared/registrations/_finance_details.html.erb
+++ b/app/views/shared/registrations/_finance_details.html.erb
@@ -28,10 +28,10 @@
           <%= t(".order_information.labels.payment_method") %>
         </th>
         <td>
-          <%= resource.order.payment_method.titleize %>
+          <%= resource.latest_order.payment_method.titleize %>
         </td>
       </tr>
-      <% resource.order.order_items.each do |item| %>
+      <% resource.latest_order.order_items.each do |item| %>
         <tr>
           <th>
             <%= item.description %>
@@ -49,19 +49,7 @@
         </th>
         <td>
           <strong class="bold-small">
-            £<%= display_pence_as_pounds(resource.order.total_amount) %>
-          </strong>
-        </td>
-      </tr>
-      <tr>
-        <th>
-          <strong class="bold-small">
-            <%= t(".order_information.labels.paid") %>
-          </strong>
-        </th>
-        <td>
-          <strong class="bold-small">
-            £<%= display_pence_as_pounds(resource.amount_paid) %>
+            £<%= display_pence_as_pounds(resource.latest_order.total_amount) %>
           </strong>
         </td>
       </tr>
@@ -70,7 +58,7 @@
           <%= t(".order_information.labels.order_code") %>
         </th>
         <td>
-          <%= resource.order.order_code %>
+          <%= resource.latest_order.order_code %>
         </td>
       </tr>
     </tbody>

--- a/config/locales/shared/registrations.en.yml
+++ b/config/locales/shared/registrations.en.yml
@@ -88,15 +88,14 @@ en:
       finance_details:
         finance_information:
           lower_tier_message: "Lower tier registration - charges are not applicable."
-          heading_with_amount_owed: "Latest charges and payments: £%{amount} owed"
-          heading: "Latest charges and payments"
+          heading_with_amount_owed: "Latest charges: £%{amount} owed"
+          heading: "Latest charges"
           section_link_label: "Finance details"
           balance:
             no_data: "Application still in progress. No finance data yet."
         order_information:
           labels:
             total_amount: "Total"
-            paid: "Paid"
             payment_method: "Payment method"
             order_code: "Order code"
       show:

--- a/spec/presenters/base_registration_presenter_spec.rb
+++ b/spec/presenters/base_registration_presenter_spec.rb
@@ -97,17 +97,21 @@ RSpec.describe BaseRegistrationPresenter do
     end
   end
 
-  describe "#order" do
-    let(:order) { double(:order) }
+  describe "#latest_order" do
+    let(:latest_order) { double(:order) }
     let(:registration) do
       double(
         :registration,
-        finance_details: double(:finance_details, orders: [order])
+        finance_details: double(:finance_details, orders: double(:orders))
       )
     end
 
-    it "returns the first order in the list of finance details orders" do
-      expect(subject.order).to eq(order)
+    it "returns the last order in the list of finance details orders" do
+      scope = double(:scope)
+      expect(registration.finance_details.orders).to receive(:order_by).with(dateCreated: :desc).and_return(scope)
+      expect(scope).to receive(:first).and_return(latest_order)
+
+      expect(subject.latest_order).to eq(latest_order)
     end
   end
 


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-785

This includes:
 - Make sure we get the *latest order in time* when showing finance details on details pages
 - Change the title of the finance section - Remove `charges`
 - Remove total paid

<img width="666" alt="Screenshot 2019-11-26 at 11 27 54" src="https://user-images.githubusercontent.com/1385397/69626197-0ff6b800-1040-11ea-820c-6ce6e8425c6d.png">
