### PR TITLE
Create conviction rejection form for registrations

### DIFF
--- a/app/controllers/registration_conviction_rejection_forms_controller.rb
+++ b/app/controllers/registration_conviction_rejection_forms_controller.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+class RegistrationConvictionRejectionFormsController < ApplicationController
+  def new
+    build_form(params[:registration_reg_identifier])
+
+    authorize_action
+  end
+
+  def create
+    return false unless build_form(params[:conviction_rejection_form][:reg_identifier])
+
+    authorize_action
+
+    submit_form
+  end
+
+  private
+
+  def build_form(reg_identifier)
+    find_registration(reg_identifier)
+    @conviction_rejection_form = ConvictionRejectionForm.new(@registration)
+  end
+
+  def submit_form
+    if @conviction_rejection_form.submit(params[:conviction_rejection_form])
+      redirect_to convictions_path
+      true
+    else
+      render :new
+      false
+    end
+  end
+
+  def find_registration(reg_identifier)
+    @registration = WasteCarriersEngine::Registration.find_by(reg_identifier: reg_identifier)
+  end
+
+  def authorize_action
+    authorize! :review_convictions, @registration
+  end
+end

--- a/app/presenters/registration_conviction_presenter.rb
+++ b/app/presenters/registration_conviction_presenter.rb
@@ -8,7 +8,6 @@ class RegistrationConvictionPresenter < BaseConvictionPresenter
   def begin_checks_path
     Rails.application.routes.url_helpers.registration_convictions_begin_checks_path(reg_identifier)
   end
- 
   def approve_path
     Rails.application.routes.url_helpers.new_registration_registration_conviction_approval_form_path(reg_identifier)
   end

--- a/app/presenters/registration_conviction_presenter.rb
+++ b/app/presenters/registration_conviction_presenter.rb
@@ -8,4 +8,8 @@ class RegistrationConvictionPresenter < BaseConvictionPresenter
   def begin_checks_path
     Rails.application.routes.url_helpers.registration_convictions_begin_checks_path(reg_identifier)
   end
+
+  def reject_path
+    Rails.application.routes.url_helpers.new_registration_registration_conviction_rejection_form_path(reg_identifier)
+  end
 end

--- a/app/presenters/registration_conviction_presenter.rb
+++ b/app/presenters/registration_conviction_presenter.rb
@@ -8,7 +8,7 @@ class RegistrationConvictionPresenter < BaseConvictionPresenter
   def begin_checks_path
     Rails.application.routes.url_helpers.registration_convictions_begin_checks_path(reg_identifier)
   end
-  
+ 
   def approve_path
     Rails.application.routes.url_helpers.new_registration_registration_conviction_approval_form_path(reg_identifier)
   end

--- a/app/presenters/registration_conviction_presenter.rb
+++ b/app/presenters/registration_conviction_presenter.rb
@@ -8,6 +8,7 @@ class RegistrationConvictionPresenter < BaseConvictionPresenter
   def begin_checks_path
     Rails.application.routes.url_helpers.registration_convictions_begin_checks_path(reg_identifier)
   end
+
   def approve_path
     Rails.application.routes.url_helpers.new_registration_registration_conviction_approval_form_path(reg_identifier)
   end

--- a/app/presenters/renewing_registration_conviction_presenter.rb
+++ b/app/presenters/renewing_registration_conviction_presenter.rb
@@ -8,6 +8,7 @@ class RenewingRegistrationConvictionPresenter < BaseConvictionPresenter
   def begin_checks_path
     Rails.application.routes.url_helpers.transient_registration_convictions_begin_checks_path(reg_identifier)
   end
+
   def approve_path
     Rails.application.routes.url_helpers.new_transient_registration_conviction_approval_form_path(reg_identifier)
   end

--- a/app/presenters/renewing_registration_conviction_presenter.rb
+++ b/app/presenters/renewing_registration_conviction_presenter.rb
@@ -8,7 +8,7 @@ class RenewingRegistrationConvictionPresenter < BaseConvictionPresenter
   def begin_checks_path
     Rails.application.routes.url_helpers.transient_registration_convictions_begin_checks_path(reg_identifier)
   end
