### PR TITLE
Update conviction dashboard to include registrations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: af80154a8e0e6e6d528bc7434ce31e31171ccf6d
+  revision: 227691e2c3a41a74d6221268fdce5b969dc87976
   branch: master
   specs:
     waste_carriers_engine (0.0.1)

--- a/app/controllers/convictions_dashboards_controller.rb
+++ b/app/controllers/convictions_dashboards_controller.rb
@@ -22,7 +22,8 @@ class ConvictionsDashboardsController < ApplicationController
   private
 
   def list_of_possible_matches
-    WasteCarriersEngine::RenewingRegistration.submitted.convictions_possible_match
+    WasteCarriersEngine::RenewingRegistration.submitted.convictions_possible_match +
+      WasteCarriersEngine::Registration.convictions_possible_match
   end
 
   def list_of_checks_in_progress
@@ -37,8 +38,9 @@ class ConvictionsDashboardsController < ApplicationController
     WasteCarriersEngine::RenewingRegistration.submitted.convictions_rejected
   end
 
-  def ordered_and_paged(transient_registrations)
-    @transient_registrations = transient_registrations.order_by("metaData.lastModified": :asc)
-                                                      .page params[:page]
+  def ordered_and_paged(matches)
+    ordered_matches = matches.sort_by { |match| match.metaData.last_modified }
+
+    @transient_registrations = Kaminari.paginate_array(ordered_matches).page(params[:page])
   end
 end

--- a/app/controllers/convictions_dashboards_controller.rb
+++ b/app/controllers/convictions_dashboards_controller.rb
@@ -32,7 +32,8 @@ class ConvictionsDashboardsController < ApplicationController
   end
 
   def list_of_approved
-    WasteCarriersEngine::RenewingRegistration.submitted.convictions_approved
+    WasteCarriersEngine::RenewingRegistration.submitted.convictions_approved +
+      WasteCarriersEngine::Registration.convictions_approved.where("metaData.status": "PENDING")
   end
 
   def list_of_rejected

--- a/app/controllers/convictions_dashboards_controller.rb
+++ b/app/controllers/convictions_dashboards_controller.rb
@@ -4,22 +4,38 @@ class ConvictionsDashboardsController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    ordered_and_paged(WasteCarriersEngine::RenewingRegistration.submitted.convictions_possible_match)
+    ordered_and_paged(list_of_possible_matches)
   end
 
   def checks_in_progress
-    ordered_and_paged(WasteCarriersEngine::RenewingRegistration.submitted.convictions_checks_in_progress)
+    ordered_and_paged(list_of_checks_in_progress)
   end
 
   def approved
-    ordered_and_paged(WasteCarriersEngine::RenewingRegistration.submitted.convictions_approved)
+    ordered_and_paged(list_of_approved)
   end
 
   def rejected
-    ordered_and_paged(WasteCarriersEngine::RenewingRegistration.submitted.convictions_rejected)
+    ordered_and_paged(list_of_rejected)
   end
 
   private
+
+  def list_of_possible_matches
+    WasteCarriersEngine::RenewingRegistration.submitted.convictions_possible_match
+  end
+
+  def list_of_checks_in_progress
+    WasteCarriersEngine::RenewingRegistration.submitted.convictions_checks_in_progress
+  end
+
+  def list_of_approved
+    WasteCarriersEngine::RenewingRegistration.submitted.convictions_approved
+  end
+
+  def list_of_rejected
+    WasteCarriersEngine::RenewingRegistration.submitted.convictions_rejected
+  end
 
   def ordered_and_paged(transient_registrations)
     @transient_registrations = transient_registrations.order_by("metaData.lastModified": :asc)

--- a/app/controllers/convictions_dashboards_controller.rb
+++ b/app/controllers/convictions_dashboards_controller.rb
@@ -27,7 +27,8 @@ class ConvictionsDashboardsController < ApplicationController
   end
 
   def list_of_checks_in_progress
-    WasteCarriersEngine::RenewingRegistration.submitted.convictions_checks_in_progress
+    WasteCarriersEngine::RenewingRegistration.submitted.convictions_checks_in_progress +
+      WasteCarriersEngine::Registration.convictions_checks_in_progress
   end
 
   def list_of_approved

