### PR TITLE
Remove all links to old backend

### DIFF
--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -91,6 +91,8 @@ module ActionLinksHelper
   end
 
   def display_view_confirmation_letter_link_for?(resource)
+    # TODO: delete next line filter when internal route exists https://eaflood.atlassian.net/browse/RUBY-786
+    return false if a_registration?(resource)
     return false unless display_registration_links?(resource)
     return false unless can?(:view_certificate, WasteCarriersEngine::Registration)
 

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -66,6 +66,8 @@ module ActionLinksHelper
   end
 
   def display_payment_details_link_for?(resource)
+    # TODO: delete next line filter when internal route exists https://eaflood.atlassian.net/browse/RUBY-786
+    return false if a_registration?(resource)
     return false unless display_transient_registration_links?(resource) || display_registration_links?(resource)
 
     resource.upper_tier?

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -21,8 +21,9 @@ module ActionLinksHelper
   def payment_link_for(resource)
     if a_transient_registration?(resource)
       transient_registration_payments_path(resource.reg_identifier)
-    elsif a_registration?(resource)
-      "#{Rails.configuration.wcrs_backend_url}/registrations/#{resource.id}/paymentstatus"
+    # TODO: re-implement when internal route exists https://eaflood.atlassian.net/browse/RUBY-786
+    # elsif a_registration?(resource)
+    #   "#{Rails.configuration.wcrs_backend_url}/registrations/#{resource.id}/paymentstatus"
     else
       "#"
     end
@@ -31,8 +32,9 @@ module ActionLinksHelper
   def convictions_link_for(resource)
     if a_transient_registration?(resource)
       transient_registration_convictions_path(resource.reg_identifier)
-    elsif a_registration?(resource)
-      "#{Rails.configuration.wcrs_backend_url}/registrations/#{resource.id}/approve"
+    # TODO: re-implement when internal route exists https://eaflood.atlassian.net/browse/RUBY-786
+    # elsif a_registration?(resource)
+    #   "#{Rails.configuration.wcrs_backend_url}/registrations/#{resource.id}/approve"
     else
       "#"
     end
@@ -57,6 +59,9 @@ module ActionLinksHelper
   end
 
   def display_payment_link_for?(resource)
+    # TODO: delete next line filter when internal route exists https://eaflood.atlassian.net/browse/RUBY-786
+    return false if a_registration?(resource)
+
     display_payment_details_link_for?(resource) && resource.pending_payment?
   end
 
@@ -67,6 +72,8 @@ module ActionLinksHelper
   end
 
   def display_revoke_link_for?(resource)
+    # TODO: delete next line filter when internal route exists https://eaflood.atlassian.net/browse/RUBY-786
+    return false if a_registration?(resource)
     return false unless display_registration_links?(resource)
     return false unless can?(:revoke, WasteCarriersEngine::Registration)
 
@@ -74,6 +81,8 @@ module ActionLinksHelper
   end
 
   def display_edit_link_for?(resource)
+    # TODO: delete next line filter when internal route exists https://eaflood.atlassian.net/browse/RUBY-786
+    return false if a_registration?(resource)
     return false unless display_registration_links?(resource)
 
     can?(:update, WasteCarriersEngine::Registration)
@@ -87,6 +96,8 @@ module ActionLinksHelper
   end
 
   def display_order_copy_cards_link_for?(resource)
+    # TODO: delete next line filter when internal route exists https://eaflood.atlassian.net/browse/RUBY-786
+    return false if a_registration?(resource)
     return false unless display_registration_links?(resource)
     return false unless can?(:order_copy_cards, WasteCarriersEngine::Registration)
 
@@ -114,6 +125,8 @@ module ActionLinksHelper
   end
 
   def display_cease_link_for?(resource)
+    # TODO: delete next line filter when internal route exists https://eaflood.atlassian.net/browse/RUBY-786
+    return false if a_registration?(resource)
     return false unless display_registration_links?(resource)
 
     can?(:cease, WasteCarriersEngine::Registration)

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -31,19 +31,19 @@
     </div>
   </div>
 
