### PR TITLE
Make 'begin checks' action work for registration convictions

### DIFF
--- a/app/controllers/convictions_controller.rb
+++ b/app/controllers/convictions_controller.rb
@@ -8,7 +8,7 @@ class ConvictionsController < ApplicationController
   end
 
   def begin_checks
-    find_resource(find_renewing_registration(params[:reg_identifier]))
+    find_resource(params)
     @resource.conviction_sign_offs.first.begin_checks!
 
     redirect_to convictions_path

--- a/app/presenters/registration_conviction_presenter.rb
+++ b/app/presenters/registration_conviction_presenter.rb
@@ -2,6 +2,6 @@
 
 class RegistrationConvictionPresenter < BaseConvictionPresenter
   def display_actions?
-    false
+    conviction_check_required?
   end
 end

--- a/app/presenters/registration_conviction_presenter.rb
+++ b/app/presenters/registration_conviction_presenter.rb
@@ -4,4 +4,8 @@ class RegistrationConvictionPresenter < BaseConvictionPresenter
   def display_actions?
     conviction_check_required?
   end
+
+  def begin_checks_path
+    Rails.application.routes.url_helpers.registration_convictions_begin_checks_path(reg_identifier)
+  end
 end

--- a/app/presenters/renewing_registration_conviction_presenter.rb
+++ b/app/presenters/renewing_registration_conviction_presenter.rb
@@ -4,4 +4,8 @@ class RenewingRegistrationConvictionPresenter < BaseConvictionPresenter
   def display_actions?
     renewal_application_submitted? && conviction_check_required?
   end
+
+  def begin_checks_path
+    Rails.application.routes.url_helpers.transient_registration_convictions_begin_checks_path(reg_identifier)
+  end
 end

--- a/app/views/convictions/index.html.erb
+++ b/app/views/convictions/index.html.erb
@@ -132,7 +132,7 @@
 
         <% if conviction_sign_off.may_begin_checks? %>
           <%= link_to t(".approve_or_reject.buttons.begin_checks"),
-                      transient_registration_convictions_begin_checks_path(@resource.reg_identifier),
+                      @resource.begin_checks_path,
                       class: "button-alert" %>
         <% end %>
 

--- a/app/views/convictions/index.html.erb
+++ b/app/views/convictions/index.html.erb
@@ -132,7 +132,7 @@
 
         <% if conviction_sign_off.may_begin_checks? %>
           <%= link_to t(".approve_or_reject.buttons.begin_checks"),
-                      convictions_begin_checks_path(@resource.reg_identifier),
+                      transient_registration_convictions_begin_checks_path(@resource.reg_identifier),
                       class: "button-alert" %>
         <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,6 +87,10 @@ Rails.application.routes.draw do
                         path_names: { new: "" }
             end
 
+  get "/bo/registrations/:registration_reg_identifier/convictions/begin-checks",
+      to: "convictions#begin_checks",
+      as: :registration_convictions_begin_checks
+
   get "/bo/transient-registrations/:transient_registration_reg_identifier/convictions/begin-checks",
       to: "convictions#begin_checks",
       as: :transient_registration_convictions_begin_checks

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,9 +87,9 @@ Rails.application.routes.draw do
                         path_names: { new: "" }
             end
 
-  get "/bo/transient-registrations/:reg_identifier/convictions/begin-checks",
+  get "/bo/transient-registrations/:transient_registration_reg_identifier/convictions/begin-checks",
       to: "convictions#begin_checks",
-      as: :convictions_begin_checks
+      as: :transient_registration_convictions_begin_checks
 
   resources :registration_transfers,
             only: %i[new create],

--- a/spec/presenters/registration_conviction_presenter_spec.rb
+++ b/spec/presenters/registration_conviction_presenter_spec.rb
@@ -3,9 +3,11 @@
 require "rails_helper"
 
 RSpec.describe RegistrationConvictionPresenter do
+  let(:reg_identifier) { "CBDU1" }
   let(:conviction_check_required) {}
   let(:registration) do
     double(:registration,
+           reg_identifier: reg_identifier,
            conviction_check_required?: conviction_check_required)
   end
   let(:view_context) { double(:view_context) }
@@ -26,6 +28,14 @@ RSpec.describe RegistrationConvictionPresenter do
       it "returns true" do
         expect(subject.display_actions?).to eq(true)
       end
+    end
+  end
+
+  describe "#begin_checks_path" do
+    it "returns the correct path" do
+      expected_path = "/bo/registrations/#{reg_identifier}/convictions/begin-checks"
+
+      expect(subject.begin_checks_path).to eq(expected_path)
     end
   end
 end

--- a/spec/presenters/registration_conviction_presenter_spec.rb
+++ b/spec/presenters/registration_conviction_presenter_spec.rb
@@ -8,8 +8,20 @@ RSpec.describe RegistrationConvictionPresenter do
   subject { described_class.new(registration, view_context) }
 
   describe "#display_actions?" do
-    it "returns false" do
-      expect(subject.display_actions?).to eq(false)
+    context "when conviction_check_required? is false" do
+      before { expect(registration).to receive(:conviction_check_required?).and_return(false) }
+
+      it "returns false" do
+        expect(subject.display_actions?).to eq(false)
+      end
+    end
+
+    context "when conviction_check_required? is true" do
+      before { expect(registration).to receive(:conviction_check_required?).and_return(true) }
+
+      it "returns true" do
+        expect(subject.display_actions?).to eq(true)
+      end
     end
   end
 end