--- a/app/controllers/convictions_dashboards_controller.rb
+++ b/app/controllers/convictions_dashboards_controller.rb
@@ -4,19 +4,19 @@ class ConvictionsDashboardsController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    ordered_and_paged(WasteCarriersEngine::RenewingRegistration.convictions_possible_match)
+    ordered_and_paged(WasteCarriersEngine::RenewingRegistration.submitted.convictions_possible_match)
   end
 
   def checks_in_progress
-    ordered_and_paged(WasteCarriersEngine::RenewingRegistration.convictions_checks_in_progress)
+    ordered_and_paged(WasteCarriersEngine::RenewingRegistration.submitted.convictions_checks_in_progress)
   end
 
   def approved
-    ordered_and_paged(WasteCarriersEngine::RenewingRegistration.convictions_approved)
+    ordered_and_paged(WasteCarriersEngine::RenewingRegistration.submitted.convictions_approved)
   end
 
   def rejected
-    ordered_and_paged(WasteCarriersEngine::RenewingRegistration.convictions_rejected)
+    ordered_and_paged(WasteCarriersEngine::RenewingRegistration.submitted.convictions_rejected)
   end
 
   private

--- a/app/controllers/convictions_dashboards_controller.rb
+++ b/app/controllers/convictions_dashboards_controller.rb
@@ -43,6 +43,6 @@ class ConvictionsDashboardsController < ApplicationController
   def ordered_and_paged(matches)
     ordered_matches = matches.sort_by { |match| match.metaData.last_modified }
 
-    @transient_registrations = Kaminari.paginate_array(ordered_matches).page(params[:page])
+    @results = Kaminari.paginate_array(ordered_matches).page(params[:page])
   end
 end

--- a/app/views/shared/_convictions_dashboard_results.html.erb
+++ b/app/views/shared/_convictions_dashboard_results.html.erb
@@ -1,4 +1,4 @@
-<% if @transient_registrations.present? %>
+<% if @results.present? %>
   <div class="grid-row">
     <div class="column-full">
       <table>
@@ -11,19 +11,19 @@
           </tr>
         </thead>
         <tbody>
-          <% @transient_registrations.each do |transient_registration| %>
+          <% @results.each do |result| %>
             <tr>
               <td>
-                <%= transient_registration.reg_identifier %>
+                <%= result.reg_identifier %>
               </td>
               <td>
-                <%= transient_registration.company_name %>
+                <%= result.company_name %>
               </td>
               <td>
-                <%= transient_registration.metaData.last_modified.in_time_zone("London").strftime("%H:%M %d/%m/%Y") %>
+                <%= result.metaData.last_modified.in_time_zone("London").strftime("%H:%M %d/%m/%Y") %>
               </td>
               <td>
-                <%= link_to t(".results.convictions_details_button"), transient_registration_convictions_path(transient_registration.reg_identifier) %>
+                <%= link_to t(".results.convictions_details_button"), transient_registration_convictions_path(result.reg_identifier) %>
               </td>
             </tr>
           <% end %>
@@ -36,9 +36,9 @@
     <div class="column-full">
       <nav role="navigation" class="pagination" aria-label="Pagination">
         <div class="pagination__summary">
-          <%= page_entries_info @transient_registrations, entry_name: "item" %>
+          <%= page_entries_info @results, entry_name: "item" %>
         </div>
-        <%= paginate @transient_registrations %>
+        <%= paginate @results %>
       </nav>
     </div>
   </div>

--- a/spec/factories/meta_data.rb
+++ b/spec/factories/meta_data.rb
@@ -5,5 +5,13 @@ FactoryBot.define do
     date_registered { Time.current }
     status { :ACTIVE }
     revoked_reason { "reason" }
+
+    trait :active do
+      status { :ACTIVE }
+    end
+
+    trait :pending do
+      status { :PENDING }
+    end
   end
 end

--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -18,8 +18,16 @@ FactoryBot.define do
 
     metaData { build(:metaData) }
 
+    trait :pending do
+      metaData { build(:metaData, :pending) }
+    end
+
+    trait :active do
+      metaData { build(:metaData, :active) }
+    end
+
     trait :expires_soon do
-      metaData { build(:metaData, status: :ACTIVE) }
+      metaData { build(:metaData, :active) }
       expires_on { 2.months.from_now }
     end
 
