### PR TITLE
Complete registration if possible after conviction approval

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: 66e06b533ec6c015c58a50779385b903995db40b
+  revision: de2c090f1a12fb3fc59aebe1e2e68606743ccb04
   branch: master
   specs:
     waste_carriers_engine (0.0.1)
@@ -217,7 +217,7 @@ GEM
     multi_json (1.14.1)
     multipart-post (2.1.1)
     netrc (0.11.0)
-    nokogiri (1.10.6)
+    nokogiri (1.10.7)
       mini_portile2 (~> 2.4.0)
     octokit (4.14.0)
       sawyer (~> 0.8.0, >= 0.5.3)

--- a/app/controllers/registration_conviction_approval_forms_controller.rb
+++ b/app/controllers/registration_conviction_approval_forms_controller.rb
@@ -25,6 +25,7 @@ class RegistrationConvictionApprovalFormsController < ApplicationController
   def submit_form
     if @conviction_approval_form.submit(params[:conviction_approval_form])
       approve_check
+      renew_if_possible
       redirect_to convictions_path
       true
     else
@@ -43,5 +44,11 @@ class RegistrationConvictionApprovalFormsController < ApplicationController
 
   def approve_check
     @registration.conviction_sign_offs.first.approve!(current_user)
+  end
+
+  def renew_if_possible
+    return if @registration.unpaid_balance?
+
+    WasteCarriersEngine::RegistrationCompletionService.run(registration: @registration)
   end
 end

--- a/spec/requests/registration_conviction_approval_forms_spec.rb
+++ b/spec/requests/registration_conviction_approval_forms_spec.rb
@@ -85,18 +85,19 @@ RSpec.describe "RegistrationConvictionApprovalForms", type: :request do
         expect(registration.reload.conviction_sign_offs.first.workflow_state).to eq("approved")
       end
 
-      skip "when there is no pending payment" do
+      context "when there is no pending payment" do
         it "activates the registration" do
-        end
-
-        skip "when the RegistrationCompletionService fails" do
-          it "rescues the error" do
-          end
+          post "/bo/registrations/#{registration.reg_identifier}/convictions/approve", conviction_approval_form: params
+          expect(registration.reload).to be_active
         end
       end
 
-      skip "when there is a pending payment" do
+      context "when there is a pending payment" do
+        let(:registration) { create(:registration, :requires_conviction_check, :pending_payment) }
+
         it "does not activate the registration" do
+          post "/bo/registrations/#{registration.reg_identifier}/convictions/approve", conviction_approval_form: params
+          expect(registration.reload).to be_pending
         end
       end
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-793

When a new registration's convictions are approved and the balance is paid, we can now call the new RegistrationCompletionService from https://github.com/DEFRA/waste-carriers-engine/pull/583

This will mark the registration as active.