### PR TITLE
Change reg conviction workflow status on reject

### DIFF
--- a/app/controllers/registration_conviction_rejection_forms_controller.rb
+++ b/app/controllers/registration_conviction_rejection_forms_controller.rb
@@ -24,6 +24,7 @@ class RegistrationConvictionRejectionFormsController < ApplicationController
 
   def submit_form
     if @conviction_rejection_form.submit(params[:conviction_rejection_form])
+      reject_check
       redirect_to convictions_path
       true
     else
@@ -38,5 +39,9 @@ class RegistrationConvictionRejectionFormsController < ApplicationController
 
   def authorize_action
     authorize! :review_convictions, @registration
+  end
+
+  def reject_check
+    @registration.conviction_sign_offs.first.reject!
   end
 end

--- a/spec/requests/registration_conviction_rejection_forms_spec.rb
+++ b/spec/requests/registration_conviction_rejection_forms_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "RegistrationConvictionRejectionForms", type: :request do
-  let(:registration) { create(:registration, :requires_conviction_check, :no_pending_payment) }
+  let(:registration) { create(:registration, :has_flagged_conviction_check) }
 
   describe "GET /bo/registrations/:reg_identifier/convictions/reject" do
     context "when a valid user is signed in" do
@@ -65,12 +65,12 @@ RSpec.describe "RegistrationConvictionRejectionForms", type: :request do
         expect(registration.reload.metaData.revoked_reason).to eq(params[:revoked_reason])
       end
 
-      skip "updates the conviction_sign_off's workflow_state" do
+      it "updates the conviction_sign_off's workflow_state" do
         post "/bo/registrations/#{registration.reg_identifier}/convictions/reject", conviction_rejection_form: params
-        expect(registration.reload.conviction_sign_offs.first.workflow_state).to eq("rejectd")
+        expect(registration.reload.conviction_sign_offs.first.workflow_state).to eq("rejected")
       end
 
-      skip "does not reject the registration" do
+      skip "rejects the registration" do
       end
 
       context "when the params are invalid" do


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-792

When a user rejects a conviction check, it should change the conviction workflow status.

Note that this doesn't reject the whole registration yet as that's a different story (RUBY-794).

---

Depends on https://github.com/DEFRA/waste-carriers-back-office/pull/493 - awaiting a rebase.