-  
+ 
   def approve_path
     Rails.application.routes.url_helpers.new_transient_registration_conviction_approval_form_path(reg_identifier)
   end

--- a/app/presenters/renewing_registration_conviction_presenter.rb
+++ b/app/presenters/renewing_registration_conviction_presenter.rb
@@ -8,7 +8,6 @@ class RenewingRegistrationConvictionPresenter < BaseConvictionPresenter
   def begin_checks_path
     Rails.application.routes.url_helpers.transient_registration_convictions_begin_checks_path(reg_identifier)
   end
- 
   def approve_path
     Rails.application.routes.url_helpers.new_transient_registration_conviction_approval_form_path(reg_identifier)
   end

--- a/app/presenters/renewing_registration_conviction_presenter.rb
+++ b/app/presenters/renewing_registration_conviction_presenter.rb
@@ -8,4 +8,8 @@ class RenewingRegistrationConvictionPresenter < BaseConvictionPresenter
   def begin_checks_path
     Rails.application.routes.url_helpers.transient_registration_convictions_begin_checks_path(reg_identifier)
   end
+
+  def reject_path
+    Rails.application.routes.url_helpers.new_transient_registration_conviction_rejection_form_path(reg_identifier)
+  end
 end

--- a/app/views/conviction_rejection_forms/new.html.erb
+++ b/app/views/conviction_rejection_forms/new.html.erb
@@ -9,11 +9,7 @@
         <%= t(".heading", reg_identifier: @transient_registration.reg_identifier) %>
       </h1>
 
-      <% if @conviction_rejection_form.errors[:revoked_reason].any? %>
-      <div class="form-group form-group-error">
-      <% else %>
-      <div class="form-group">
-      <% end %>
+      <div class="form-group <%= "form-group-error" if @conviction_rejection_form.errors[:revoked_reason].any? %>">
         <fieldset id="company_name">
           <legend class="visuallyhidden">
             <%= t(".heading", reg_identifier: @transient_registration.reg_identifier) %>

--- a/app/views/convictions/index.html.erb
+++ b/app/views/convictions/index.html.erb
@@ -138,7 +138,7 @@
 
         <% if @resource.sign_off.may_reject? %>
         <%= link_to t(".approve_or_reject.buttons.reject"),
-                    new_transient_registration_conviction_rejection_form_path(@resource.reg_identifier),
+                    @resource.reject_path,
                     class: "button-warning" %>
         <% end %>
       <% else %>

--- a/app/views/registration_conviction_rejection_forms/new.html.erb
+++ b/app/views/registration_conviction_rejection_forms/new.html.erb
@@ -20,7 +20,7 @@
           </legend>
 
           <% if @conviction_rejection_form.errors[:revoked_reason].any? %>
-          <span class="error-message"><%= @conviction_rejection_form.errors[:revoked_reason].join(", ") %></span>
+            <span class="error-message"><%= @conviction_rejection_form.errors[:revoked_reason].join(", ") %></span>
           <% end %>
 
           <%= f.label :revoked_reason, t(".revoked_reason_label"), class: "form-label" %>

