### PR TITLE
Fix broken back link on successful reg transfer

### DIFF
--- a/app/controllers/registration_transfers_controller.rb
+++ b/app/controllers/registration_transfers_controller.rb
@@ -19,6 +19,7 @@ class RegistrationTransfersController < ApplicationController
 
   def success
     find_registration(params[:registration_reg_identifier])
+    authorize_action
   end
 
   private

--- a/app/views/registration_transfers/success.html.erb
+++ b/app/views/registration_transfers/success.html.erb
@@ -1,6 +1,6 @@
 <div class="grid-row">
   <div class="column-two-thirds">
-    <%= render("waste_carriers_engine/shared/back", back_path: new_registration_transfer_path(@registration.reg_identifier)) %>
+    <%= render("waste_carriers_engine/shared/back", back_path: new_registration_registration_transfer_path(@registration.reg_identifier)) %>
 
     <h1 class="heading-large">
       <%= t(".heading", reg_identifier: @registration.reg_identifier) %>

--- a/spec/requests/registration_transfers_spec.rb
+++ b/spec/requests/registration_transfers_spec.rb
@@ -115,4 +115,52 @@ RSpec.describe "RegistrationTransfers", type: :request do
       end
     end
   end
+
+  describe "GET /bo/registrations/:reg_identifier/transfer/success" do
+    before do
+      # Page expects the registration's account email to belong to an actual user
+      create(:external_user, email: registration.account_email)
+    end
+
+    context "when a valid user is signed in" do
+      let(:user) { create(:user, :agency) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      it "renders the success template" do
+        get "/bo/registrations/#{registration.reg_identifier}/transfer/success"
+        expect(response).to render_template(:success)
+      end
+
+      it "includes the registration info on the page" do
+        get "/bo/registrations/#{registration.reg_identifier}/transfer/success"
+        expect(response.body).to include("Registration #{registration.reg_identifier} has been transferred")
+      end
+
+      it "returns a 200 response" do
+        get "/bo/registrations/#{registration.reg_identifier}/transfer/success"
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context "when a non-agency user is signed in" do
+      let(:user) { create(:user, :finance) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      it "redirects to the permissions error page" do
+        get "/bo/registrations/#{registration.reg_identifier}/transfer/success"
+        expect(response).to redirect_to("/bo/pages/permission")
+      end
+    end
+
+    context "when a user is not signed in" do
+      it "redirects to the sign-in page" do
+        get "/bo/registrations/#{registration.reg_identifier}/transfer/success"
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This path hadn't been updated after the tweaks in https://github.com/DEFRA/waste-carriers-back-office/pull/502. As it was, it was causing the page to error. Updating the path fixes it.