### PR TITLE
Update conviction details page to work with new registrations

### DIFF
--- a/app/controllers/convictions_controller.rb
+++ b/app/controllers/convictions_controller.rb
@@ -4,19 +4,19 @@ class ConvictionsController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    find_transient_registration(params[:transient_registration_reg_identifier])
+    find_resource(params[:transient_registration_reg_identifier])
   end
 
   def begin_checks
-    find_transient_registration(params[:reg_identifier])
-    @transient_registration.conviction_sign_offs.first.begin_checks!
+    find_resource(params[:reg_identifier])
+    @resource.conviction_sign_offs.first.begin_checks!
 
     redirect_to convictions_path
   end
 
   private
 
-  def find_transient_registration(reg_identifier)
-    @transient_registration = WasteCarriersEngine::RenewingRegistration.where(reg_identifier: reg_identifier).first
+  def find_resource(reg_identifier)
+    @resource = WasteCarriersEngine::RenewingRegistration.where(reg_identifier: reg_identifier).first
   end
 end

--- a/app/controllers/convictions_controller.rb
+++ b/app/controllers/convictions_controller.rb
@@ -25,10 +25,12 @@ class ConvictionsController < ApplicationController
   end
 
   def find_registration(reg_identifier)
-    @resource = WasteCarriersEngine::Registration.find_by(reg_identifier: reg_identifier)
+    registration = WasteCarriersEngine::Registration.find_by(reg_identifier: reg_identifier)
+    @resource = RegistrationConvictionPresenter.new(registration, view_context)
   end
 
   def find_renewing_registration(reg_identifier)
-    @resource = WasteCarriersEngine::RenewingRegistration.find_by(reg_identifier: reg_identifier)
+    renewing_registration = WasteCarriersEngine::RenewingRegistration.find_by(reg_identifier: reg_identifier)
+    @resource = RenewingRegistrationConvictionPresenter.new(renewing_registration, view_context)
   end
 end

--- a/app/controllers/convictions_controller.rb
+++ b/app/controllers/convictions_controller.rb
@@ -4,11 +4,11 @@ class ConvictionsController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    find_resource(params[:transient_registration_reg_identifier])
+    find_resource(params)
   end
 
   def begin_checks
-    find_resource(params[:reg_identifier])
+    find_resource(find_renewing_registration(params[:reg_identifier]))
     @resource.conviction_sign_offs.first.begin_checks!
 
     redirect_to convictions_path
@@ -16,7 +16,19 @@ class ConvictionsController < ApplicationController
 
   private
 
-  def find_resource(reg_identifier)
-    @resource = WasteCarriersEngine::RenewingRegistration.where(reg_identifier: reg_identifier).first
+  def find_resource(params)
+    if params[:registration_reg_identifier].present?
+      find_registration(params[:registration_reg_identifier])
+    elsif params[:transient_registration_reg_identifier].present?
+      find_renewing_registration(params[:transient_registration_reg_identifier])
+    end
+  end
+
+  def find_registration(reg_identifier)
+    @resource = WasteCarriersEngine::Registration.find_by(reg_identifier: reg_identifier)
+  end
+
+  def find_renewing_registration(reg_identifier)
+    @resource = WasteCarriersEngine::RenewingRegistration.find_by(reg_identifier: reg_identifier)
   end
 end

--- a/app/helpers/convictions_helper.rb
+++ b/app/helpers/convictions_helper.rb
@@ -2,44 +2,44 @@
 
 module ConvictionsHelper
   def declared_convictions
-    return "unknown" unless @transient_registration.declared_convictions.present?
+    return "unknown" unless @resource.declared_convictions.present?
 
-    @transient_registration.declared_convictions == "yes"
+    @resource.declared_convictions == "yes"
   end
 
   def business_convictions
-    return "unknown" unless @transient_registration.conviction_search_result.present?
+    return "unknown" unless @resource.conviction_search_result.present?
 
-    @transient_registration.business_has_matching_or_unknown_conviction?
+    @resource.business_has_matching_or_unknown_conviction?
   end
 
   def people_convictions
     return "unknown" if unknown_people_convictions?
 
-    @transient_registration.key_person_has_matching_or_unknown_conviction?
+    @resource.key_person_has_matching_or_unknown_conviction?
   end
 
   def people_with_matches
-    @transient_registration.key_people.select(&:conviction_check_required?)
+    @resource.key_people.select(&:conviction_check_required?)
   end
 
   def relevant_people_without_matches