@@ -41,6 +49,12 @@ FactoryBot.define do
       key_people { [build(:key_person, :requires_conviction_check)] }
       conviction_search_result { build(:conviction_search_result, :match_result_yes) }
       conviction_sign_offs { [build(:conviction_sign_off, :checks_in_progress)] }
+    end
+
+    trait :has_approved_conviction_check do
+      key_people { [build(:key_person, :requires_conviction_check)] }
+      conviction_search_result { build(:conviction_search_result, :match_result_yes) }
+      conviction_sign_offs { [build(:conviction_sign_off, :approved)] }
     end
 
     trait :has_rejected_conviction_check do

--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -30,5 +30,11 @@ FactoryBot.define do
     trait :no_pending_payment do
       finance_details { build(:finance_details, :zero_balance) }
     end
+
+    trait :requires_conviction_check do
+      key_people { [build(:key_person, :requires_conviction_check)] }
+      conviction_search_result { build(:conviction_search_result, :match_result_yes) }
+      conviction_sign_offs { [build(:conviction_sign_off)] }
+    end
   end
 end

--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -36,5 +36,11 @@ FactoryBot.define do
       conviction_search_result { build(:conviction_search_result, :match_result_yes) }
       conviction_sign_offs { [build(:conviction_sign_off)] }
     end
+
+    trait :has_flagged_conviction_check do
+      key_people { [build(:key_person, :requires_conviction_check)] }
+      conviction_search_result { build(:conviction_search_result, :match_result_yes) }
+      conviction_sign_offs { [build(:conviction_sign_off, :checks_in_progress)] }
+    end
   end
 end

--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -42,5 +42,11 @@ FactoryBot.define do
       conviction_search_result { build(:conviction_search_result, :match_result_yes) }
       conviction_sign_offs { [build(:conviction_sign_off, :checks_in_progress)] }
     end
+
+    trait :has_rejected_conviction_check do
+      key_people { [build(:key_person, :requires_conviction_check)] }
+      conviction_search_result { build(:conviction_search_result, :match_result_yes) }
+      conviction_sign_offs { [build(:conviction_sign_off, :rejected)] }
+    end
   end
 end

--- a/spec/requests/convictions_dashboards_spec.rb
+++ b/spec/requests/convictions_dashboards_spec.rb
@@ -92,23 +92,13 @@ RSpec.describe "ConvictionsDashboards", type: :request do
         expect(response).to have_http_status(200)
       end
 
-      it "links to registrations which require an initial convictions check" do
+      it "links to the correct registrations and renewals" do
         get "/bo/convictions"
+
         expect(response.body).to include(link_to_possible_matches_registration)
-      end
-
-      it "links to renewals which require an initial convictions check" do
-        get "/bo/convictions"
         expect(response.body).to include(link_to_possible_matches_renewal)
-      end
 
-      it "does not link to registrations which don't require an initial convictions check" do
-        get "/bo/convictions"
         expect(response.body).to_not include(link_to_checks_in_progress_registration)
-      end
-
-      it "does not link to renewals which don't require an initial convictions check" do
-        get "/bo/convictions"
         expect(response.body).to_not include(link_to_checks_in_progress_renewal)
       end
     end
@@ -138,23 +128,13 @@ RSpec.describe "ConvictionsDashboards", type: :request do
         expect(response).to have_http_status(200)
       end
 
-      it "links to registrations which have have ongoing conviction checks" do
+      it "links to the correct registrations and renewals" do
         get "/bo/convictions/in-progress"
+
         expect(response.body).to include(link_to_checks_in_progress_registration)
-      end
-
-      it "links to renewals which have have ongoing conviction checks" do
-        get "/bo/convictions/in-progress"
         expect(response.body).to include(link_to_checks_in_progress_renewal)
-      end
 
-      it "does not link to registrations which don't have ongoing conviction checks" do
-        get "/bo/convictions/in-progress"
         expect(response.body).to_not include(link_to_possible_matches_registration)
-      end
-
-      it "does not link to renewals which don't have ongoing conviction checks" do
-        get "/bo/convictions/in-progress"
         expect(response.body).to_not include(link_to_rejected_renewal)
       end
     end
@@ -184,28 +164,14 @@ RSpec.describe "ConvictionsDashboards", type: :request do
         expect(response).to have_http_status(200)
       end
 
