### PR TITLE
Create conviction approval form for registrations

### DIFF
--- a/app/controllers/registration_conviction_approval_forms_controller.rb
+++ b/app/controllers/registration_conviction_approval_forms_controller.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+class RegistrationConvictionApprovalFormsController < ApplicationController
+  def new
+    build_form(params[:registration_reg_identifier])
+
+    authorize_action
+  end
+
+  def create
+    return false unless build_form(params[:conviction_approval_form][:reg_identifier])
+
+    authorize_action
+
+    submit_form
+  end
+
+  private
+
+  def build_form(reg_identifier)
+    find_registration(reg_identifier)
+    @conviction_approval_form = ConvictionApprovalForm.new(@registration)
+  end
+
+  def submit_form
+    if @conviction_approval_form.submit(params[:conviction_approval_form])
+      redirect_to convictions_path
+      true
+    else
+      render :new
+      false
+    end
+  end
+
+  def find_registration(reg_identifier)
+    @registration = WasteCarriersEngine::Registration.find_by(reg_identifier: reg_identifier)
+  end
+
+  def authorize_action
+    authorize! :review_convictions, @registration
+  end
+end

--- a/app/views/registration_conviction_approval_forms/new.html.erb
+++ b/app/views/registration_conviction_approval_forms/new.html.erb
@@ -1,0 +1,48 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render("waste_carriers_engine/shared/back", back_path: registration_convictions_path(@registration.reg_identifier)) %>
+
+    <%= form_for(@conviction_approval_form, url: registration_registration_conviction_approval_forms_path) do |f| %>
+      <%= render("waste_carriers_engine/shared/errors", object: @conviction_approval_form) %>
+
+      <h1 class="heading-large">
+        <%= t(".heading", reg_identifier: @registration.reg_identifier) %>
+      </h1>
+
+      <% if @conviction_approval_form.errors[:revoked_reason].any? %>
+      <div class="form-group form-group-error">
+      <% else %>
+      <div class="form-group">
+      <% end %>
+        <fieldset id="company_name">
+          <legend class="visuallyhidden">
+            <%= t(".heading", reg_identifier: @registration.reg_identifier) %>
+          </legend>
+
+          <% if @conviction_approval_form.errors[:revoked_reason].any? %>
+          <span class="error-message"><%= @conviction_approval_form.errors[:revoked_reason].join(", ") %></span>
+          <% end %>
+
+          <%= f.label :revoked_reason, t(".revoked_reason_label"), class: "form-label" %>
+          <%= f.text_area :revoked_reason, class: "form-control" %>
+        </fieldset>
+      </div>
+
+      <div class="form-group">
+        <div class="notice">
+          <i class="icon icon-important">
+            <span class="visually-hidden">Warning</span>
+          </i>
+          <strong class="bold-small">
+            <p><%= t(".renewal_message") %></p>
+          </strong>
+        </div>
+      </div>
+
+      <%= f.hidden_field :reg_identifier, value: @conviction_approval_form.reg_identifier %>
+      <div class="form-group">
+        <%= f.submit t(".approve_button"), class: "button" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/registration_conviction_approval_forms.en.yml
+++ b/config/locales/registration_conviction_approval_forms.en.yml
@@ -1,0 +1,17 @@
+en:
+  registration_conviction_approval_forms:
+    new:
+      title: "Approve a renewal with possible convictions"
+      heading: "Approve a renewal with possible convictions: %{reg_identifier}"
+      revoked_reason_label: "Reason for approval"
+      renewal_message: "If there is no unpaid balance, approving this conviction check will automatically complete the renewal."
+      approve_button: "Approve this renewal"
+  activemodel:
+    errors:
+      models:
+        conviction_approval_form:
+          attributes:
+            base:
+              already_signed_off: "Convictions for this renewal have already been approved or rejected"
+            revoked_reason:
+              blank: "You must enter a reason for this decision"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,11 @@ Rails.application.routes.draw do
             path: "/bo/registrations" do
               resources :convictions,
                         only: :index
+
+              resources :registration_conviction_approval_forms,
+                        only: %i[new create],
+                        path: "convictions/approve",
+                        path_names: { new: "" }
             end
 
   resources :transient_registrations,