-    @transient_registration.relevant_people - people_with_matches
+    @resource.relevant_people - people_with_matches
   end
 
   def conviction_sign_off
-    return unless @transient_registration.conviction_sign_offs.present?
+    return unless @resource.conviction_sign_offs.present?
 
-    @transient_registration.conviction_sign_offs.first
+    @resource.conviction_sign_offs.first
   end
 
   private
 
   def unknown_people_convictions?
-    return true unless @transient_registration.key_people.present?
+    return true unless @resource.key_people.present?
 
     # Check to see if any conviction_search_results are present
-    conviction_search_results = @transient_registration.key_people.map(&:conviction_search_result).compact
+    conviction_search_results = @resource.key_people.map(&:conviction_search_result).compact
     conviction_search_results.count.zero?
   end
 end

--- a/app/presenters/base_conviction_presenter.rb
+++ b/app/presenters/base_conviction_presenter.rb
@@ -1,4 +1,11 @@
 # frozen_string_literal: true
 
 class BaseConvictionPresenter < WasteCarriersEngine::BasePresenter
+  def conviction_status_message
+    if conviction_sign_offs.first.present?
+      I18n.t(".convictions.index.status.#{conviction_sign_offs.first.workflow_state}")
+    else
+      I18n.t(".convictions.index.status.not_required")
+    end
+  end
 end

--- a/app/presenters/base_conviction_presenter.rb
+++ b/app/presenters/base_conviction_presenter.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class BaseConvictionPresenter < WasteCarriersEngine::BasePresenter
+end

--- a/app/presenters/base_conviction_presenter.rb
+++ b/app/presenters/base_conviction_presenter.rb
@@ -8,4 +8,8 @@ class BaseConvictionPresenter < WasteCarriersEngine::BasePresenter
       I18n.t(".convictions.index.status.not_required")
     end
   end
+
+  def approved_or_revoked?
+    conviction_check_approved? || revoked?
+  end
 end

--- a/app/presenters/registration_conviction_presenter.rb
+++ b/app/presenters/registration_conviction_presenter.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class RegistrationConvictionPresenter < BaseConvictionPresenter
+end

--- a/app/presenters/registration_conviction_presenter.rb
+++ b/app/presenters/registration_conviction_presenter.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
 
 class RegistrationConvictionPresenter < BaseConvictionPresenter
+  def display_actions?
+    false
+  end
 end

--- a/app/presenters/renewing_registration_conviction_presenter.rb
+++ b/app/presenters/renewing_registration_conviction_presenter.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
 
 class RenewingRegistrationConvictionPresenter < BaseConvictionPresenter
+  def display_actions?
+    renewal_application_submitted? && conviction_check_required?
+  end
 end

--- a/app/presenters/renewing_registration_conviction_presenter.rb
+++ b/app/presenters/renewing_registration_conviction_presenter.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class RenewingRegistrationConvictionPresenter < BaseConvictionPresenter
+end

--- a/app/views/convictions/index.html.erb
+++ b/app/views/convictions/index.html.erb
@@ -117,7 +117,7 @@
     </table>
     <% end %>
 
-    <% if @resource.renewal_application_submitted? && @resource.conviction_check_required? %>
+    <% if @resource.display_actions? %>
       <h2 class="heading-medium">
         <%= t(".approve_or_reject.heading") %>
       </h2>

--- a/app/views/convictions/index.html.erb
+++ b/app/views/convictions/index.html.erb
@@ -63,7 +63,7 @@
       <% end %>
     <% end %>
 
-    <% if @resource.conviction_check_approved? || @resource.metaData.REVOKED? %>
+    <% if @resource.approved_or_revoked? %>
     <table>
       <caption class="heading-medium">
         <%= t(".conviction_sign_off.heading") %>
@@ -76,7 +76,7 @@
           <td>
             <% if @resource.conviction_check_approved? %>
               <%= t(".conviction_sign_off.labels.status_values.approved") %>
-            <% elsif @resource.metaData.REVOKED? %>
+            <% elsif @resource.revoked? %>
               <%= t(".conviction_sign_off.labels.status_values.rejected") %>
             <% end %>
           </td>

--- a/app/views/convictions/index.html.erb
+++ b/app/views/convictions/index.html.erb
@@ -1,6 +1,6 @@
 <div class="grid-row">
   <div class="column-two-thirds">
