### PR TITLE
Add visually hidden link text to convictions dashboard

### DIFF
--- a/app/views/shared/_convictions_dashboard_results.html.erb
+++ b/app/views/shared/_convictions_dashboard_results.html.erb
@@ -23,7 +23,13 @@
                 <%= result.metaData.last_modified.in_time_zone("London").strftime("%H:%M %d/%m/%Y") %>
               </td>
               <td>
-                <%= link_to t(".results.convictions_details_button"), details_path(result) %>
+                <%= link_to details_path(result) do %>
+                  <%= t(".results.details_link.text") %>
+                  <span class="visually-hidden">
+                    <%= t(".results.details_link.visually_hidden_text",
+                          name: result.company_name) %>
+                  </span>
+                <% end %>
               </td>
             </tr>
           <% end %>

--- a/config/locales/convictions_dashboards.en.yml
+++ b/config/locales/convictions_dashboards.en.yml
@@ -24,7 +24,9 @@ en:
           company_name: "Company name"
           last_modified: "Last modified"
           actions: "Actions"
-        convictions_details_button: "Conviction details"
+        details_link:
+          text: "Conviction details"
+          visually_hidden_text: "for %{name}"
       no_results: "No results found."
     convictions_dashboard_menu:
       menu:


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-791

This PR adds visually hidden text to the details links on the convictions dashboard, so the links are not identical for screenreaders.