### PR TITLE
Link to reg conviction details pages from dashboard

### DIFF
--- a/app/helpers/convictions_dashboards_helper.rb
+++ b/app/helpers/convictions_dashboards_helper.rb
@@ -11,4 +11,12 @@ module ConvictionsDashboardsHelper
     }
     action_paths[action.to_sym]
   end
+
+  def details_path(resource)
+    if resource.is_a?(WasteCarriersEngine::Registration)
+      registration_convictions_path(resource.reg_identifier)
+    elsif resource.is_a?(WasteCarriersEngine::RenewingRegistration)
+      transient_registration_convictions_path(resource.reg_identifier)
+    end
+  end
 end

--- a/app/views/shared/_convictions_dashboard_results.html.erb
+++ b/app/views/shared/_convictions_dashboard_results.html.erb
@@ -23,7 +23,7 @@
                 <%= result.metaData.last_modified.in_time_zone("London").strftime("%H:%M %d/%m/%Y") %>
               </td>
               <td>
-                <%= link_to t(".results.convictions_details_button"), transient_registration_convictions_path(result.reg_identifier) %>
+                <%= link_to t(".results.convictions_details_button"), details_path(result) %>
               </td>
             </tr>
           <% end %>

--- a/spec/helpers/convictions_dashboards_helper_spec.rb
+++ b/spec/helpers/convictions_dashboards_helper_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ConvictionsDashboardsHelper, type: :helper do
+  describe "#details_path" do
+    let(:resource) {}
+    let(:path) { helper.details_path(resource) }
+
+    context "when the resource is a registration" do
+      let(:resource) { WasteCarriersEngine::Registration.new(reg_identifier: "CBDU1") }
+
+      it "returns the correct path" do
+        expected_path = registration_convictions_path(resource.reg_identifier)
+
+        expect(path).to eq(expected_path)
+      end
+    end
+
+    context "when the resource is a renewing_registration" do
+      let(:resource) { WasteCarriersEngine::RenewingRegistration.new(reg_identifier: "CBDU1") }
+
+      it "returns the correct path" do
+        expected_path = transient_registration_convictions_path(resource.reg_identifier)
+
+        expect(path).to eq(expected_path)
+      end
+    end
+  end
+end

--- a/spec/requests/convictions_dashboards_spec.rb
+++ b/spec/requests/convictions_dashboards_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "ConvictionsDashboards", type: :request do
     # Make sure it's one of the 'oldest' registrations so would be top of the list
     registration.metaData.update_attributes(last_modified: Date.new(1999, 1, 1))
 
-    transient_registration_convictions_path(registration.reg_identifier)
+    registration_convictions_path(registration.reg_identifier)
   end
 
   let!(:link_to_checks_in_progress_registration) do
@@ -16,7 +16,7 @@ RSpec.describe "ConvictionsDashboards", type: :request do
     # Make sure it's one of the 'oldest' registrations so would be top of the list
     registration.metaData.update_attributes(last_modified: Date.new(1999, 1, 1))
 
-    transient_registration_convictions_path(registration.reg_identifier)
+    registration_convictions_path(registration.reg_identifier)
   end
 
   let!(:link_to_pending_approved_registration) do
@@ -24,7 +24,7 @@ RSpec.describe "ConvictionsDashboards", type: :request do
     # Make sure it's one of the 'oldest' registrations so would be top of the list
     registration.metaData.update_attributes(last_modified: Date.new(1999, 1, 1))
 
-    transient_registration_convictions_path(registration.reg_identifier)
+    registration_convictions_path(registration.reg_identifier)
   end
 
   let!(:link_to_active_approved_registration) do
@@ -32,7 +32,7 @@ RSpec.describe "ConvictionsDashboards", type: :request do
     # Make sure it's one of the 'oldest' registrations so would be top of the list
     registration.metaData.update_attributes(last_modified: Date.new(1999, 1, 1))
 
-    transient_registration_convictions_path(registration.reg_identifier)
+    registration_convictions_path(registration.reg_identifier)
   end
 
   let!(:link_to_rejected_registration) do
@@ -40,7 +40,7 @@ RSpec.describe "ConvictionsDashboards", type: :request do
     # Make sure it's one of the 'oldest' registrations so would be top of the list
     registration.metaData.update_attributes(last_modified: Date.new(1999, 1, 1))
 
-    transient_registration_convictions_path(registration.reg_identifier)
+    registration_convictions_path(registration.reg_identifier)
   end
 
   let!(:link_to_new_from_frontend_registration) do
@@ -49,7 +49,7 @@ RSpec.describe "ConvictionsDashboards", type: :request do
     registration.metaData.update_attributes(last_modified: Date.new(1999, 1, 1))
     registration.conviction_sign_offs.first.unset(:workflow_state)
 
-    transient_registration_convictions_path(registration.reg_identifier)
+    registration_convictions_path(registration.reg_identifier)
   end
 
   let!(:link_to_possible_matches_renewal) do


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-792

Now that we have some conviction details pages for registrations, the dashboard 'conviction details' links can be updated to link to them.

---

Will be broken until https://github.com/DEFRA/waste-carriers-back-office/pull/486 is merged.