-    <%= render("waste_carriers_engine/shared/back", back_path: renewing_registration_path(@resource.reg_identifier)) %>
+    <%= render("waste_carriers_engine/shared/back", back_path: convictions_path) %>
 
     <h1 class="heading-large">
       <%= t(".heading", reg_identifier: @resource.reg_identifier) %>

--- a/app/views/convictions/index.html.erb
+++ b/app/views/convictions/index.html.erb
@@ -1,9 +1,9 @@
 <div class="grid-row">
   <div class="column-two-thirds">
-    <%= render("waste_carriers_engine/shared/back", back_path: renewing_registration_path(@transient_registration.reg_identifier)) %>
+    <%= render("waste_carriers_engine/shared/back", back_path: renewing_registration_path(@resource.reg_identifier)) %>
 
     <h1 class="heading-large">
-      <%= t(".heading", reg_identifier: @transient_registration.reg_identifier) %>
+      <%= t(".heading", reg_identifier: @resource.reg_identifier) %>
     </h1>
 
     <div class="panel">
@@ -28,7 +28,7 @@
       <%= t(".business_convictions.#{business_convictions}") %>
     </p>
     <% if business_convictions == true %>
-      <%= render("shared/conviction_search_result", conviction_search_result: @transient_registration.conviction_search_result, person: nil) %>
+      <%= render("shared/conviction_search_result", conviction_search_result: @resource.conviction_search_result, person: nil) %>
     <% end %>
 
     <h2 class="heading-medium">
@@ -42,7 +42,7 @@
       <% people_with_matches.each do |person| %>
         <h3 class="heading-small">
           <% if person.person_type == "KEY" %>
-            <%= t(".people_convictions.person_heading.#{@transient_registration.business_type}") %>
+            <%= t(".people_convictions.person_heading.#{@resource.business_type}") %>
           <% else %>
             <%= t(".people_convictions.person_heading.relevant") %>
           <% end %>
@@ -67,7 +67,7 @@
       <% end %>
     <% end %>
 
-    <% if @transient_registration.conviction_check_approved? || @transient_registration.metaData.REVOKED? %>
+    <% if @resource.conviction_check_approved? || @resource.metaData.REVOKED? %>
     <table>
       <caption class="heading-medium">
         <%= t(".conviction_sign_off.heading") %>
@@ -78,9 +78,9 @@
             <%= t(".conviction_sign_off.labels.status") %>
           </td>
           <td>
-            <% if @transient_registration.conviction_check_approved? %>
+            <% if @resource.conviction_check_approved? %>
               <%= t(".conviction_sign_off.labels.status_values.approved") %>
-            <% elsif @transient_registration.metaData.REVOKED? %>
+            <% elsif @resource.metaData.REVOKED? %>
               <%= t(".conviction_sign_off.labels.status_values.rejected") %>
             <% end %>
           </td>
@@ -90,26 +90,26 @@
             <%= t(".conviction_sign_off.labels.revoked_reason") %>
           </td>
           <td>
-            <%= @transient_registration.metaData.revoked_reason %>
+            <%= @resource.metaData.revoked_reason %>
           </td>
         </tr>
-        <% if @transient_registration.conviction_sign_offs.first.confirmed_by.present? %>
+        <% if @resource.conviction_sign_offs.first.confirmed_by.present? %>
         <tr>
           <td>
             <%= t(".conviction_sign_off.labels.confirmed_by") %>
           </td>
           <td>
-            <%= @transient_registration.conviction_sign_offs.first.confirmed_by %>
+            <%= @resource.conviction_sign_offs.first.confirmed_by %>
           </td>
         </tr>
         <% end %>
-        <% if @transient_registration.conviction_sign_offs.first.confirmed_at.present? %>
+        <% if @resource.conviction_sign_offs.first.confirmed_at.present? %>
         <tr>
           <td>
             <%= t(".conviction_sign_off.labels.confirmed_at") %>
           </td>
           <td>
-            <%= @transient_registration.conviction_sign_offs.first.confirmed_at.in_time_zone("London").strftime("%A %e %B %Y at %l:%M%P") %>
+            <%= @resource.conviction_sign_offs.first.confirmed_at.in_time_zone("London").strftime("%A %e %B %Y at %l:%M%P") %>
           </td>
         </tr>
         <% end %>
@@ -117,11 +117,11 @@
     </table>
     <% end %>
 
