### PR TITLE
Redirects after a renewing is confirmed

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -4,9 +4,11 @@ class RegistrationsController < ApplicationController
   before_action :authenticate_user!
 
   def show
-    registration = WasteCarriersEngine::Registration.find_by(reg_identifier: params[:reg_identifier])
-
-    redirect_to bo_path unless registration.present?
+    begin
+      registration = WasteCarriersEngine::Registration.find_by(reg_identifier: params[:reg_identifier])
+    rescue Mongoid::Errors::DocumentNotFound
+      return redirect_to bo_path
+    end
 
     @registration = RegistrationPresenter.new(registration, view_context)
   end

--- a/app/controllers/renewing_registrations_controller.rb
+++ b/app/controllers/renewing_registrations_controller.rb
@@ -7,7 +7,7 @@ class RenewingRegistrationsController < ApplicationController
     begin
       transient_registration = WasteCarriersEngine::RenewingRegistration.find_by reg_identifier: params[:reg_identifier]
     rescue Mongoid::Errors::DocumentNotFound
-      scope = WasteCarriersEngine::Registration.where(reg_identifier: params[:reg_identifier]).any?
+      scope = WasteCarriersEngine::Registration.where(reg_identifier: params[:reg_identifier])
 
       return redirect_to registration_path(params[:reg_identifier]) if scope.any?
 

--- a/app/controllers/renewing_registrations_controller.rb
+++ b/app/controllers/renewing_registrations_controller.rb
@@ -5,13 +5,13 @@ class RenewingRegistrationsController < ApplicationController
 
   def show
     begin
-      transient_registration = WasteCarriersEngine::RenewingRegistration.find_by(reg_identifier: params[:reg_identifier])
+      transient_registration = WasteCarriersEngine::RenewingRegistration.find_by reg_identifier: params[:reg_identifier]
     rescue Mongoid::Errors::DocumentNotFound
-      if WasteCarriersEngine::Registration.where(reg_identifier: params[:reg_identifier]).any?
-        return redirect_to registration_path(params[:reg_identifier])
-      else
-        return redirect_to bo_path
-      end
+      scope = WasteCarriersEngine::Registration.where(reg_identifier: params[:reg_identifier]).any?
+
+      return redirect_to registration_path(params[:reg_identifier]) if scope.any?
+
+      return redirect_to bo_path
     end
 
     @transient_registration = RenewingRegistrationPresenter.new(transient_registration, view_context)

--- a/app/controllers/renewing_registrations_controller.rb
+++ b/app/controllers/renewing_registrations_controller.rb
@@ -5,7 +5,7 @@ class RenewingRegistrationsController < ApplicationController
 
   def show
     begin
-      transient_registration = WasteCarriersEngine::RenewingRegistration.find_by reg_identifier: params[:reg_identifier]
+      transient_registration = fetch_renewing_registration
     rescue Mongoid::Errors::DocumentNotFound
       scope = WasteCarriersEngine::Registration.where(reg_identifier: params[:reg_identifier])
 
@@ -15,5 +15,11 @@ class RenewingRegistrationsController < ApplicationController
     end
 
     @transient_registration = RenewingRegistrationPresenter.new(transient_registration, view_context)
+  end
+
+  private
+
+  def fetch_renewing_registration
+    WasteCarriersEngine::RenewingRegistration.find_by(reg_identifier: params[:reg_identifier])
   end
 end

--- a/app/controllers/renewing_registrations_controller.rb
+++ b/app/controllers/renewing_registrations_controller.rb
@@ -4,9 +4,15 @@ class RenewingRegistrationsController < ApplicationController
   before_action :authenticate_user!
 
   def show
-    transient_registration = WasteCarriersEngine::RenewingRegistration.find_by(reg_identifier: params[:reg_identifier])
-
-    redirect_to bo_path unless transient_registration.present?
+    begin
+      transient_registration = WasteCarriersEngine::RenewingRegistration.find_by(reg_identifier: params[:reg_identifier])
+    rescue Mongoid::Errors::DocumentNotFound
+      if WasteCarriersEngine::Registration.where(reg_identifier: params[:reg_identifier]).any?
+        return redirect_to registration_path(params[:reg_identifier])
+      else
+        return redirect_to bo_path
+      end
+    end
 
     @transient_registration = RenewingRegistrationPresenter.new(transient_registration, view_context)
   end

--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -13,8 +13,6 @@ test:
       uri: <%= ENV['WCRS_TEST_REGSDB_URI'] || 'mongodb://mongoUser:password1234@localhost:27017/waste-carriers-test' %>
     users:
       uri: <%= ENV['WCRS_TEST_USERSDB_URI'] || 'mongodb://mongoUser:password1234@localhost:27017/waste-carriers-users-test' %>
-  options:
-    raise_not_found_error: false
 production:
   clients:
     default:

--- a/spec/requests/renewing_registrations_spec.rb
+++ b/spec/requests/renewing_registrations_spec.rb
@@ -33,8 +33,19 @@ RSpec.describe "RenewingRegistrations", type: :request do
       end
 
       context "when no matching transient_registration exists" do
+        context "when a registration exist with that identifier" do
+          let(:registration) { create(:registration) }
+
+          it "rerdirects to the registration details page" do
+            get "/bo/renewing-registrations/#{registration.reg_identifier}"
+
+            expect(response).to redirect_to(registration_path(registration.reg_identifier))
+          end
+        end
+
         it "redirects to the dashboard" do
           get "/bo/renewing-registrations/foo"
+
           expect(response).to redirect_to(bo_path)
         end
       end

--- a/spec/requests/renewing_registrations_spec.rb
+++ b/spec/requests/renewing_registrations_spec.rb
@@ -33,10 +33,10 @@ RSpec.describe "RenewingRegistrations", type: :request do
       end
 
       context "when no matching transient_registration exists" do
-        context "when a registration exist with that identifier" do
+        context "when a registrations exist with that reg_identifier" do
           let(:registration) { create(:registration) }
 
-          it "rerdirects to the registration details page" do
+          it "redirects to the registration details page" do
             get "/bo/renewing-registrations/#{registration.reg_identifier}"
 
             expect(response).to redirect_to(registration_path(registration.reg_identifier))


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-782

When confirming a payment or approving convictions, a renewing registration might get confirmed and evolve to a registration. In that case, the details page of the renewing registration will not exist any more. Historically, we used to just redirect the user to the main dashboard, but during one of the many refactoring we have killed that functionality, and the test suite didn't highlight the issue due to having different mongoId settings than other environments. Hence, I have also killed those special settings as part of this story.
Now, if a user gets to the renewal details page with a renewal id that no longer exist, we will check if we have a registration matching that id and we will redierct the user there. If there is not even a registration matching the given id, we will redirect to the dashboard as we were historically doing.