-  <div class="column-one-third">
+  <!-- TODO: restore link when internal route exists https://eaflood.atlassian.net/browse/RUBY-786 -->
+  <!-- <div class="column-one-third">
     <div class="wcr-actions">
       <h2 class="heading-small">
-        <%= t(".actions.subheading") %>
+        <%#= t(".actions.subheading") %>
       </h2>
       <ul>
         <li>
-          <!-- TODO: restore link when internal route exists https://eaflood.atlassian.net/browse/RUBY-786 -->
           <%#= link_to t(".actions.new_registration"), "#" %>
         </li>
       </ul>
     </div>
-  </div>
+  </div> -->
 </div>
 
 <% if @results.any? %>

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -38,8 +38,8 @@
       </h2>
       <ul>
         <li>
-          <%= link_to t(".actions.new_registration"),
-                      "#{Rails.configuration.wcrs_backend_url}/registrations/start" %>
+          <!-- TODO: restore link when internal route exists https://eaflood.atlassian.net/browse/RUBY-786 -->
+          <%#= link_to t(".actions.new_registration"), "#" %>
         </li>
       </ul>
     </div>

--- a/app/views/shared/registrations/_action_links_panel.html.erb
+++ b/app/views/shared/registrations/_action_links_panel.html.erb
@@ -30,8 +30,7 @@
       </li>
     <% end %>
 
-    <!-- TODO: put back the check when internal route exists https://eaflood.atlassian.net/browse/RUBY-786 -->
-    <% if false #display_view_confirmation_letter_link_for?(resource) %>
+    <% if display_view_confirmation_letter_link_for?(resource) %>
       <li>
         <%= link_to t(".actions_box.links.view_confirmation_letter"), resource.view_confirmation_letter_link %>
       </li>

--- a/app/views/shared/registrations/_action_links_panel.html.erb
+++ b/app/views/shared/registrations/_action_links_panel.html.erb
@@ -30,7 +30,8 @@
       </li>
     <% end %>
 
-    <% if display_view_confirmation_letter_link_for?(resource) %>
+    <!-- TODO: put back the check when internal route exists https://eaflood.atlassian.net/browse/RUBY-786 -->
+    <% if false #display_view_confirmation_letter_link_for?(resource) %>
       <li>
         <%= link_to t(".actions_box.links.view_confirmation_letter"), resource.view_confirmation_letter_link %>
       </li>

--- a/app/views/shared/registrations/_expired_panel.html.erb
+++ b/app/views/shared/registrations/_expired_panel.html.erb
@@ -6,8 +6,9 @@
     <%= link_to t(".links.renew"),
                 WasteCarriersEngine::Engine.routes.url_helpers.new_renewal_start_form_path(resource.reg_identifier),
                 class: 'button' %>
-  <% else %>
-    <%= link_to t(".links.new_registration"),
+  <!-- TODO: restore when internal route exists https://eaflood.atlassian.net/browse/RUBY-786 -->
+  <%# else %>
+    <%#= link_to t(".links.new_registration"),
                 "#{Rails.configuration.wcrs_backend_url}/registrations/start",
                 class: 'button' %>
   <% end %>

--- a/app/views/shared/registrations/_finance_details.html.erb
+++ b/app/views/shared/registrations/_finance_details.html.erb
@@ -8,7 +8,7 @@
   <% end %>
 </h2>
 
-<% if resource.show_finance_details_link? %>
+<% if resource.show_finance_details_link? && display_payment_link_for?(resource) %>
   <p>
     <%= link_to t(".finance_information.section_link_label"), resource.finance_details_link %>
   </p>

--- a/app/views/shared/registrations/_pending_payment_panel.html.erb
+++ b/app/views/shared/registrations/_pending_payment_panel.html.erb
@@ -5,5 +5,8 @@
   <p>
     <%= t(".status.messages.pending_payment", total: display_pence_as_pounds(resource.finance_details_balance)) %>
   </p>