-    <% if @transient_registration.renewal_application_submitted? && @transient_registration.conviction_check_required? %>
+    <% if @resource.renewal_application_submitted? && @resource.conviction_check_required? %>
       <h2 class="heading-medium">
         <%= t(".approve_or_reject.heading") %>
       </h2>
-      <% if can? :review_convictions, @transient_registration %>
+      <% if can? :review_convictions, @resource %>
         <p>
           <%= t(".approve_or_reject.paragraph_1") %>
         </p>
@@ -130,19 +130,19 @@
         </p>
         <% if conviction_sign_off.may_approve? %>
           <%= link_to t(".approve_or_reject.buttons.approve"),
-                      new_transient_registration_conviction_approval_form_path(@transient_registration.reg_identifier),
+                      new_transient_registration_conviction_approval_form_path(@resource.reg_identifier),
                       class: "button" %>
         <% end %>
 
         <% if conviction_sign_off.may_begin_checks? %>
           <%= link_to t(".approve_or_reject.buttons.begin_checks"),
-                      convictions_begin_checks_path(@transient_registration.reg_identifier),
+                      convictions_begin_checks_path(@resource.reg_identifier),
                       class: "button-alert" %>
         <% end %>
 
         <% if conviction_sign_off.may_reject? %>
         <%= link_to t(".approve_or_reject.buttons.reject"),
-                    new_transient_registration_conviction_rejection_form_path(@transient_registration.reg_identifier),
+                    new_transient_registration_conviction_rejection_form_path(@resource.reg_identifier),
                     class: "button-warning" %>
         <% end %>
       <% else %>

--- a/app/views/convictions/index.html.erb
+++ b/app/views/convictions/index.html.erb
@@ -7,11 +7,7 @@
     </h1>
 
     <div class="panel">
-      <% if conviction_sign_off.present? %>
-        <%= t(".status.#{conviction_sign_off.workflow_state}") %>
-      <% else %>
-        <%= t(".status.not_required") %>
-      <% end %>
+      <%= @resource.conviction_status_message %>
     </div>
 
     <h2 class="heading-medium">

--- a/config/locales/convictions.en.yml
+++ b/config/locales/convictions.en.yml
@@ -4,11 +4,11 @@ en:
       title: "Conviction details"
       heading: "Conviction information for %{reg_identifier}"
       status:
-        possible_match: "This renewal may have matching or declared convictions and requires an initial review."
-        checks_in_progress: "This renewal has been reviewed and flagged as having relevant convictions."
-        approved: "This renewal was approved after a review of the matching or declared convictions."
-        rejected: "This renewal was rejected after a review of the matching or declared convictions."
-        not_required: "This renewal does not require a conviction check before it can be approved."
+        possible_match: "This registration may have matching or declared convictions and requires an initial review."
+        checks_in_progress: "This registration has been reviewed and flagged as having relevant convictions."
+        approved: "This registration was approved after a review of the matching or declared convictions."
+        rejected: "This registration was rejected after a review of the matching or declared convictions."
+        not_required: "This registration does not require a conviction check before it can be approved."
       declared_convictions:
         heading: "Declared convictions"
         "true": "Yes – the user declared there were relevant convictions."
@@ -18,12 +18,12 @@ en:
         heading: Matching convictions for the business
         "true": "There is a possible matching conviction for the business:"
         "false": "No matching convictions were found for the business."
-        unknown: "Unknown – the automated conviction checks have not run yet. This may be because the renewal application is still in progress."
+        unknown: "Unknown – the automated conviction checks have not run yet. This may be because the registration application is still in progress."
       people_convictions:
         heading: People with matching convictions
         "true": "There are possible matching convictions for the following people:"
         "false": "No matching convictions were found for people."
-        unknown: "Unknown – the automated conviction checks have not run yet. This may be because the renewal application is still in progress."
+        unknown: "Unknown – the automated conviction checks have not run yet. This may be because the registration application is still in progress."
         person_heading:
           localAuthority: "Chief executive"
           limitedCompany: "Company director"
@@ -47,8 +47,8 @@ en:
           revoked_reason: "Comment"
       approve_or_reject:
         heading: "Manage this conviction check"
-        paragraph_1: "You can approve or reject this renewal based on this conviction information."
-        paragraph_2: "If the renewal hasn't been paid for yet, it won't be renewed until payment is received and processed."
+        paragraph_1: "You can approve or reject this registration based on this conviction information."
+        paragraph_2: "If the registration hasn't been paid for yet, it won't be renewed until payment is received and processed."
         buttons:
           approve: "Approve"
           begin_checks: "Relevant conviction found"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,10 @@ Rails.application.routes.draw do
   resources :registrations,
             only: :show,
             param: :reg_identifier,