--- a/app/views/registration_conviction_rejection_forms/new.html.erb
+++ b/app/views/registration_conviction_rejection_forms/new.html.erb
@@ -1,0 +1,48 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render("waste_carriers_engine/shared/back", back_path: registration_convictions_path(@registration.reg_identifier)) %>
+
+    <%= form_for(@conviction_rejection_form, url: registration_registration_conviction_rejection_forms_path) do |f| %>
+      <%= render("waste_carriers_engine/shared/errors", object: @conviction_rejection_form) %>
+
+      <h1 class="heading-large">
+        <%= t(".heading", reg_identifier: @registration.reg_identifier) %>
+      </h1>
+
+      <% if @conviction_rejection_form.errors[:revoked_reason].any? %>
+      <div class="form-group form-group-error">
+      <% else %>
+      <div class="form-group">
+      <% end %>
+        <fieldset id="company_name">
+          <legend class="visuallyhidden">
+            <%= t(".heading", reg_identifier: @registration.reg_identifier) %>
+          </legend>
+
+          <% if @conviction_rejection_form.errors[:revoked_reason].any? %>
+          <span class="error-message"><%= @conviction_rejection_form.errors[:revoked_reason].join(", ") %></span>
+          <% end %>
+
+          <%= f.label :revoked_reason, t(".revoked_reason_label"), class: "form-label" %>
+          <%= f.text_area :revoked_reason, class: "form-control" %>
+        </fieldset>
+      </div>
+
+      <div class="form-group">
+        <div class="notice">
+          <i class="icon icon-important">
+            <span class="visually-hidden">Warning</span>
+          </i>
+          <strong class="bold-small">
+            <p><%= t(".warning") %></p>
+          </strong>
+        </div>
+      </div>
+
+      <%= f.hidden_field :reg_identifier, value: @conviction_rejection_form.reg_identifier %>
+      <div class="form-group">
+        <%= f.submit t(".reject_button"), class: "button" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/registration_conviction_rejection_forms.en.yml
+++ b/config/locales/registration_conviction_rejection_forms.en.yml
@@ -1,0 +1,17 @@
+en:
+  registration_conviction_rejection_forms:
+    new:
+      title: "Reject a registration with possible convictions"
+      heading: "Reject a registration with possible convictions: %{reg_identifier}"
+      revoked_reason_label: "Reason for rejection"
+      warning: "Once rejected, this registration cannot be completed."
+      reject_button: "Reject this renewal"
+  activemodel:
+    errors:
+      models:
+        conviction_rejection_form:
+          attributes:
+            base:
+              already_signed_off: "Convictions for this registration have already been approved or rejected"
+            revoked_reason:
+              blank: "You must enter a reason for this decision"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,11 @@ Rails.application.routes.draw do
             path: "/bo/registrations" do
               resources :convictions,
                         only: :index
+
+              resources :registration_conviction_rejection_forms,
+                        only: %i[new create],
+                        path: "convictions/reject",
+                        path_names: { new: "" }
             end
 
   resources :transient_registrations,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,7 +37,7 @@ Rails.application.routes.draw do
                         only: %i[new create],
                         path: "convictions/approve",
                         path_names: { new: "" }
-              
+
               resources :registration_conviction_rejection_forms,
                         only: %i[new create],
                         path: "convictions/reject",

--- a/spec/presenters/registration_conviction_presenter_spec.rb
+++ b/spec/presenters/registration_conviction_presenter_spec.rb
@@ -38,4 +38,12 @@ RSpec.describe RegistrationConvictionPresenter do
       expect(subject.begin_checks_path).to eq(expected_path)
     end
   end
+
+  describe "#reject_path" do
+    it "returns the correct path" do
+      expected_path = "/bo/registrations/#{reg_identifier}/convictions/reject"
+
+      expect(subject.reject_path).to eq(expected_path)
+    end
+  end
 end

--- a/spec/presenters/renewing_registration_conviction_presenter_spec.rb
+++ b/spec/presenters/renewing_registration_conviction_presenter_spec.rb
@@ -52,4 +52,12 @@ RSpec.describe RenewingRegistrationConvictionPresenter do
       expect(subject.begin_checks_path).to eq(expected_path)
     end
   end
+
+  describe "#reject_path" do
+    it "returns the correct path" do
+      expected_path = "/bo/transient-registrations/#{reg_identifier}/convictions/reject"
+
+      expect(subject.reject_path).to eq(expected_path)
+    end
+  end
 end