-  <%= link_to t(".status.actions.payment_button"), resource.finance_details_link, class: 'button' %>
+  <!-- TODO: delete condition when internal route exists https://eaflood.atlassian.net/browse/RUBY-786 -->
+  <% if display_payment_link_for?(resource) %>
+    <%= link_to t(".status.actions.payment_button"), resource.finance_details_link, class: 'button' %>
+  <% end %>
 </div>

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -366,41 +366,46 @@ RSpec.describe ActionLinksHelper, type: :helper do
     context "when the resource is a registration" do
       let(:resource) { build(:registration) }
 
-      before do
-        expect(helper).to receive(:can?).with(:view_certificate, WasteCarriersEngine::Registration).and_return(can)
+      it "returns false" do
+        expect(helper.display_view_confirmation_letter_link_for?(resource)).to eq(false)
       end
 
-      context "when the user has permission for revoking" do
-        let(:can) { true }
+      # TODO: re-implement when internal route exists https://eaflood.atlassian.net/browse/RUBY-786
+      # before do
+      #   expect(helper).to receive(:can?).with(:view_certificate, WasteCarriersEngine::Registration).and_return(can)
+      # end
 
-        before do
-          expect(resource).to receive(:active?).and_return(active)
-        end
+      # context "when the user has permission for revoking" do
+      #   let(:can) { true }
 
-        context "when the resource is active" do
-          let(:active) { true }
+      #   before do
+      #     expect(resource).to receive(:active?).and_return(active)
+      #   end
 
-          it "returns true" do
-            expect(helper.display_view_confirmation_letter_link_for?(resource)).to be_truthy
-          end
-        end
+      #   context "when the resource is active" do
+      #     let(:active) { true }
 
-        context "when the resource is not active" do
-          let(:active) { false }
+      #     it "returns true" do
+      #       expect(helper.display_view_confirmation_letter_link_for?(resource)).to be_truthy
+      #     end
+      #   end
 
-          it "returns false" do
-            expect(helper.display_view_confirmation_letter_link_for?(resource)).to be_falsey
-          end
-        end
-      end
+      #   context "when the resource is not active" do
+      #     let(:active) { false }
 
-      context "when the user has no permission for revoking" do
-        let(:can) { false }
+      #     it "returns false" do
+      #       expect(helper.display_view_confirmation_letter_link_for?(resource)).to be_falsey
+      #     end
+      #   end
+      # end
 
-        it "returns false" do
-          expect(helper.display_view_confirmation_letter_link_for?(resource)).to be_falsey
-        end
-      end
+      # context "when the user has no permission for revoking" do
+      #   let(:can) { false }
+
+      #   it "returns false" do
+      #     expect(helper.display_view_confirmation_letter_link_for?(resource)).to be_falsey
+      #   end
+      # end
     end
 
     context "when the resource is a transient registration" do

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -56,14 +56,15 @@ RSpec.describe ActionLinksHelper, type: :helper do
       end
     end
 
-    context "when the resource is a registration" do
-      let(:resource) { build(:registration) }
+    # TODO: re-implement when internal route exists https://eaflood.atlassian.net/browse/RUBY-786
+    # context "when the resource is a registration" do
+    #   let(:resource) { build(:registration) }
 
-      it "returns the correct path" do
-        path = "#{Rails.configuration.wcrs_backend_url}/registrations/#{resource.id}/paymentstatus"
-        expect(helper.payment_link_for(resource)).to eq(path)
-      end
-    end
+    #   it "returns the correct path" do
+    #     path = "#{Rails.configuration.wcrs_backend_url}/registrations/#{resource.id}/paymentstatus"
+    #     expect(helper.payment_link_for(resource)).to eq(path)
+    #   end
+    # end
 
     context "when the resource is not a registration or a transient_registration" do
       let(:resource) { nil }
@@ -83,14 +84,15 @@ RSpec.describe ActionLinksHelper, type: :helper do
       end
     end
 
-    context "when the resource is a registration" do
-      let(:resource) { build(:registration) }
+    # TODO: re-implement when internal route exists https://eaflood.atlassian.net/browse/RUBY-786
+    # context "when the resource is a registration" do
+    #   let(:resource) { build(:registration) }
 
