### PR TITLE
Redirect to registration details after transfering

### DIFF
--- a/app/helpers/registration_transfers_helper.rb
+++ b/app/helpers/registration_transfers_helper.rb
@@ -6,11 +6,4 @@ module RegistrationTransfersHelper
     user = ExternalUser.where(email: email).first
     user.invitation_created_at.present? && user.invitation_accepted_at.blank?
   end
-
-  def continue_after_transfer_link(registration)
-    [Rails.configuration.wcrs_backend_url,
-     "/registrations?utf8=%E2%9C%93&q=",
-     registration.reg_identifier,
-     "&commit=Search&searchWithin=any"].join
-  end
 end

--- a/app/views/registration_transfers/success.html.erb
+++ b/app/views/registration_transfers/success.html.erb
@@ -19,7 +19,7 @@
     </div>
 
     <div class="form-group">
-      <%= link_to t(".button"), continue_after_transfer_link(@registration), class: "button" %>
+      <%= link_to t(".button"), registration_path(@registration.reg_identifier), class: "button" %>
     </div>
   </end>
 </end>

--- a/spec/helpers/registration_transfers_helper_spec.rb
+++ b/spec/helpers/registration_transfers_helper_spec.rb
@@ -38,13 +38,4 @@ RSpec.describe RegistrationTransfersHelper, type: :helper do
       end
     end
   end
-
-  describe "#continue_after_transfer_link" do
-    let(:subject) { helper.continue_after_transfer_link(registration) }
-
-    it "returns the correct link" do
-      url = "http://localhost:3000/registrations?utf8=%E2%9C%93&q=#{registration.reg_identifier}&commit=Search&searchWithin=any"
-      expect(subject).to eq(url)
-    end
-  end
 end


### PR DESCRIPTION
Since now we have an internal details page that works with registrations, we want users transferring registration to be redirected to it after completing a transfer.