### PR TITLE
Deal with new frontend regs on possible matches list

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,7 @@ gem "defra_ruby_aws", "~> 0.2.0"
 # Use the waste carriers engine for the user journey
 gem "waste_carriers_engine",
     git: "https://github.com/DEFRA/waste-carriers-engine",
-    branch: "master"
+    branch: "feature/conv-no-workflow-state"
 
 # Allows us to automatically generate the change log from the tags, issues,
 # labels and pull requests on GitHub. Added as a dependency so all dev's have

--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,7 @@ gem "defra_ruby_aws", "~> 0.2.0"
 # Use the waste carriers engine for the user journey
 gem "waste_carriers_engine",
     git: "https://github.com/DEFRA/waste-carriers-engine",
-    branch: "feature/conv-no-workflow-state"
+    branch: "master"
 
 # Allows us to automatically generate the change log from the tags, issues,
 # labels and pull requests on GitHub. Added as a dependency so all dev's have

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: f7798b1681d22a9a4dfd70043ff1c232d05769ba
-  branch: feature/conv-no-workflow-state
+  revision: 87dfdcf52f9bffb9a335669cbf2eaa0193696277
+  branch: master
   specs:
     waste_carriers_engine (0.0.1)
       aasm (~> 4.12)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: 227691e2c3a41a74d6221268fdce5b969dc87976
-  branch: master
+  revision: f7798b1681d22a9a4dfd70043ff1c232d05769ba
+  branch: feature/conv-no-workflow-state
   specs:
     waste_carriers_engine (0.0.1)
       aasm (~> 4.12)

--- a/app/controllers/convictions_dashboards_controller.rb
+++ b/app/controllers/convictions_dashboards_controller.rb
@@ -23,7 +23,8 @@ class ConvictionsDashboardsController < ApplicationController
 
   def list_of_possible_matches
     WasteCarriersEngine::RenewingRegistration.submitted.convictions_possible_match +
-      WasteCarriersEngine::Registration.convictions_possible_match
+      WasteCarriersEngine::Registration.convictions_possible_match +
+      WasteCarriersEngine::Registration.convictions_new_without_status
   end
 
   def list_of_checks_in_progress

--- a/spec/requests/convictions_dashboards_spec.rb
+++ b/spec/requests/convictions_dashboards_spec.rb
@@ -43,6 +43,15 @@ RSpec.describe "ConvictionsDashboards", type: :request do
     transient_registration_convictions_path(registration.reg_identifier)
   end
 
+  let!(:link_to_new_from_frontend_registration) do
+    registration = create(:registration, :requires_conviction_check, :pending)
+    # Make sure it's one of the 'oldest' registrations so would be top of the list
+    registration.metaData.update_attributes(last_modified: Date.new(1999, 1, 1))
+    registration.conviction_sign_offs.first.unset(:workflow_state)
+
+    transient_registration_convictions_path(registration.reg_identifier)
+  end
+
   let!(:link_to_possible_matches_renewal) do
     renewal = create(:renewing_registration, :requires_conviction_check)
     # Make sure it's one of the 'oldest' renewals so would be top of the list
@@ -96,6 +105,7 @@ RSpec.describe "ConvictionsDashboards", type: :request do
         get "/bo/convictions"
 
         expect(response.body).to include(link_to_possible_matches_registration)
+        expect(response.body).to include(link_to_new_from_frontend_registration)
         expect(response.body).to include(link_to_possible_matches_renewal)
 
         expect(response.body).to_not include(link_to_checks_in_progress_registration)
@@ -135,6 +145,7 @@ RSpec.describe "ConvictionsDashboards", type: :request do
         expect(response.body).to include(link_to_checks_in_progress_renewal)
 
         expect(response.body).to_not include(link_to_possible_matches_registration)
+        expect(response.body).to_not include(link_to_new_from_frontend_registration)
         expect(response.body).to_not include(link_to_rejected_renewal)
       end
     end
@@ -172,6 +183,7 @@ RSpec.describe "ConvictionsDashboards", type: :request do
 
         expect(response.body).to_not include(link_to_active_approved_registration)
         expect(response.body).to_not include(link_to_possible_matches_registration)
+        expect(response.body).to_not include(link_to_new_from_frontend_registration)
         expect(response.body).to_not include(link_to_possible_matches_renewal)
       end
     end
@@ -208,6 +220,7 @@ RSpec.describe "ConvictionsDashboards", type: :request do
 
         expect(response.body).to_not include(link_to_rejected_registration)
         expect(response.body).to_not include(link_to_possible_matches_registration)
+        expect(response.body).to_not include(link_to_new_from_frontend_registration)
         expect(response.body).to_not include(link_to_possible_matches_renewal)
       end
     end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-791

Any conviction_sign_offs that are created in the waste-carriers-frontend don't get a workflow_state when they are created. So we need to call an additional scope to include those as well. This will make sure that new, unapproved conviction_sign_offs are still listed in the 'possible matches' list when appropriate.

---

Depends on https://github.com/DEFRA/waste-carriers-engine/pull/574