-      it "returns the correct path" do
-        path = "#{Rails.configuration.wcrs_backend_url}/registrations/#{resource.id}/approve"
-        expect(helper.convictions_link_for(resource)).to eq(path)
-      end
-    end
+    #   it "returns the correct path" do
+    #     path = "#{Rails.configuration.wcrs_backend_url}/registrations/#{resource.id}/approve"
+    #     expect(helper.convictions_link_for(resource)).to eq(path)
+    #   end
+    # end
 
     context "when the resource is not a registration or a transient_registration" do
       let(:resource) { nil }
@@ -207,29 +209,34 @@ RSpec.describe ActionLinksHelper, type: :helper do
     context "when the result is a Registration" do
       let(:result) { build(:registration) }
 
-      context "when the result has been revoked" do
-        before { result.metaData.status = "REVOKED" }
-
-        it "returns false" do
-          expect(helper.display_payment_link_for?(result)).to eq(false)
-        end
+      it "returns false" do
+        expect(helper.display_payment_link_for?(result)).to eq(false)
       end
 
-      context "when the result has no pending payment" do
-        let(:result) { build(:registration, :no_pending_payment) }
+      # TODO: re-implement when internal route exists https://eaflood.atlassian.net/browse/RUBY-786
+      # context "when the result has been revoked" do
+      #   before { result.metaData.status = "REVOKED" }
 
-        it "returns false" do
-          expect(helper.display_payment_link_for?(result)).to eq(false)
-        end
-      end
+      #   it "returns false" do
+      #     expect(helper.display_payment_link_for?(result)).to eq(false)
+      #   end
+      # end
 
-      context "when the result has a pending payment" do
-        let(:result) { build(:registration, :pending_payment) }
+      # context "when the result has no pending payment" do
+      #   let(:result) { build(:registration, :no_pending_payment) }
 
-        it "returns true" do
-          expect(helper.display_payment_link_for?(result)).to eq(true)
-        end
-      end
+      #   it "returns false" do
+      #     expect(helper.display_payment_link_for?(result)).to eq(false)
+      #   end
+      # end
+
+      # context "when the result has a pending payment" do
+      #   let(:result) { build(:registration, :pending_payment) }
+
+      #   it "returns true" do
+      #     expect(helper.display_payment_link_for?(result)).to eq(true)
+      #   end
+      # end
     end
 
     context "when the result is a RenewingRegistration" do
@@ -265,41 +272,46 @@ RSpec.describe ActionLinksHelper, type: :helper do
     context "when the resource is a registration" do
       let(:resource) { build(:registration) }
 
-      before do
-        expect(helper).to receive(:can?).with(:revoke, WasteCarriersEngine::Registration).and_return(can)
+      it "returns false" do
+        expect(helper.display_revoke_link_for?(resource)).to eq(false)
       end
 
-      context "when the user has permission for revoking" do
-        let(:can) { true }
+      # TODO: re-implement when internal route exists https://eaflood.atlassian.net/browse/RUBY-786
+      # before do
+      #   expect(helper).to receive(:can?).with(:revoke, WasteCarriersEngine::Registration).and_return(can)
+      # end
 
-        before do
-          expect(resource).to receive(:active?).and_return(active)
-        end
+      # context "when the user has permission for revoking" do
+      #   let(:can) { true }
 
-        context "when the resource is active" do
-          let(:active) { true }
+      #   before do
+      #     expect(resource).to receive(:active?).and_return(active)
+      #   end
 
-          it "returns true" do
-            expect(helper.display_revoke_link_for?(resource)).to be_truthy
-          end
-        end
+      #   context "when the resource is active" do
+      #     let(:active) { true }
 
-        context "when the resource is not active" do
-          let(:active) { false }
+      #     it "returns true" do
+      #       expect(helper.display_revoke_link_for?(resource)).to be_truthy
+      #     end
+      #   end
 
-          it "returns false" do
-            expect(helper.display_revoke_link_for?(resource)).to be_falsey
-          end
-        end
-      end
+      #   context "when the resource is not active" do
+      #     let(:active) { false }
 
-      context "when the user has no permission for revoking" do
-        let(:can) { false }
+      #     it "returns false" do
+      #       expect(helper.display_revoke_link_for?(resource)).to be_falsey
+      #     end
+      #   end
+      # end
 