--- a/spec/requests/registration_conviction_rejection_forms_spec.rb
+++ b/spec/requests/registration_conviction_rejection_forms_spec.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "RegistrationConvictionRejectionForms", type: :request do
+  let(:registration) { create(:registration, :requires_conviction_check, :no_pending_payment) }
+
+  describe "GET /bo/registrations/:reg_identifier/convictions/reject" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user, :agency) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      it "renders the new template" do
+        get "/bo/registrations/#{registration.reg_identifier}/convictions/reject"
+        expect(response).to render_template(:new)
+      end
+
+      it "returns a 200 response" do
+        get "/bo/registrations/#{registration.reg_identifier}/convictions/reject"
+        expect(response).to have_http_status(200)
+      end
+
+      it "includes the reg identifier" do
+        get "/bo/registrations/#{registration.reg_identifier}/convictions/reject"
+        expect(response.body).to include(registration.reg_identifier)
+      end
+    end
+
+    context "when a non-agency user is signed in" do
+      let(:user) { create(:user, :finance) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      it "redirects to the permissions error page" do
+        get "/bo/registrations/#{registration.reg_identifier}/convictions/reject"
+        expect(response).to redirect_to("/bo/pages/permission")
+      end
+    end
+  end
+
+  describe "POST /bo/registrations/:reg_identifier/convictions/reject" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user, :agency) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      let(:params) do
+        {
+          reg_identifier: registration.reg_identifier,
+          revoked_reason: "foo"
+        }
+      end
+
+      it "redirects to the convictions page" do
+        post "/bo/registrations/#{registration.reg_identifier}/convictions/reject", conviction_rejection_form: params
+        expect(response).to redirect_to(convictions_path)
+      end
+
+      it "updates the revoked_reason" do
+        post "/bo/registrations/#{registration.reg_identifier}/convictions/reject", conviction_rejection_form: params
+        expect(registration.reload.metaData.revoked_reason).to eq(params[:revoked_reason])
+      end
+
+      skip "updates the conviction_sign_off's workflow_state" do
+        post "/bo/registrations/#{registration.reg_identifier}/convictions/reject", conviction_rejection_form: params
+        expect(registration.reload.conviction_sign_offs.first.workflow_state).to eq("rejectd")
+      end
+
+      skip "does not reject the registration" do
+      end
+
+      context "when the params are invalid" do
+        let(:params) do
+          {
+            reg_identifier: registration.reg_identifier,
+            revoked_reason: ""
+          }
+        end
+
+        it "renders the new template" do
+          post "/bo/registrations/#{registration.reg_identifier}/convictions/reject", conviction_rejection_form: params
+          expect(response).to render_template(:new)
+        end
+
+        it "does not update the revoked_reason" do
+          post "/bo/registrations/#{registration.reg_identifier}/convictions/reject", conviction_rejection_form: params
+          expect(registration.reload.metaData.revoked_reason).to_not eq(params[:revoked_reason])
+        end
+      end
+    end
+
+    context "when a non-agency user is signed in" do
+      let(:user) { create(:user, :finance) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      let(:params) do
+        {
+          reg_identifier: registration.reg_identifier,
+          revoked_reason: "foo"
+        }
+      end
+
+      it "redirects to the permissions error page" do
+        post "/bo/registrations/#{registration.reg_identifier}/convictions/reject", conviction_rejection_form: params
+        expect(response).to redirect_to("/bo/pages/permission")
+      end
+
+      it "does not update the revoked_reason" do
+        post "/bo/registrations/#{registration.reg_identifier}/convictions/reject", conviction_rejection_form: params
+        expect(registration.reload.metaData.revoked_reason).to_not eq(params[:revoked_reason])
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-792

Until we have moved new registrations into the engine and they become transient_registrations, we need to have a slightly separate process for rejecting convictions on registrations.

This PR sets up a version of the conviction rejection form that works with pending new registrations. It doesn't cover making the rejection actually do anything.

We can reuse the ConvictionRejectionForm, but a separate controller, route and view is required.

This is a bit cludgy and duplicates a lot of code, but the intent is that it's very easy to remove once we no longer need it!

---

Evil twin of https://github.com/DEFRA/waste-carriers-back-office/pull/492