-            path: "/bo/registrations"
+            path: "/bo/registrations" do
+              resources :convictions,
+                        only: :index
+            end
 
   resources :transient_registrations,
             only: [],

--- a/spec/helpers/convictions_helper_spec.rb
+++ b/spec/helpers/convictions_helper_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ConvictionsHelper, type: :helper do
   let(:transient_registration) { build(:renewing_registration) }
 
   before do
-    assign(:transient_registration, transient_registration)
+    assign(:resource, transient_registration)
   end
 
   describe "#declared_convictions" do

--- a/spec/presenters/base_conviction_presenter_spec.rb
+++ b/spec/presenters/base_conviction_presenter_spec.rb
@@ -3,7 +3,33 @@
 require "rails_helper"
 
 RSpec.describe BaseConvictionPresenter do
-  let(:registration) { double(:registration) }
+  let(:conviction_sign_off) { double(:conviction_sign_off, workflow_state: "possible_match") }
+  let(:conviction_sign_offs) { [conviction_sign_off] }
+  let(:registration) do
+    double(:registration,
+           conviction_sign_offs: conviction_sign_offs)
+  end
+
   let(:view_context) { double(:view_context) }
   subject { described_class.new(registration, view_context) }
+
+  describe "#conviction_status_message" do
+    context "when a conviction_sign_off is present" do
+      it "returns the correct message" do
+        message = "This renewal may have matching or declared convictions and requires an initial review."
+
+        expect(subject.conviction_status_message).to eq(message)
+      end
+    end
+
+    context "when a conviction_sign_off is not present" do
+      let(:conviction_sign_offs) { [] }
+
+      it "returns the correct message" do
+        message = "This renewal does not require a conviction check before it can be approved."
+
+        expect(subject.conviction_status_message).to eq(message)
+      end
+    end
+  end
 end

--- a/spec/presenters/base_conviction_presenter_spec.rb
+++ b/spec/presenters/base_conviction_presenter_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe BaseConvictionPresenter do
   describe "#conviction_status_message" do
     context "when a conviction_sign_off is present" do
       it "returns the correct message" do
-        message = "This renewal may have matching or declared convictions and requires an initial review."
+        message = "This registration may have matching or declared convictions and requires an initial review."
 
         expect(subject.conviction_status_message).to eq(message)
       end
@@ -30,7 +30,7 @@ RSpec.describe BaseConvictionPresenter do
       let(:conviction_sign_offs) { [] }
 
       it "returns the correct message" do
-        message = "This renewal does not require a conviction check before it can be approved."
+        message = "This registration does not require a conviction check before it can be approved."
 
         expect(subject.conviction_status_message).to eq(message)
       end

--- a/spec/presenters/base_conviction_presenter_spec.rb
+++ b/spec/presenters/base_conviction_presenter_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BaseConvictionPresenter do
+  let(:registration) { double(:registration) }
+  let(:view_context) { double(:view_context) }
+  subject { described_class.new(registration, view_context) }
+end

--- a/spec/presenters/base_conviction_presenter_spec.rb
+++ b/spec/presenters/base_conviction_presenter_spec.rb
@@ -5,9 +5,13 @@ require "rails_helper"
 RSpec.describe BaseConvictionPresenter do
   let(:conviction_sign_off) { double(:conviction_sign_off, workflow_state: "possible_match") }
   let(:conviction_sign_offs) { [conviction_sign_off] }
+  let(:conviction_check_approved) {}
+  let(:revoked) {}
   let(:registration) do
     double(:registration,
-           conviction_sign_offs: conviction_sign_offs)
+           conviction_sign_offs: conviction_sign_offs,
+           conviction_check_approved?: conviction_check_approved,
+           revoked?: revoked)
   end
 
   let(:view_context) { double(:view_context) }
@@ -29,6 +33,36 @@ RSpec.describe BaseConvictionPresenter do
         message = "This renewal does not require a conviction check before it can be approved."
 
         expect(subject.conviction_status_message).to eq(message)
