### PR TITLE
Update registration's conviction status when approving check

### DIFF
--- a/app/controllers/registration_conviction_approval_forms_controller.rb
+++ b/app/controllers/registration_conviction_approval_forms_controller.rb
@@ -24,6 +24,7 @@ class RegistrationConvictionApprovalFormsController < ApplicationController
 
   def submit_form
     if @conviction_approval_form.submit(params[:conviction_approval_form])
+      approve_check
       redirect_to convictions_path
       true
     else
@@ -38,5 +39,9 @@ class RegistrationConvictionApprovalFormsController < ApplicationController
 
   def authorize_action
     authorize! :review_convictions, @registration
+  end
+
+  def approve_check
+    @registration.conviction_sign_offs.first.approve!(current_user)
   end
 end

--- a/spec/requests/registration_conviction_approval_forms_spec.rb
+++ b/spec/requests/registration_conviction_approval_forms_spec.rb
@@ -65,22 +65,22 @@ RSpec.describe "RegistrationConvictionApprovalForms", type: :request do
         expect(registration.reload.metaData.revoked_reason).to eq(params[:revoked_reason])
       end
 
-      skip "updates the conviction_sign_off's confirmed" do
+      it "updates the conviction_sign_off's confirmed" do
         post "/bo/registrations/#{registration.reg_identifier}/convictions/approve", conviction_approval_form: params
         expect(registration.reload.conviction_sign_offs.first.confirmed).to eq("yes")
       end
 
-      skip "updates the conviction_sign_off's confirmed_at" do
+      it "updates the conviction_sign_off's confirmed_at" do
         post "/bo/registrations/#{registration.reg_identifier}/convictions/approve", conviction_approval_form: params
         expect(registration.reload.conviction_sign_offs.first.confirmed_at).to be_a(DateTime)
       end
 
-      skip "updates the conviction_sign_off's confirmed_by" do
+      it "updates the conviction_sign_off's confirmed_by" do
         post "/bo/registrations/#{registration.reg_identifier}/convictions/approve", conviction_approval_form: params
         expect(registration.reload.conviction_sign_offs.first.confirmed_by).to eq(user.email)
       end
 
-      skip "updates the conviction_sign_off's workflow_state" do
+      it "updates the conviction_sign_off's workflow_state" do
         post "/bo/registrations/#{registration.reg_identifier}/convictions/approve", conviction_approval_form: params
         expect(registration.reload.conviction_sign_offs.first.workflow_state).to eq("approved")
       end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-792

When a user approves a conviction check, that should change the conviction workflow status.

This also updates some of the metadata in the conviction_sign_off.

Note that this doesn't cover approving and activating the registration itself - that's part of a separate story (RUBY-793).