### PR TITLE
Fix renew link in registration details page

### DIFF
--- a/app/views/shared/registrations/_action_links_panel.html.erb
+++ b/app/views/shared/registrations/_action_links_panel.html.erb
@@ -12,7 +12,7 @@
 
     <% if display_renew_link_for?(resource) %>
       <li>
-        <%= link_to t(".actions_box.links.renew"), transient_registration_payments_path(resource.reg_identifier) %>
+        <%= link_to t(".actions_box.links.renew"), renew_link_for(resource) %>
       </li>
     <% end %>
 


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-723

Fix link to renew functionality which was redirecting the user to the payment page instead