### PR TITLE
Fix assisted digital continue link

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: 1c270a93698adfd0c4f0fd215d011ea7ad0a8845
+  revision: 2d3f0995f8bd0787f47f3374eddb4c09671fa96b
   branch: master
   specs:
     waste_carriers_engine (0.0.1)


### PR DESCRIPTION
Following https://github.com/DEFRA/waste-carriers-back-office/pull/502 we noticed that this continue link didn't always work depending on whether the registration already had a renewal in progress or not.

The new behaviour is that if a renewal is in progress, we will use the token for it. If not, we use the reg_identifier, which is acceptable when no token exists.

This will probably need further changes if the page is ever required for other journeys (eg editing).