### PR TITLE
Include AD privacy policy in renew/resume links

### DIFF
--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -15,7 +15,7 @@ module ActionLinksHelper
   def resume_link_for(resource)
     return "#" unless a_transient_registration?(resource)
 
-    WasteCarriersEngine::Engine.routes.url_helpers.new_renewal_start_form_path(resource.reg_identifier)
+    ad_privacy_policy_path(resource.reg_identifier)
   end
 
   def payment_link_for(resource)
@@ -43,7 +43,7 @@ module ActionLinksHelper
   def renew_link_for(resource)
     return "#" unless a_registration?(resource)
 
-    WasteCarriersEngine::Engine.routes.url_helpers.new_renewal_start_form_path(resource.reg_identifier)
+    ad_privacy_policy_path(resource.reg_identifier)
   end
 
   def display_details_link_for?(resource)

--- a/app/views/shared/registrations/_action_links_panel.html.erb
+++ b/app/views/shared/registrations/_action_links_panel.html.erb
@@ -6,7 +6,7 @@
     <!-- TODO: This `display_resume_link_for?` will need to be updated when we build NewRegistration -->
     <% if display_resume_link_for?(resource) %>
       <li>
-        <%= link_to t(".actions_box.links.continue_button"), WasteCarriersEngine::Engine.routes.url_helpers.new_renewal_start_form_path(resource.reg_identifier) %>
+        <%= link_to t(".actions_box.links.continue_button"), resume_link_for(resource) %>
       </li>
     <% end %>
 

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe ActionLinksHelper, type: :helper do
       let(:resource) { build(:renewing_registration) }
 
       it "returns the correct path" do
-        expect(helper.resume_link_for(resource)).to eq(WasteCarriersEngine::Engine.routes.url_helpers.new_renewal_start_form_path(resource.reg_identifier))
+        expect(helper.resume_link_for(resource)).to eq(ad_privacy_policy_path(resource.reg_identifier))
       end
     end
 
@@ -108,7 +108,7 @@ RSpec.describe ActionLinksHelper, type: :helper do
       let(:resource) { create(:registration) }
 
       it "returns the correct path" do
-        expect(helper.renew_link_for(resource)).to eq(WasteCarriersEngine::Engine.routes.url_helpers.new_renewal_start_form_path(resource.reg_identifier))
+        expect(helper.renew_link_for(resource)).to eq(ad_privacy_policy_path(resource.reg_identifier))
       end
     end
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-803

We spotted that the 'renew' and 'resume' links in the back office went straight to the renewal workflow and skipped the AD privacy policy.

This update fixes the links to go to the AD privacy policy first.