-        it "returns false" do
-          expect(helper.display_revoke_link_for?(resource)).to be_falsey
-        end
-      end
+      # context "when the user has no permission for revoking" do
+      #   let(:can) { false }
+
+      #   it "returns false" do
+      #     expect(helper.display_revoke_link_for?(resource)).to be_falsey
+      #   end
+      # end
     end
 
     context "when the resource is a transient registration" do
@@ -315,25 +327,30 @@ RSpec.describe ActionLinksHelper, type: :helper do
     context "when the resource is a registration" do
       let(:resource) { build(:registration) }
 
-      before do
-        expect(helper).to receive(:can?).with(:update, WasteCarriersEngine::Registration).and_return(can)
+      it "returns false" do
+        expect(helper.display_edit_link_for?(resource)).to eq(false)
       end
 
-      context "when the user has permission for revoking" do
-        let(:can) { true }
+      # TODO: re-implement when internal route exists https://eaflood.atlassian.net/browse/RUBY-786
+      # before do
+      #   expect(helper).to receive(:can?).with(:update, WasteCarriersEngine::Registration).and_return(can)
+      # end
 
-        it "returns true" do
-          expect(helper.display_edit_link_for?(resource)).to be_truthy
-        end
-      end
+      # context "when the user has permission for revoking" do
+      #   let(:can) { true }
 
-      context "when the user has no permission for revoking" do
-        let(:can) { false }
+      #   it "returns true" do
+      #     expect(helper.display_edit_link_for?(resource)).to be_truthy
+      #   end
+      # end
 
-        it "returns false" do
-          expect(helper.display_edit_link_for?(resource)).to be_falsey
-        end
-      end
+      # context "when the user has no permission for revoking" do
+      #   let(:can) { false }
+
+      #   it "returns false" do
+      #     expect(helper.display_edit_link_for?(resource)).to be_falsey
+      #   end
+      # end
     end
 
     context "when the resource is a transient registration" do
@@ -399,57 +416,62 @@ RSpec.describe ActionLinksHelper, type: :helper do
     context "when the resource is a registration" do
       let(:resource) { build(:registration) }
 
-      before do
-        expect(helper).to receive(:can?).with(:order_copy_cards, WasteCarriersEngine::Registration).and_return(can)
+      it "returns false" do
+        expect(helper.display_order_copy_cards_link_for?(resource)).to eq(false)
       end
 
-      context "when the user has permission for revoking" do
-        let(:can) { true }
+      # TODO: re-implement when internal route exists https://eaflood.atlassian.net/browse/RUBY-786
+      # before do
+      #   expect(helper).to receive(:can?).with(:order_copy_cards, WasteCarriersEngine::Registration).and_return(can)
+      # end
 
-        before do
-          expect(resource).to receive(:active?).and_return(active)
-        end
+      # context "when the user has permission for revoking" do
+      #   let(:can) { true }
 
-        context "when the resource is active" do
-          let(:active) { true }
+      #   before do
+      #     expect(resource).to receive(:active?).and_return(active)
+      #   end
 
-          before do
-            expect(resource).to receive(:upper_tier?).and_return(upper_tier)
-          end
+      #   context "when the resource is active" do
+      #     let(:active) { true }
 
-          context "when the resource is an upper tier" do
-            let(:upper_tier) { true }
+      #     before do
+      #       expect(resource).to receive(:upper_tier?).and_return(upper_tier)
+      #     end
 
-            it "returns true" do
-              expect(helper.display_order_copy_cards_link_for?(resource)).to be_truthy
-            end
-          end
+      #     context "when the resource is an upper tier" do
+      #       let(:upper_tier) { true }
 
-          context "when the resource is not an upper tier" do
-            let(:upper_tier) { false }
+      #       it "returns true" do
+      #         expect(helper.display_order_copy_cards_link_for?(resource)).to be_truthy
+      #       end
+      #     end
 
-            it "returns false" do
-              expect(helper.display_order_copy_cards_link_for?(resource)).to be_falsey
-            end
-          end
-        end
+      #     context "when the resource is not an upper tier" do
+      #       let(:upper_tier) { false }
 