--- a/spec/requests/registration_conviction_approval_forms_spec.rb
+++ b/spec/requests/registration_conviction_approval_forms_spec.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "RegistrationConvictionApprovalForms", type: :request do
+  let(:registration) { create(:registration, :requires_conviction_check, :no_pending_payment) }
+
+  describe "GET /bo/registrations/:reg_identifier/convictions/approve" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user, :agency) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      it "renders the new template" do
+        get "/bo/registrations/#{registration.reg_identifier}/convictions/approve"
+        expect(response).to render_template(:new)
+      end
+
+      it "returns a 200 response" do
+        get "/bo/registrations/#{registration.reg_identifier}/convictions/approve"
+        expect(response).to have_http_status(200)
+      end
+
+      it "includes the reg identifier" do
+        get "/bo/registrations/#{registration.reg_identifier}/convictions/approve"
+        expect(response.body).to include(registration.reg_identifier)
+      end
+    end
+
+    context "when a non-agency user is signed in" do
+      let(:user) { create(:user, :finance) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      it "redirects to the permissions error page" do
+        get "/bo/registrations/#{registration.reg_identifier}/convictions/approve"
+        expect(response).to redirect_to("/bo/pages/permission")
+      end
+    end
+  end
+
+  describe "POST /bo/registrations/:reg_identifier/convictions/approve" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user, :agency) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      let(:params) do
+        {
+          reg_identifier: registration.reg_identifier,
+          revoked_reason: "foo"
+        }
+      end
+
+      it "redirects to the convictions page" do
+        post "/bo/registrations/#{registration.reg_identifier}/convictions/approve", conviction_approval_form: params
+        expect(response).to redirect_to(convictions_path)
+      end
+
+      it "updates the revoked_reason" do
+        post "/bo/registrations/#{registration.reg_identifier}/convictions/approve", conviction_approval_form: params
+        expect(registration.reload.metaData.revoked_reason).to eq(params[:revoked_reason])
+      end
+
+      skip "updates the conviction_sign_off's confirmed" do
+        post "/bo/registrations/#{registration.reg_identifier}/convictions/approve", conviction_approval_form: params
+        expect(registration.reload.conviction_sign_offs.first.confirmed).to eq("yes")
+      end
+
+      skip "updates the conviction_sign_off's confirmed_at" do
+        post "/bo/registrations/#{registration.reg_identifier}/convictions/approve", conviction_approval_form: params
+        expect(registration.reload.conviction_sign_offs.first.confirmed_at).to be_a(DateTime)
+      end
+
+      skip "updates the conviction_sign_off's confirmed_by" do
+        post "/bo/registrations/#{registration.reg_identifier}/convictions/approve", conviction_approval_form: params
+        expect(registration.reload.conviction_sign_offs.first.confirmed_by).to eq(user.email)
+      end
+
+      skip "updates the conviction_sign_off's workflow_state" do
+        post "/bo/registrations/#{registration.reg_identifier}/convictions/approve", conviction_approval_form: params
+        expect(registration.reload.conviction_sign_offs.first.workflow_state).to eq("approved")
+      end
+
+      skip "when there is no pending payment" do
+        it "activates the registration" do
+        end
+
+        skip "when the RegistrationCompletionService fails" do
+          it "rescues the error" do
+          end
+        end
+      end
+
+      skip "when there is a pending payment" do
+        it "does not activate the registration" do
+        end
+      end
+
+      context "when the params are invalid" do
+        let(:params) do
+          {
+            reg_identifier: registration.reg_identifier,
+            revoked_reason: ""
+          }
+        end
+
+        it "renders the new template" do
+          post "/bo/registrations/#{registration.reg_identifier}/convictions/approve", conviction_approval_form: params
+          expect(response).to render_template(:new)
+        end
+
+        it "does not update the revoked_reason" do
+          post "/bo/registrations/#{registration.reg_identifier}/convictions/approve", conviction_approval_form: params
+          expect(registration.reload.metaData.revoked_reason).to_not eq(params[:revoked_reason])
+        end
+
+        it "does not update the conviction_sign_off" do
+          post "/bo/registrations/#{registration.reg_identifier}/convictions/approve", conviction_approval_form: params
+          expect(registration.reload.conviction_sign_offs.first.confirmed).to eq("no")
+        end
+      end
+    end
+
+    context "when a non-agency user is signed in" do
+      let(:user) { create(:user, :finance) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      let(:params) do
+        {
+          reg_identifier: registration.reg_identifier,
+          revoked_reason: "foo"
+        }
+      end
+
+      it "redirects to the permissions error page" do
+        post "/bo/registrations/#{registration.reg_identifier}/convictions/approve", conviction_approval_form: params
+        expect(response).to redirect_to("/bo/pages/permission")
+      end
+
+      it "does not update the revoked_reason" do
+        post "/bo/registrations/#{registration.reg_identifier}/convictions/approve", conviction_approval_form: params
+        expect(registration.reload.metaData.revoked_reason).to_not eq(params[:revoked_reason])
+      end
+
+      it "does not update the conviction_sign_off" do
+        post "/bo/registrations/#{registration.reg_identifier}/convictions/approve", conviction_approval_form: params
+        expect(registration.reload.conviction_sign_offs.first.confirmed).to eq("no")
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-792

Until we have moved new registrations into the engine and they become transient_registrations, we need to have a slightly separate process for approving convictions on registrations.

This PR sets up a version of the conviction approval form that works with pending new registrations. It doesn't cover making the approval actually do anything.

We can reuse the ConvictionApprovalForm, but a separate controller, route and view is required.

This is a bit cludgy and duplicates a lot of code, but the intent is that it's very easy to remove once we no longer need it!