--- a/spec/presenters/registration_conviction_presenter_spec.rb
+++ b/spec/presenters/registration_conviction_presenter_spec.rb
@@ -3,13 +3,17 @@
 require "rails_helper"
 
 RSpec.describe RegistrationConvictionPresenter do
-  let(:registration) { double(:registration) }
+  let(:conviction_check_required) {}
+  let(:registration) do
+    double(:registration,
+           conviction_check_required?: conviction_check_required)
+  end
   let(:view_context) { double(:view_context) }
   subject { described_class.new(registration, view_context) }
 
   describe "#display_actions?" do
     context "when conviction_check_required? is false" do
-      before { expect(registration).to receive(:conviction_check_required?).and_return(false) }
+      let(:conviction_check_required) { false }
 
       it "returns false" do
         expect(subject.display_actions?).to eq(false)
@@ -17,7 +21,7 @@ RSpec.describe RegistrationConvictionPresenter do
     end
 
     context "when conviction_check_required? is true" do
-      before { expect(registration).to receive(:conviction_check_required?).and_return(true) }
+      let(:conviction_check_required) { true }
 
       it "returns true" do
         expect(subject.display_actions?).to eq(true)

--- a/spec/presenters/renewing_registration_conviction_presenter_spec.rb
+++ b/spec/presenters/renewing_registration_conviction_presenter_spec.rb
@@ -3,10 +3,12 @@
 require "rails_helper"
 
 RSpec.describe RenewingRegistrationConvictionPresenter do
+  let(:reg_identifier) { "CBDU1" }
   let(:conviction_check_required) {}
   let(:renewal_application_submitted) {}
   let(:renewing_registration) do
     double(:renewing_registration,
+           reg_identifier: reg_identifier,
            conviction_check_required?: conviction_check_required,
            renewal_application_submitted?: renewal_application_submitted)
   end
@@ -40,6 +42,14 @@ RSpec.describe RenewingRegistrationConvictionPresenter do
           expect(subject.display_actions?).to eq(true)
         end
       end
+    end
+  end
+
+  describe "#begin_checks_path" do
+    it "returns the correct path" do
+      expected_path = "/bo/transient-registrations/#{reg_identifier}/convictions/begin-checks"
+
+      expect(subject.begin_checks_path).to eq(expected_path)
     end
   end
 end

--- a/spec/presenters/renewing_registration_conviction_presenter_spec.rb
+++ b/spec/presenters/renewing_registration_conviction_presenter_spec.rb
@@ -3,13 +3,19 @@
 require "rails_helper"
 
 RSpec.describe RenewingRegistrationConvictionPresenter do
-  let(:renewing_registration) { double(:renewing_registration) }
+  let(:conviction_check_required) {}
+  let(:renewal_application_submitted) {}
+  let(:renewing_registration) do
+    double(:renewing_registration,
+           conviction_check_required?: conviction_check_required,
+           renewal_application_submitted?: renewal_application_submitted)
+  end
   let(:view_context) { double(:view_context) }
   subject { described_class.new(renewing_registration, view_context) }
 
   describe "#display_actions?" do
     context "when renewal_application_submitted? is false" do
-      before { expect(renewing_registration).to receive(:renewal_application_submitted?).and_return(false) }
+      let(:renewal_application_submitted) { false }
 
       it "returns false" do
         expect(subject.display_actions?).to eq(false)
@@ -17,10 +23,10 @@ RSpec.describe RenewingRegistrationConvictionPresenter do
     end
 
     context "when renewal_application_submitted? is true" do
-      before { expect(renewing_registration).to receive(:renewal_application_submitted?).and_return(true) }
+      let(:renewal_application_submitted) { true }
 
       context "when conviction_check_required? is false" do
-        before { expect(renewing_registration).to receive(:conviction_check_required?).and_return(false) }
+        let(:conviction_check_required) { false }
 
         it "returns false" do
           expect(subject.display_actions?).to eq(false)
@@ -28,7 +34,7 @@ RSpec.describe RenewingRegistrationConvictionPresenter do
       end
 
       context "when conviction_check_required? is true" do
-        before { expect(renewing_registration).to receive(:conviction_check_required?).and_return(true) }
+        let(:conviction_check_required) { true }
 
         it "returns true" do
           expect(subject.display_actions?).to eq(true)

--- a/spec/requests/convictions_spec.rb
+++ b/spec/requests/convictions_spec.rb
@@ -54,6 +54,25 @@ RSpec.describe "Convictions", type: :request do
     end
   end
 
+  describe "/bo/registrations/:registration_reg_identifier/convictions/begin-checks" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      it "updates the status of the conviction_sign_off" do
+        get "/bo/registrations/#{registration.reg_identifier}/convictions/begin-checks"
+        expect(registration.reload.conviction_sign_offs.first.workflow_state).to eq("checks_in_progress")
+      end
+
+      it "redirects to the convictions page" do
+        get "/bo/registrations/#{registration.reg_identifier}/convictions/begin-checks"
+        expect(response).to redirect_to(convictions_path)
+      end
+    end
+  end
+
   describe "/bo/transient-registrations/:transient_registration_reg_identifier/convictions/begin-checks" do
     context "when a valid user is signed in" do
       let(:user) { create(:user) }

--- a/spec/requests/convictions_spec.rb
+++ b/spec/requests/convictions_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe "Convictions", type: :request do
     end
   end
 
-  describe "/bo/transient-registrations/:reg_identifier/convictions/begin-checks" do
+  describe "/bo/transient-registrations/:transient_registration_reg_identifier/convictions/begin-checks" do
     context "when a valid user is signed in" do
       let(:user) { create(:user) }
       before(:each) do


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-792

This PR will make the 'begin checks' button visible and working on the registration conviction details page.