### PR TITLE
Flash messages style

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -37,6 +37,7 @@
 @import 'partials/buttons';
 @import 'partials/dashboards';
 @import 'partials/dates';
+@import 'partials/flash-messages';
 @import 'partials/pagination';
 @import 'partials/people';
 @import 'partials/registrations';

--- a/app/assets/stylesheets/partials/_flash-messages.scss
+++ b/app/assets/stylesheets/partials/_flash-messages.scss
@@ -1,0 +1,27 @@
+.error-summary.flash-message {
+  border-color: #00703c;
+  background-color: #00703c;
+  color: #ffffff;
+  font-size: 24px;
+}
+
+.error-summary.flash-success {
+  border-color: #1d70b8;
+  background-color: #1d70b8;
+  color: #ffffff;
+  font-size: 24px;
+}
+
+.flash-success .error-summary-list a:link,
+.flash-success .error-summary-list a:visited,
+.flash-success .error-summary-list a:hover,
+.flash-success .error-summary-list a:active,
+.flash-success .error-summary-list p,
+.flash-message .error-summary-list a:link,
+.flash-message .error-summary-list a:visited,
+.flash-message .error-summary-list a:hover,
+.flash-message .error-summary-list a:active,
+.flash-message .error-summary-list p {
+  color: #ffffff;
+  font-size: 24px;
+ }


### PR DESCRIPTION
This adds the style for flash messages as per BO design.


<img width="813" alt="Screenshot 2019-12-12 at 15 01 46" src="https://user-images.githubusercontent.com/1385397/70718407-70e4e800-1cf0-11ea-93a8-87b157a9d344.png">