+      end
+    end
+  end
+
+  describe "#approved_or_revoked?" do
+    context "when conviction_check_approved? is true" do
+      let(:conviction_check_approved) { true }
+
+      it "returns true" do
+        expect(subject.approved_or_revoked?).to eq(true)
+      end
+    end
+
+    context "when conviction_check_approved? is false" do
+      let(:conviction_check_approved) { false }
+
+      context "when revoked? is true" do
+        let(:revoked) { true }
+
+        it "returns true" do
+          expect(subject.approved_or_revoked?).to eq(true)
+        end
+      end
+
+      context "when revoked? is false" do
+        let(:revoked) { false }
+
+        it "returns false" do
+          expect(subject.approved_or_revoked?).to eq(false)
+        end
       end
     end
   end

--- a/spec/presenters/registration_conviction_presenter_spec.rb
+++ b/spec/presenters/registration_conviction_presenter_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RegistrationConvictionPresenter do
+  let(:registration) { double(:registration) }
+  let(:view_context) { double(:view_context) }
+  subject { described_class.new(registration, view_context) }
+end

--- a/spec/presenters/registration_conviction_presenter_spec.rb
+++ b/spec/presenters/registration_conviction_presenter_spec.rb
@@ -6,4 +6,10 @@ RSpec.describe RegistrationConvictionPresenter do
   let(:registration) { double(:registration) }
   let(:view_context) { double(:view_context) }
   subject { described_class.new(registration, view_context) }
+
+  describe "#display_actions?" do
+    it "returns false" do
+      expect(subject.display_actions?).to eq(false)
+    end
+  end
 end

--- a/spec/presenters/renewing_registration_conviction_presenter_spec.rb
+++ b/spec/presenters/renewing_registration_conviction_presenter_spec.rb
@@ -5,5 +5,35 @@ require "rails_helper"
 RSpec.describe RenewingRegistrationConvictionPresenter do
   let(:renewing_registration) { double(:renewing_registration) }
   let(:view_context) { double(:view_context) }
-  subject { described_class.new(registration, view_context) }
+  subject { described_class.new(renewing_registration, view_context) }
+
+  describe "#display_actions?" do
+    context "when renewal_application_submitted? is false" do
+      before { expect(renewing_registration).to receive(:renewal_application_submitted?).and_return(false) }
+
+      it "returns false" do
+        expect(subject.display_actions?).to eq(false)
+      end
+    end
+
+    context "when renewal_application_submitted? is true" do
+      before { expect(renewing_registration).to receive(:renewal_application_submitted?).and_return(true) }
+
+      context "when conviction_check_required? is false" do
+        before { expect(renewing_registration).to receive(:conviction_check_required?).and_return(false) }
+
+        it "returns false" do
+          expect(subject.display_actions?).to eq(false)
+        end
+      end
+
+      context "when conviction_check_required? is true" do
+        before { expect(renewing_registration).to receive(:conviction_check_required?).and_return(true) }
+
+        it "returns true" do
+          expect(subject.display_actions?).to eq(true)
+        end
+      end
+    end
+  end
 end

--- a/spec/presenters/renewing_registration_conviction_presenter_spec.rb
+++ b/spec/presenters/renewing_registration_conviction_presenter_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RenewingRegistrationConvictionPresenter do
+  let(:renewing_registration) { double(:renewing_registration) }
+  let(:view_context) { double(:view_context) }
+  subject { described_class.new(registration, view_context) }
+end

--- a/spec/requests/convictions_spec.rb
+++ b/spec/requests/convictions_spec.rb
@@ -3,7 +3,32 @@
 require "rails_helper"
 
 RSpec.describe "Convictions", type: :request do
+  let(:registration) { create(:registration, :requires_conviction_check) }
   let(:transient_registration) { create(:renewing_registration, :requires_conviction_check) }
+
+  describe "/bo/registrations/:reg_identifier/convictions" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      it "renders the index template" do
+        get "/bo/registrations/#{registration.reg_identifier}/convictions"
+        expect(response).to render_template(:index)
+      end
+
+      it "returns a 200 response" do
+        get "/bo/registrations/#{registration.reg_identifier}/convictions"
+        expect(response).to have_http_status(200)
+      end
+
+      it "includes the reg identifier" do
+        get "/bo/registrations/#{registration.reg_identifier}/convictions"
+        expect(response.body).to include(registration.reg_identifier)
+      end
+    end
+  end
 
   describe "/bo/transient-registrations/:reg_identifier/convictions" do
     context "when a valid user is signed in" do


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-792

This PR will set up the conviction details page to work with registrations as well as renewals.

It covers setting up the routes, controllers and views so the page loads correctly.

It does not include any of the actions you can take from here.