-      it "links to pending registrations which have have approved conviction checks" do
+      it "links to the correct registrations and renewals" do
         get "/bo/convictions/approved"
+
         expect(response.body).to include(link_to_pending_approved_registration)
-      end
-
-      it "links to renewals which have have approved conviction checks" do
-        get "/bo/convictions/approved"
         expect(response.body).to include(link_to_approved_renewal)
-      end
 
-      it "does not link to active registrations which have have approved conviction checks" do
-        get "/bo/convictions/approved"
         expect(response.body).to_not include(link_to_active_approved_registration)
-      end
-
-      it "does not link to registrations which don't have approved conviction checks" do
-        get "/bo/convictions/approved"
         expect(response.body).to_not include(link_to_possible_matches_registration)
-      end
-
-      it "does not link to renewals which don't have approved conviction checks" do
-        get "/bo/convictions/approved"
         expect(response.body).to_not include(link_to_possible_matches_renewal)
       end
     end
@@ -235,23 +201,13 @@ RSpec.describe "ConvictionsDashboards", type: :request do
         expect(response).to have_http_status(200)
       end
 
-      it "links to renewals which have have rejected conviction checks" do
+      it "links to the correct registrations and renewals" do
         get "/bo/convictions/rejected"
+
         expect(response.body).to include(link_to_rejected_renewal)
-      end
 
-      it "does not link to registrations which have have rejected conviction checks" do
-        get "/bo/convictions/rejected"
         expect(response.body).to_not include(link_to_rejected_registration)
-      end
-
-      it "does not link to registrations which don't have rejected conviction checks" do
-        get "/bo/convictions/rejected"
         expect(response.body).to_not include(link_to_possible_matches_registration)
-      end
-
-      it "does not link to renewals which don't have rejected conviction checks" do
-        get "/bo/convictions/rejected"
         expect(response.body).to_not include(link_to_possible_matches_renewal)
       end
     end

--- a/spec/requests/convictions_dashboards_spec.rb
+++ b/spec/requests/convictions_dashboards_spec.rb
@@ -19,6 +19,22 @@ RSpec.describe "ConvictionsDashboards", type: :request do
     transient_registration_convictions_path(registration.reg_identifier)
   end
 
+  let!(:link_to_pending_approved_registration) do
+    registration = create(:registration, :has_approved_conviction_check, :pending)
+    # Make sure it's one of the 'oldest' registrations so would be top of the list
+    registration.metaData.update_attributes(last_modified: Date.new(1999, 1, 1))
+
+    transient_registration_convictions_path(registration.reg_identifier)
+  end
+
+  let!(:link_to_active_approved_registration) do
+    registration = create(:registration, :has_approved_conviction_check, :active)
+    # Make sure it's one of the 'oldest' registrations so would be top of the list
+    registration.metaData.update_attributes(last_modified: Date.new(1999, 1, 1))
+
+    transient_registration_convictions_path(registration.reg_identifier)
+  end
+
   let!(:link_to_rejected_registration) do
     registration = create(:registration, :has_rejected_conviction_check)
     # Make sure it's one of the 'oldest' registrations so would be top of the list
@@ -168,9 +184,19 @@ RSpec.describe "ConvictionsDashboards", type: :request do
         expect(response).to have_http_status(200)
       end
 
+      it "links to pending registrations which have have approved conviction checks" do
+        get "/bo/convictions/approved"
+        expect(response.body).to include(link_to_pending_approved_registration)
+      end
+
       it "links to renewals which have have approved conviction checks" do
         get "/bo/convictions/approved"
         expect(response.body).to include(link_to_approved_renewal)
+      end
+
+      it "does not link to active registrations which have have approved conviction checks" do
+        get "/bo/convictions/approved"
+        expect(response.body).to_not include(link_to_active_approved_registration)
       end
 
       it "does not link to registrations which don't have approved conviction checks" do

--- a/spec/requests/convictions_dashboards_spec.rb
+++ b/spec/requests/convictions_dashboards_spec.rb
@@ -3,6 +3,14 @@
 require "rails_helper"
 
 RSpec.describe "ConvictionsDashboards", type: :request do
