### PR TITLE
Don't display 'pending checks' message after rejection

### DIFF
--- a/app/views/registrations/show.html.erb
+++ b/app/views/registrations/show.html.erb
@@ -9,10 +9,10 @@
           <%= t(".heading", reg_identifier: @registration.reg_identifier) %>
         </h1>
 
-        <% if @registration.pending_manual_conviction_check? %>
-          <%= render "shared/registrations/pending_convictions_panel", resource: @registration %>
-        <% elsif @registration.rejected_conviction_checks? %>
+        <% if @registration.rejected_conviction_checks? %>
           <%= render "shared/registrations/rejected_conviction_checks_details", resource: @registration %>
+        <% elsif @registration.pending_manual_conviction_check? %>
+          <%= render "shared/registrations/pending_convictions_panel", resource: @registration %>
         <% end %>
 
         <% if @registration.pending_payment? %>


### PR DESCRIPTION
Spotted that the 'Conviction checks required' message was still being displayed on the registration details page after a rejection.

Swapping the order of the checks fixes this.