-        context "when the resource is not active" do
-          let(:active) { false }
+      #       it "returns false" do
+      #         expect(helper.display_order_copy_cards_link_for?(resource)).to be_falsey
+      #       end
+      #     end
+      #   end
 
-          it "returns false" do
-            expect(helper.display_order_copy_cards_link_for?(resource)).to be_falsey
-          end
-        end
-      end
+      #   context "when the resource is not active" do
+      #     let(:active) { false }
 
-      context "when the user has no permission for revoking" do
-        let(:can) { false }
+      #     it "returns false" do
+      #       expect(helper.display_order_copy_cards_link_for?(resource)).to be_falsey
+      #     end
+      #   end
+      # end
 
-        it "returns false" do
-          expect(helper.display_order_copy_cards_link_for?(resource)).to be_falsey
-        end
-      end
+      # context "when the user has no permission for revoking" do
+      #   let(:can) { false }
+
+      #   it "returns false" do
+      #     expect(helper.display_order_copy_cards_link_for?(resource)).to be_falsey
+      #   end
+      # end
     end
 
     context "when the resource is a transient registration" do
@@ -465,25 +487,30 @@ RSpec.describe ActionLinksHelper, type: :helper do
     context "when the resource is a registration" do
       let(:resource) { build(:registration) }
 
-      before do
-        expect(helper).to receive(:can?).with(:cease, WasteCarriersEngine::Registration).and_return(can)
+      it "returns false" do
+        expect(helper.display_cease_link_for?(resource)).to eq(false)
       end
 
-      context "when the user has permission for revoking" do
-        let(:can) { true }
+      # TODO: re-implement when internal route exists https://eaflood.atlassian.net/browse/RUBY-786
+      # before do
+      #   expect(helper).to receive(:can?).with(:cease, WasteCarriersEngine::Registration).and_return(can)
+      # end
 
-        it "returns true" do
-          expect(helper.display_cease_link_for?(resource)).to be_truthy
-        end
-      end
+      # context "when the user has permission for revoking" do
+      #   let(:can) { true }
 
-      context "when the user has no permission for revoking" do
-        let(:can) { false }
+      #   it "returns true" do
+      #     expect(helper.display_cease_link_for?(resource)).to be_truthy
+      #   end
+      # end
 
-        it "returns false" do
-          expect(helper.display_cease_link_for?(resource)).to be_falsey
-        end
-      end
+      # context "when the user has no permission for revoking" do
+      #   let(:can) { false }
+
+      #   it "returns false" do
+      #     expect(helper.display_cease_link_for?(resource)).to be_falsey
+      #   end
+      # end
     end
 
     context "when the resource is a transient registration" do
@@ -499,17 +526,22 @@ RSpec.describe ActionLinksHelper, type: :helper do
     context "when the result is a Registration" do
       let(:result) { build(:registration) }
 
-      it "returns true" do
-        expect(helper.display_payment_details_link_for?(result)).to eq(true)
+      it "returns false" do
+        expect(helper.display_payment_details_link_for?(result)).to eq(false)
       end
 
-      context "when the result has been revoked" do
-        before { result.metaData.status = "REVOKED" }
+      # TODO: re-implement when internal route exists https://eaflood.atlassian.net/browse/RUBY-786
+      # it "returns true" do
+      #   expect(helper.display_payment_details_link_for?(result)).to eq(true)
+      # end
 
-        it "returns false" do
-          expect(helper.display_payment_details_link_for?(result)).to eq(false)
-        end
-      end
+      # context "when the result has been revoked" do
+      #   before { result.metaData.status = "REVOKED" }
+
+      #   it "returns false" do
+      #     expect(helper.display_payment_details_link_for?(result)).to eq(false)
+      #   end
+      # end
     end
 
     context "when the result is a RenewingRegistration" do


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-786

Since the two system do not share login cookies, when moving from the new back office to the old back office users are asked to login again every time. In the case of starting a new registration, they were blocked to do so half way through the process and redirected to login and then to the admin's dashboard.
Since there is currently no functionality on the old code to deal with the redirect to the correct page after login, we decided to kill all the links for our initial release.