+  let!(:link_to_possible_matches_registration) do
+    registration = create(:registration, :requires_conviction_check)
+    # Make sure it's one of the 'oldest' registrations so would be top of the list
+    registration.metaData.update_attributes(last_modified: Date.new(1999, 1, 1))
+
+    transient_registration_convictions_path(registration.reg_identifier)
+  end
+
   let!(:link_to_possible_matches_renewal) do
     renewal = create(:renewing_registration, :requires_conviction_check)
     # Make sure it's one of the 'oldest' renewals so would be top of the list
@@ -52,6 +60,11 @@ RSpec.describe "ConvictionsDashboards", type: :request do
         expect(response).to have_http_status(200)
       end
 
+      it "links to registrations which require an initial convictions check" do
+        get "/bo/convictions"
+        expect(response.body).to include(link_to_possible_matches_registration)
+      end
+
       it "links to renewals which require an initial convictions check" do
         get "/bo/convictions"
         expect(response.body).to include(link_to_possible_matches_renewal)
@@ -93,6 +106,11 @@ RSpec.describe "ConvictionsDashboards", type: :request do
         expect(response.body).to include(link_to_checks_in_progress_renewal)
       end
 
+      it "does not link to registrations which don't have ongoing conviction checks" do
+        get "/bo/convictions/in-progress"
+        expect(response.body).to_not include(link_to_possible_matches_registration)
+      end
+
       it "does not link to renewals which don't have ongoing conviction checks" do
         get "/bo/convictions/in-progress"
         expect(response.body).to_not include(link_to_rejected_renewal)
@@ -129,6 +147,11 @@ RSpec.describe "ConvictionsDashboards", type: :request do
         expect(response.body).to include(link_to_approved_renewal)
       end
 
+      it "does not link to registrations which don't have approved conviction checks" do
+        get "/bo/convictions/approved"
+        expect(response.body).to_not include(link_to_possible_matches_registration)
+      end
+
       it "does not link to renewals which don't have approved conviction checks" do
         get "/bo/convictions/approved"
         expect(response.body).to_not include(link_to_possible_matches_renewal)
@@ -163,6 +186,11 @@ RSpec.describe "ConvictionsDashboards", type: :request do
       it "links to renewals which have have rejected conviction checks" do
         get "/bo/convictions/rejected"
         expect(response.body).to include(link_to_rejected_renewal)
+      end
+
+      it "does not link to registrations which don't have rejected conviction checks" do
+        get "/bo/convictions/rejected"
+        expect(response.body).to_not include(link_to_possible_matches_registration)
       end
 
       it "does not link to renewals which don't have rejected conviction checks" do

--- a/spec/requests/convictions_dashboards_spec.rb
+++ b/spec/requests/convictions_dashboards_spec.rb
@@ -19,6 +19,14 @@ RSpec.describe "ConvictionsDashboards", type: :request do
     transient_registration_convictions_path(registration.reg_identifier)
   end
 
+  let!(:link_to_rejected_registration) do
+    registration = create(:registration, :has_rejected_conviction_check)
+    # Make sure it's one of the 'oldest' registrations so would be top of the list
+    registration.metaData.update_attributes(last_modified: Date.new(1999, 1, 1))
+
+    transient_registration_convictions_path(registration.reg_identifier)
+  end
+
   let!(:link_to_possible_matches_renewal) do
     renewal = create(:renewing_registration, :requires_conviction_check)
     # Make sure it's one of the 'oldest' renewals so would be top of the list
@@ -204,6 +212,11 @@ RSpec.describe "ConvictionsDashboards", type: :request do
       it "links to renewals which have have rejected conviction checks" do
         get "/bo/convictions/rejected"
         expect(response.body).to include(link_to_rejected_renewal)
+      end
+
+      it "does not link to registrations which have have rejected conviction checks" do
+        get "/bo/convictions/rejected"
+        expect(response.body).to_not include(link_to_rejected_registration)
       end
 
       it "does not link to registrations which don't have rejected conviction checks" do


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-791

Currently, the screen only handles submitted renewals which are awaiting approval.

In the old backend, there is no such screen. Users have to use BOXI to identify those with outstanding checks, then use the dashboard search to find and process them.

As part of the migration to the back-office, NCCC has asked that this screen be the only mechanism for accessing convictions checks in order to help streamline the process. So this PR updates the dashboard to include registrations which require approval as well.