### PR TITLE
Activate and deactivate back office users

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -40,7 +40,7 @@ class ApplicationController < ActionController::Base
     return if skip_auth_on_this_controller?
 
     authenticate_user!
-    redirect_to "/bo/pages/deactivated" if current_user_cannot_use_back_office?
+    redirect_to "/bo/pages/deactivated" if current_user_is_deactivated?
   end
 
   # http://jacopretorius.net/2014/01/force-page-to-reload-on-browser-back-in-rails.html
@@ -59,7 +59,7 @@ class ApplicationController < ActionController::Base
     controller.include?("pages") || controller.include?("devise")
   end
 
-  def current_user_cannot_use_back_office?
+  def current_user_is_deactivated?
     # Don't try to check user permissions if the user isn't logged in
     return false if current_user.blank?
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -40,7 +40,7 @@ class ApplicationController < ActionController::Base
     return if skip_auth_on_this_controller?
 
     authenticate_user!
-    redirect_to "/bo/pages/deactivated" if current_user_is_deactivated?
+    redirect_to "/bo/pages/deactivated" if current_user_cannot_use_back_office?
   end
 
   # http://jacopretorius.net/2014/01/force-page-to-reload-on-browser-back-in-rails.html
@@ -59,7 +59,7 @@ class ApplicationController < ActionController::Base
     controller.include?("pages") || controller.include?("devise")
   end
 
-  def current_user_is_deactivated?
+  def current_user_cannot_use_back_office?
     # Don't try to check user permissions if the user isn't logged in
     return false if current_user.blank?
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class SessionsController < Devise::SessionsController
+  skip_before_action :authenticate_and_authorize_active_user
+
   def destroy
     current_user.invalidate_all_sessions!
     super

--- a/app/controllers/user_activations_controller.rb
+++ b/app/controllers/user_activations_controller.rb
@@ -3,36 +3,31 @@
 class UserActivationsController < ApplicationController
   include UsersHelper
 
+  before_action :assign_user
+  before_action :check_activation_permissions
+
   def activate_form
-    assign_user(params[:id])
-    check_activation_permissions
     redirect_to users_url if @user.active?
   end
 
   def deactivate_form
-    assign_user(params[:id])
-    check_activation_permissions
     redirect_to users_url unless @user.active?
   end
 
   def activate
-    assign_user(params[:id])
-    check_activation_permissions
     @user.activate! unless @user.active?
     redirect_to users_url
   end
 
   def deactivate
-    assign_user(params[:id])
-    check_activation_permissions
     @user.deactivate! if @user.active?
     redirect_to users_url
   end
 
   private
 
-  def assign_user(id)
-    @user = User.find(id)
+  def assign_user
+    @user = User.find(params[:id])
   end
 
   def check_activation_permissions

--- a/app/controllers/user_activations_controller.rb
+++ b/app/controllers/user_activations_controller.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class UserActivationsController < ApplicationController
+  def activate_form
+    assign_user(params[:id])
+    redirect_to users_url if @user.active?
+  end
+
+  def deactivate_form
+    assign_user(params[:id])
+    redirect_to users_url unless @user.active?
+  end
+
+  def activate
+    assign_user(params[:id])
+    redirect_to users_url
+  end
+
+  def deactivate
+    assign_user(params[:id])
+    redirect_to users_url
+  end
+
+  private
+
+  def assign_user(id)
+    @user = User.find(id)
+  end
+end

--- a/app/controllers/user_activations_controller.rb
+++ b/app/controllers/user_activations_controller.rb
@@ -13,11 +13,13 @@ class UserActivationsController < ApplicationController
 
   def activate
     assign_user(params[:id])
+    @user.activate! unless @user.active?
     redirect_to users_url
   end
 
   def deactivate
     assign_user(params[:id])
+    @user.deactivate! if @user.active?
     redirect_to users_url
   end
 

--- a/app/controllers/user_activations_controller.rb
+++ b/app/controllers/user_activations_controller.rb
@@ -1,24 +1,30 @@
 # frozen_string_literal: true
 
 class UserActivationsController < ApplicationController
+  include UsersHelper
+
   def activate_form
     assign_user(params[:id])
+    check_activation_permissions
     redirect_to users_url if @user.active?
   end
 
   def deactivate_form
     assign_user(params[:id])
+    check_activation_permissions
     redirect_to users_url unless @user.active?
   end
 
   def activate
     assign_user(params[:id])
+    check_activation_permissions
     @user.activate! unless @user.active?
     redirect_to users_url
   end
 
   def deactivate
     assign_user(params[:id])
+    check_activation_permissions
     @user.deactivate! if @user.active?
     redirect_to users_url
   end
@@ -27,5 +33,11 @@ class UserActivationsController < ApplicationController
 
   def assign_user(id)
     @user = User.find(id)
+  end
+
+  def check_activation_permissions
+    return if agency_with_permission?(@user, current_user) || finance_with_permission?(@user, current_user)
+
+    raise CanCan::AccessDenied
   end
 end

--- a/app/controllers/user_activity_controller.rb
+++ b/app/controllers/user_activity_controller.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class UserActivityController < ApplicationController
+  include UsersHelper
+
+  before_action :assign_user
+  before_action :check_activation_permissions
+
+  def new
+    redirect_to users_url if user_activity_level_is_wrong?
+  end
+
+  def create
+    perform_activation_action unless user_activity_level_is_wrong?
+    redirect_to users_url
+  end
+
+  private
+
+  def assign_user
+    @user = User.find(params[:user_id])
+  end
+
+  def check_activation_permissions
+    return if agency_with_permission?(@user, current_user) || finance_with_permission?(@user, current_user)
+
+    raise CanCan::AccessDenied
+  end
+end

--- a/app/controllers/user_deactivations_controller.rb
+++ b/app/controllers/user_deactivations_controller.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
-class UserActivationsController < UserActivityController
+class UserDeactivationsController < UserActivityController
   include UsersHelper
 
   private
 
   def user_activity_level_is_wrong?
-    @user.active?
+    !@user.active?
   end
 
   def perform_activation_action
-    @user.activate!
+    @user.deactivate!
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -4,6 +4,10 @@ class Ability
   include CanCan::Ability
 
   def initialize(user)
+    return unless user.active?
+
+    can :use_back_office, :all
+
     assign_agency_user_permissions(user)
     assign_finance_user_permissions(user)
   end

--- a/app/models/concerns/can_behave_like_user.rb
+++ b/app/models/concerns/can_behave_like_user.rb
@@ -55,12 +55,14 @@ module CanBehaveLikeUser
   private
 
   def password_must_have_lowercase_uppercase_and_numeric
+    return unless password.present? && errors[:password].empty?
+
     has_lowercase = (password =~ /[a-z]/)
     has_uppercase = (password =~ /[A-Z]/)
     has_numeric = (password =~ /[0-9]/)
 
     return true if has_lowercase && has_uppercase && has_numeric
 
-    errors.add(:password, I18n.t("errors.messages.weakPassword"))
+    errors.add(:password, :invalid_format)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,7 @@ class User
   # Use the User database
   store_in client: "users", collection: "back_office_users"
 
+  field :active, type: Boolean, default: true
   field :session_token, type: String
 
   delegate :can?, :cannot?, to: :ability
@@ -27,11 +28,11 @@ class User
   end
 
   def activate!
-    update!(active: true)
+    update_attribute(:active, true)
   end
 
   def deactivate!
-    update!(active: false)
+    update_attribute(:active, false)
   end
 
   # Roles

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,6 +22,10 @@ class User
     set(session_token: SecureRandom.hex)
   end
 
+  def active?
+    active == true
+  end
+
   # Roles
 
   ROLES = %w[agency

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,6 +26,10 @@ class User
     active == true
   end
 
+  def activate!
+    update!(active: true)
+  end
+
   # Roles
 
   ROLES = %w[agency

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,7 +24,7 @@ class User
   end
 
   def active?
-    active == true
+    active == true || active.nil?
   end
 
   def activate!

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,6 +30,10 @@ class User
     update!(active: true)
   end
 
+  def deactivate!
+    update!(active: false)
+  end
+
   # Roles
 
   ROLES = %w[agency

--- a/app/views/pages/deactivated.html.erb
+++ b/app/views/pages/deactivated.html.erb
@@ -1,0 +1,6 @@
+<% content_for :title, I18n.t(".pages.deactivated.title")  %>
+
+<div class="text">
+  <h1 class="heading-large"><%= I18n.t(".pages.deactivated.heading") %></h1>
+  <p><%= I18n.t(".pages.deactivated.text") %></p>
+</div>

--- a/app/views/user_activations/activate_form.html.erb
+++ b/app/views/user_activations/activate_form.html.erb
@@ -1,0 +1,21 @@
+<div class="grid-row">
+  <div class="column-full">
+    <%= render("waste_carriers_engine/shared/back", back_path: users_path) %>
+
+    <h1 class="heading-large">
+      <%= t(".heading") %>
+    </h1>
+  </div>
+</div>
+
+<div class="grid-row">
+  <div class="column-full">
+    <p><%= t(".paragraph_1") %></p>
+    <p><%= @user.email %></p>
+    <p><%= t(".paragraph_2") %></p>
+
+    <%= button_to t(".button"),
+              activate_user_path(@user.id),
+              class: "button" %>
+  </div>
+</div>

--- a/app/views/user_activations/deactivate_form.html.erb
+++ b/app/views/user_activations/deactivate_form.html.erb
@@ -1,0 +1,21 @@
+<div class="grid-row">
+  <div class="column-full">
+    <%= render("waste_carriers_engine/shared/back", back_path: users_path) %>
+
+    <h1 class="heading-large">
+      <%= t(".heading") %>
+    </h1>
+  </div>
+</div>
+
+<div class="grid-row">
+  <div class="column-full">
+    <p><%= t(".paragraph_1") %></p>
+    <p><%= @user.email %></p>
+    <p><%= t(".paragraph_2") %></p>
+
+    <%= button_to t(".button"),
+              deactivate_user_path(@user.id),
+              class: "button" %>
+  </div>
+</div>

--- a/app/views/user_activations/new.html.erb
+++ b/app/views/user_activations/new.html.erb
@@ -15,7 +15,7 @@
     <p><%= t(".paragraph_2") %></p>
 
     <%= button_to t(".button"),
-              deactivate_user_path(@user.id),
+              user_activations_path(@user.id),
               class: "button" %>
   </div>
 </div>

--- a/app/views/user_deactivations/new.html.erb
+++ b/app/views/user_deactivations/new.html.erb
@@ -15,7 +15,7 @@
     <p><%= t(".paragraph_2") %></p>
 
     <%= button_to t(".button"),
-              activate_user_path(@user.id),
+              user_deactivations_path(@user.id),
               class: "button" %>
   </div>
 </div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -36,7 +36,11 @@
                   <%= t(".user_list.roles.#{user.role}") %>
                 </td>
                 <td>
-                  <%= t(".user_list.statuses.active") %>
+                  <% if user.active? %>
+                    <%= t(".user_list.statuses.active") %>
+                  <% else %>
+                    <%= t(".user_list.statuses.deactivated") %>
+                  <% end %>
                 </td>
                 <td>
                   <% if display_user_actions?(user, current_user) %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -56,7 +56,7 @@
                       </li>
                       <li>
                         <% if user.active? %>
-                          <%= link_to deactivate_user_form_path(user.id) do %>
+                          <%= link_to user_deactivations_path(user.id) do %>
                             <%= t(".user_list.actions.deactivate.link_text") %>
                             <span class="visually-hidden">
                               <%= t(".user_list.actions.deactivate.visually_hidden_text",
@@ -64,7 +64,7 @@
                             </span>
                           <% end %>
                         <% else %>
-                          <%= link_to activate_user_form_path(user.id) do %>
+                          <%= link_to user_activations_path(user.id) do %>
                             <%= t(".user_list.actions.activate.link_text") %>
                             <span class="visually-hidden">
                               <%= t(".user_list.actions.activate.visually_hidden_text",

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -55,13 +55,23 @@
                        <% end %>
                       </li>
                       <li>
-                        <%= link_to "#" do %>
-                          <%= t(".user_list.actions.deactivate.link_text") %>
-                          <span class="visually-hidden">
-                           <%= t(".user_list.actions.deactivate.visually_hidden_text",
-                                 email: user.email) %>
-                         </span>
-                       <% end %>
+                        <% if user.active? %>
+                          <%= link_to deactivate_user_form_path(user.id) do %>
+                            <%= t(".user_list.actions.deactivate.link_text") %>
+                            <span class="visually-hidden">
+                              <%= t(".user_list.actions.deactivate.visually_hidden_text",
+                                    email: user.email) %>
+                            </span>
+                          <% end %>
+                        <% else %>
+                          <%= link_to activate_user_form_path(user.id) do %>
+                            <%= t(".user_list.actions.activate.link_text") %>
+                            <span class="visually-hidden">
+                              <%= t(".user_list.actions.activate.visually_hidden_text",
+                                    email: user.email) %>
+                            </span>
+                          <% end %>
+                        <% end %>
                       </li>
                     </ul>
                   <% end %>

--- a/config/locales/pages/deactivated.en.yml
+++ b/config/locales/pages/deactivated.en.yml
@@ -1,0 +1,6 @@
+en:
+  pages:
+    deactivated:
+      title: "Your account has been deactivated"
+      heading: "Your account has been deactivated"
+      text: "You cannot use the Waste Carriers Back Office unless your account is active. If you believe you should have access, contact an NCCC super user."

--- a/config/locales/user_activations.en.yml
+++ b/config/locales/user_activations.en.yml
@@ -1,0 +1,14 @@
+en:
+  user_activations:
+    activate_form:
+      title: "Activate user"
+      heading: "Activate user"
+      paragraph_1: "You are about to activate this user:"
+      paragraph_2: "Once activated, this user will be able to access and use the back office."
+      button: "Activate"
+    deactivate_form:
+      title: "Deactivate user"
+      heading: "Deactivate user"
+      paragraph_1: "You are about to deactivate this user:"
+      paragraph_2: "Once deactivated, this user will not be able to access and use the back office."
+      button: "Deactivate"

--- a/config/locales/user_activations.en.yml
+++ b/config/locales/user_activations.en.yml
@@ -1,14 +1,8 @@
 en:
   user_activations:
-    activate_form:
+    new:
       title: "Activate user"
       heading: "Activate user"
       paragraph_1: "You are about to activate this user:"
       paragraph_2: "Once activated, this user will be able to access and use the back office."
       button: "Activate"
-    deactivate_form:
-      title: "Deactivate user"
-      heading: "Deactivate user"
-      paragraph_1: "You are about to deactivate this user:"
-      paragraph_2: "Once deactivated, this user will not be able to access and use the back office."
-      button: "Deactivate"

--- a/config/locales/user_deactivations.en.yml
+++ b/config/locales/user_deactivations.en.yml
@@ -1,0 +1,8 @@
+en:
+  user_deactivations:
+    new:
+      title: "Deactivate user"
+      heading: "Deactivate user"
+      paragraph_1: "You are about to deactivate this user:"
+      paragraph_2: "Once deactivated, this user will not be able to access and use the back office."
+      button: "Deactivate"

--- a/config/locales/users.en.yml
+++ b/config/locales/users.en.yml
@@ -32,3 +32,12 @@ en:
           activate:
             link_text: "Activate"
             visually_hidden_text: " %{email}"
+  mongoid:
+    errors:
+      models:
+        user:
+          attributes:
+            password:
+              blank: "You must enter a password"
+              too_short: "The password must be at least 8 characters long"
+              invalid_format: "The password must contain uppercase letters, lowercase letters and numbers"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -126,10 +126,23 @@ Rails.application.routes.draw do
       to: "users#index",
       as: :users
 
-  get "/bo/users/activate/:id", to: "user_activations#activate_form", as: :activate_user_form
-  get "/bo/users/deactivate/:id", to: "user_activations#deactivate_form", as: :deactivate_user_form
-  post "/bo/users/activate/:id", to: "user_activations#activate", as: :activate_user
-  post "/bo/users/deactivate/:id", to: "user_activations#deactivate", as: :deactivate_user
+  resources :users,
+            only: [],
+            param: :id,
+            path: "/bo/users",
+            path_names: { show: "/:id" } do
+              resources :user_activations,
+                        as: :activations,
+                        only: %i[new create],
+                        path: "activate",
+                        path_names: { new: "" }
+
+              resources :user_deactivations,
+                        as: :deactivations,
+                        only: %i[new create],
+                        path: "deactivate",
+                        path_names: { new: "" }
+            end
 
   resources :user_migrations,
             only: %i[new create],

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -128,8 +128,7 @@ Rails.application.routes.draw do
 
   resources :users,
             only: [],
-            path: "/bo/users",
-            path_names: { show: "/:id" } do
+            path: "/bo/users" do
               resources :user_activations,
                         as: :activations,
                         only: %i[new create],

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -126,6 +126,11 @@ Rails.application.routes.draw do
       to: "users#index",
       as: :users
 
+  get "/bo/users/activate/:id", to: "user_activations#activate_form", as: :activate_user_form
+  get "/bo/users/deactivate/:id", to: "user_activations#deactivate_form", as: :deactivate_user_form
+  post "/bo/users/activate/:id", to: "user_activations#activate", as: :activate_user
+  post "/bo/users/deactivate/:id", to: "user_activations#deactivate", as: :deactivate_user
+
   resources :user_migrations,
             only: %i[new create],
             path: "/bo/users/migrate",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -128,7 +128,6 @@ Rails.application.routes.draw do
 
   resources :users,
             only: [],
-            param: :id,
             path: "/bo/users",
             path_names: { show: "/:id" } do
               resources :user_activations,

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -10,6 +10,10 @@ FactoryBot.define do
 
     role { "agency" }
 
+    trait :inactive do
+      active { false }
+    end
+
     trait :agency do
       role { "agency" }
     end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -5,7 +5,8 @@ require "rails_helper"
 
 RSpec.describe Ability, type: :model do
   let(:role) {}
-  let(:user) { double(:user, role: role) }
+  let(:active) { true }
+  let(:user) { double(:user, role: role, active?: active) }
   subject(:ability) { Ability.new(user) }
 
   # Agency users have ascending permissions - each tier has the permissions of
@@ -17,6 +18,8 @@ RSpec.describe Ability, type: :model do
     include_examples "agency_super examples"
     include_examples "agency_with_refund examples"
     include_examples "agency examples"
+
+    include_examples "active and inactive examples"
   end
 
   context "when the user role is agency_with_refund" do
@@ -25,6 +28,8 @@ RSpec.describe Ability, type: :model do
     include_examples "below agency_super examples"
     include_examples "agency_with_refund examples"
     include_examples "agency examples"
+
+    include_examples "active and inactive examples"
   end
 
   context "when the user role is agency" do
@@ -33,6 +38,8 @@ RSpec.describe Ability, type: :model do
     include_examples "below agency_super examples"
     include_examples "below agency_with_refund examples"
     include_examples "agency examples"
+
+    include_examples "active and inactive examples"
   end
 
   # Finance users do not have ascending permissions.
@@ -41,17 +48,23 @@ RSpec.describe Ability, type: :model do
     let(:role) { "finance_super" }
 
     include_examples "finance_super examples"
+
+    include_examples "active and inactive examples"
   end
 
   context "when the user role is finance_admin" do
     let(:role) { "finance_admin" }
 
     include_examples "finance_admin examples"
+
+    include_examples "active and inactive examples"
   end
 
   context "when the user role is finance" do
     let(:role) { "finance" }
 
     include_examples "finance examples"
+
+    include_examples "active and inactive examples"
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,6 +4,24 @@ require "cancan/matchers"
 require "rails_helper"
 
 RSpec.describe User, type: :model do
+  describe "#active?" do
+    context "when 'active' is true" do
+      let(:user) { User.new(active: true) }
+
+      it "returns true" do
+        expect(user.active?).to eq(true)
+      end
+    end
+
+    context "when 'active' is false" do
+      let(:user) { User.new(active: false) }
+
+      it "returns false" do
+        expect(user.active?).to eq(false)
+      end
+    end
+  end
+
   describe "#password" do
     context "when the user's password meets the requirements" do
       let(:user) { build(:user, password: "Secret123") }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -22,6 +22,15 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe "#activate!" do
+    let(:user) { build(:user, :inactive) }
+
+    it "makes the user active" do
+      user.activate!
+      expect(user.active).to eq(true)
+    end
+  end
+
   describe "#password" do
     context "when the user's password meets the requirements" do
       let(:user) { build(:user, password: "Secret123") }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -20,6 +20,14 @@ RSpec.describe User, type: :model do
         expect(user.active?).to eq(false)
       end
     end
+
+    context "when 'active' is nil" do
+      let(:user) { User.new(active: nil) }
+
+      it "returns true" do
+        expect(user.active?).to eq(true)
+      end
+    end
   end
 
   describe "#activate!" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -31,6 +31,15 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe "#deactivate!" do
+    let(:user) { build(:user) }
+
+    it "makes the user inactive" do
+      user.deactivate!
+      expect(user.active).to eq(false)
+    end
+  end
+
   describe "#password" do
     context "when the user's password meets the requirements" do
       let(:user) { build(:user, password: "Secret123") }

--- a/spec/requests/dashboards_spec.rb
+++ b/spec/requests/dashboards_spec.rb
@@ -40,6 +40,15 @@ RSpec.describe "Dashboards", type: :request do
       end
     end
 
+    context "when a deactivated user is signed in" do
+      before { sign_in(create(:user, :inactive)) }
+
+      it "redirects to the deactivated page" do
+        get "/bo"
+        expect(response).to redirect_to("/bo/pages/deactivated")
+      end
+    end
+
     context "when a user is not signed in" do
       it "redirects to the sign-in page" do
         get "/bo"

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Pages", type: :request do
+  describe "/bo/pages/deactivated" do
+    context "when an active user is logged in" do
+      before do
+        sign_in(create(:user))
+      end
+
+      it "displays the correct page" do
+        get "/bo/pages/deactivated"
+
+        expect(response).to have_http_status(200)
+        expect(response).to render_template(:deactivated)
+      end
+    end
+
+    context "when an inactive user is logged in" do
+      before do
+        sign_in(create(:user, :inactive))
+      end
+
+      it "displays the correct page" do
+        get "/bo/pages/deactivated"
+
+        expect(response).to have_http_status(200)
+        expect(response).to render_template(:deactivated)
+      end
+    end
+
+    context "when no user is logged in" do
+      it "displays the correct page" do
+        get "/bo/pages/deactivated"
+
+        expect(response).to have_http_status(200)
+        expect(response).to render_template(:deactivated)
+      end
+    end
+  end
+end

--- a/spec/requests/routes_spec.rb
+++ b/spec/requests/routes_spec.rb
@@ -67,9 +67,12 @@ RSpec.describe "Root", type: :request do
     end
 
     context "when a deactivated user is signed in" do
+      let(:user) { create(:user, :inactive) }
       let(:registration) { create(:registration, reg_identifier: "CBDU12345") }
 
-      before { sign_in(create(:user, :inactive)) }
+      before(:each) do
+        sign_in(user)
+      end
 
       it "redirects to the deactivated page" do
         get "/bo/#{registration.reg_identifier}/renew"

--- a/spec/requests/routes_spec.rb
+++ b/spec/requests/routes_spec.rb
@@ -74,9 +74,9 @@ RSpec.describe "Root", type: :request do
         sign_in(user)
       end
 
-      it "redirects to the deactivated page" do
+      it "returns a 302 (redirect) response" do
         get "/bo/#{registration.reg_identifier}/renew"
-        expect(response).to redirect_to("/bo/pages/deactivated")
+        expect(response).to have_http_status(302)
       end
     end
   end

--- a/spec/requests/routes_spec.rb
+++ b/spec/requests/routes_spec.rb
@@ -4,6 +4,10 @@ require "rails_helper"
 
 RSpec.describe "Root", type: :request do
   describe "GET /" do
+    before(:each) do
+      sign_in(create(:user))
+    end
+
     it "redirects to /bo" do
       get "/"
       expect(response).to redirect_to(bo_path)
@@ -59,6 +63,17 @@ RSpec.describe "Root", type: :request do
       it "redirects the user to the renewal start page" do
         get "/bo/#{registration.reg_identifier}/renew"
         expect(response.body).to include("You are about to renew your registration")
+      end
+    end
+
+    context "when a deactivated user is signed in" do
+      let(:registration) { create(:registration, reg_identifier: "CBDU12345") }
+
+      before { sign_in(create(:user, :inactive)) }
+
+      it "redirects to the deactivated page" do
+        get "/bo/#{registration.reg_identifier}/renew"
+        expect(response).to redirect_to("/bo/pages/deactivated")
       end
     end
   end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -63,6 +63,15 @@ RSpec.describe "Sessions", type: :request do
         get destroy_user_session_path
         expect(user.reload.session_token).to_not eq(old_session_token)
       end
+
+      context "when the user is inactive" do
+        let(:user) { create(:user, :inactive) }
+
+        it "signs the user out" do
+          get destroy_user_session_path
+          expect(controller.current_user).to be_nil
+        end
+      end
     end
   end
 end

--- a/spec/requests/user_activations_spec.rb
+++ b/spec/requests/user_activations_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "User Activations", type: :request do
+  let(:active_user) { create(:user, :agency) }
+  let(:inactive_user) { create(:user, :agency, :inactive) }
+
+  describe "GET /bo/users/activate/:id" do
+    context "when a super user is signed in" do
+      let(:user) { create(:user, :agency_super) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      context "when the user to be activated is inactive" do
+        it "renders the activate_form template" do
+          get "/bo/users/activate/#{inactive_user.id}"
+          expect(response).to render_template(:activate_form)
+        end
+      end
+
+      context "when the user to be activated is already active" do
+        it "redirects to the user list" do
+          get "/bo/users/activate/#{active_user.id}"
+          expect(response).to redirect_to(users_path)
+        end
+      end
+    end
+  end
+
+  describe "GET /bo/users/deactivate/:id" do
+    context "when a super user is signed in" do
+      let(:user) { create(:user, :agency_super) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      context "when the user to be deactivated is active" do
+        it "renders the deactivate_form template" do
+          get "/bo/users/deactivate/#{active_user.id}"
+          expect(response).to render_template(:deactivate_form)
+        end
+      end
+
+      context "when the user to be deactivated is already inactive" do
+        it "redirects to the user list" do
+          get "/bo/users/deactivate/#{inactive_user.id}"
+          expect(response).to redirect_to(users_path)
+        end
+      end
+    end
+  end
+
+  describe "POST /bo/users/activate" do
+    context "when a super user is signed in" do
+      let(:user) { create(:user, :agency_super) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      context "when the user to be activated is inactive" do
+        it "redirects to the user list" do
+          post "/bo/users/activate/#{inactive_user.id}"
+          expect(response).to redirect_to(users_path)
+        end
+      end
+
+      context "when the user to be activated is already active" do
+        it "redirects to the user list" do
+          post "/bo/users/activate/#{active_user.id}"
+          expect(response).to redirect_to(users_path)
+        end
+      end
+    end
+  end
+
+  describe "POST /bo/users/deactivate" do
+    context "when a super user is signed in" do
+      let(:user) { create(:user, :agency_super) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      context "when the user to be deactivated is active" do
+        it "redirects to the user list" do
+          post "/bo/users/deactivate/#{active_user.id}"
+          expect(response).to redirect_to(users_path)
+        end
+      end
+
+      context "when the user to be deactivated is already inactive" do
+        it "redirects to the user list" do
+          post "/bo/users/deactivate/#{inactive_user.id}"
+          expect(response).to redirect_to(users_path)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/user_activations_spec.rb
+++ b/spec/requests/user_activations_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe "User Activations", type: :request do
   let(:active_user) { create(:user, :agency) }
   let(:inactive_user) { create(:user, :agency, :inactive) }
 
+  before { allow_any_instance_of(User).to receive(:valid?).and_return(true) }
+
   describe "GET /bo/users/activate/:id" do
     context "when a super user is signed in" do
       let(:user) { create(:user, :agency_super) }

--- a/spec/requests/user_activations_spec.rb
+++ b/spec/requests/user_activations_spec.rb
@@ -6,8 +6,6 @@ RSpec.describe "User Activations", type: :request do
   let(:active_user) { create(:user, :agency) }
   let(:inactive_user) { create(:user, :agency, :inactive) }
 
-  before { allow_any_instance_of(User).to receive(:valid?).and_return(true) }
-
   describe "GET /bo/users/activate/:id" do
     context "when a super user is signed in" do
       let(:user) { create(:user, :agency_super) }

--- a/spec/requests/user_activations_spec.rb
+++ b/spec/requests/user_activations_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "User Activations", type: :request do
   let(:active_user) { create(:user, role: subject_user_role) }
   let(:inactive_user) { create(:user, :inactive, role: subject_user_role) }
 
-  describe "GET /bo/users/activate/:id" do
+  describe "GET /bo/users/:id/activate" do
     context "when a super user is signed in" do
       let(:user) { create(:user, role: current_user_role) }
       before(:each) do
@@ -42,7 +42,7 @@ RSpec.describe "User Activations", type: :request do
     end
   end
 
-  describe "POST /bo/users/activate" do
+  describe "POST /bo/users/:id/activate" do
     context "when a super user is signed in" do
       let(:user) { create(:user, role: current_user_role) }
       before(:each) do

--- a/spec/requests/user_activations_spec.rb
+++ b/spec/requests/user_activations_spec.rb
@@ -3,27 +3,40 @@
 require "rails_helper"
 
 RSpec.describe "User Activations", type: :request do
-  let(:active_user) { create(:user, :agency) }
-  let(:inactive_user) { create(:user, :agency, :inactive) }
+  let(:current_user_role) { :agency_super }
+  let(:subject_user_role) { :agency }
+  let(:active_user) { create(:user, role: subject_user_role) }
+  let(:inactive_user) { create(:user, :inactive, role: subject_user_role) }
 
   describe "GET /bo/users/activate/:id" do
     context "when a super user is signed in" do
-      let(:user) { create(:user, :agency_super) }
+      let(:user) { create(:user, role: current_user_role) }
       before(:each) do
         sign_in(user)
       end
 
-      context "when the user to be activated is inactive" do
-        it "renders the activate_form template" do
-          get "/bo/users/activate/#{inactive_user.id}"
-          expect(response).to render_template(:activate_form)
+      context "when the current user has permission to activate the user" do
+        context "when the user to be activated is inactive" do
+          it "renders the activate_form template" do
+            get "/bo/users/activate/#{inactive_user.id}"
+            expect(response).to render_template(:activate_form)
+          end
+        end
+
+        context "when the user to be activated is already active" do
+          it "redirects to the user list" do
+            get "/bo/users/activate/#{active_user.id}"
+            expect(response).to redirect_to(users_path)
+          end
         end
       end
 
-      context "when the user to be activated is already active" do
-        it "redirects to the user list" do
-          get "/bo/users/activate/#{active_user.id}"
-          expect(response).to redirect_to(users_path)
+      context "when the current user does not have permission to activate the user" do
+        let(:current_user_role) { :finance_super }
+
+        it "redirects to a permission error" do
+          get "/bo/users/activate/#{inactive_user.id}"
+          expect(response).to redirect_to("/bo/pages/permission")
         end
       end
     end
@@ -31,22 +44,36 @@ RSpec.describe "User Activations", type: :request do
 
   describe "GET /bo/users/deactivate/:id" do
     context "when a super user is signed in" do
-      let(:user) { create(:user, :agency_super) }
+      let(:user) { create(:user, role: current_user_role) }
       before(:each) do
         sign_in(user)
       end
 
-      context "when the user to be deactivated is active" do
-        it "renders the deactivate_form template" do
-          get "/bo/users/deactivate/#{active_user.id}"
-          expect(response).to render_template(:deactivate_form)
+      context "when the current user has permission to activate the user" do
+        let(:current_user_role) { :finance_super }
+        let(:subject_user_role) { :finance }
+
+        context "when the user to be deactivated is active" do
+          it "renders the deactivate_form template" do
+            get "/bo/users/deactivate/#{active_user.id}"
+            expect(response).to render_template(:deactivate_form)
+          end
+        end
+
+        context "when the user to be deactivated is already inactive" do
+          it "redirects to the user list" do
+            get "/bo/users/deactivate/#{inactive_user.id}"
+            expect(response).to redirect_to(users_path)
+          end
         end
       end
 
-      context "when the user to be deactivated is already inactive" do
-        it "redirects to the user list" do
-          get "/bo/users/deactivate/#{inactive_user.id}"
-          expect(response).to redirect_to(users_path)
+      context "when the current user does not have permission to activate the user" do
+        let(:subject_user_role) { :finance }
+
+        it "redirects to a permission error" do
+          get "/bo/users/deactivate/#{active_user.id}"
+          expect(response).to redirect_to("/bo/pages/permission")
         end
       end
     end
@@ -54,27 +81,38 @@ RSpec.describe "User Activations", type: :request do
 
   describe "POST /bo/users/activate" do
     context "when a super user is signed in" do
-      let(:user) { create(:user, :agency_super) }
+      let(:user) { create(:user, role: current_user_role) }
       before(:each) do
         sign_in(user)
       end
 
-      context "when the user to be activated is inactive" do
-        it "redirects to the user list" do
-          post "/bo/users/activate/#{inactive_user.id}"
-          expect(response).to redirect_to(users_path)
+      context "when the current user has permission to activate the user" do
+        context "when the user to be activated is inactive" do
+          it "redirects to the user list" do
+            post "/bo/users/activate/#{inactive_user.id}"
+            expect(response).to redirect_to(users_path)
+          end
+
+          it "activates the user" do
+            post "/bo/users/activate/#{inactive_user.id}"
+            expect(inactive_user.reload.active?).to eq(true)
+          end
         end
 
-        it "activates the user" do
-          post "/bo/users/activate/#{inactive_user.id}"
-          expect(inactive_user.reload.active?).to eq(true)
+        context "when the user to be activated is already active" do
+          it "redirects to the user list" do
+            post "/bo/users/activate/#{active_user.id}"
+            expect(response).to redirect_to(users_path)
+          end
         end
       end
 
-      context "when the user to be activated is already active" do
-        it "redirects to the user list" do
-          post "/bo/users/activate/#{active_user.id}"
-          expect(response).to redirect_to(users_path)
+      context "when the current user does not have permission to activate the user" do
+        let(:subject_user_role) { :finance }
+
+        it "redirects to a permission error" do
+          post "/bo/users/activate/#{inactive_user.id}"
+          expect(response).to redirect_to("/bo/pages/permission")
         end
       end
     end
@@ -82,27 +120,41 @@ RSpec.describe "User Activations", type: :request do
 
   describe "POST /bo/users/deactivate" do
     context "when a super user is signed in" do
-      let(:user) { create(:user, :agency_super) }
+      let(:user) { create(:user, role: current_user_role) }
       before(:each) do
         sign_in(user)
       end
 
-      context "when the user to be deactivated is active" do
-        it "redirects to the user list" do
-          post "/bo/users/deactivate/#{active_user.id}"
-          expect(response).to redirect_to(users_path)
+      context "when the current user has permission to activate the user" do
+        let(:current_user_role) { :finance_super }
+        let(:subject_user_role) { :finance }
+
+        context "when the user to be deactivated is active" do
+          it "redirects to the user list" do
+            post "/bo/users/deactivate/#{active_user.id}"
+            expect(response).to redirect_to(users_path)
+          end
+
+          it "deactivates the user" do
+            post "/bo/users/deactivate/#{active_user.id}"
+            expect(active_user.reload.active?).to eq(false)
+          end
         end
 
-        it "deactivates the user" do
-          post "/bo/users/deactivate/#{active_user.id}"
-          expect(active_user.reload.active?).to eq(false)
+        context "when the user to be deactivated is already inactive" do
+          it "redirects to the user list" do
+            post "/bo/users/deactivate/#{inactive_user.id}"
+            expect(response).to redirect_to(users_path)
+          end
         end
       end
 
-      context "when the user to be deactivated is already inactive" do
-        it "redirects to the user list" do
-          post "/bo/users/deactivate/#{inactive_user.id}"
-          expect(response).to redirect_to(users_path)
+      context "when the current user does not have permission to activate the user" do
+        let(:current_user_role) { :finance_super }
+
+        it "redirects to a permission error" do
+          post "/bo/users/deactivate/#{active_user.id}"
+          expect(response).to redirect_to("/bo/pages/permission")
         end
       end
     end

--- a/spec/requests/user_activations_spec.rb
+++ b/spec/requests/user_activations_spec.rb
@@ -64,6 +64,11 @@ RSpec.describe "User Activations", type: :request do
           post "/bo/users/activate/#{inactive_user.id}"
           expect(response).to redirect_to(users_path)
         end
+
+        it "activates the user" do
+          post "/bo/users/activate/#{inactive_user.id}"
+          expect(inactive_user.reload.active?).to eq(true)
+        end
       end
 
       context "when the user to be activated is already active" do
@@ -86,6 +91,11 @@ RSpec.describe "User Activations", type: :request do
         it "redirects to the user list" do
           post "/bo/users/deactivate/#{active_user.id}"
           expect(response).to redirect_to(users_path)
+        end
+
+        it "deactivates the user" do
+          post "/bo/users/deactivate/#{active_user.id}"
+          expect(active_user.reload.active?).to eq(false)
         end
       end
 

--- a/spec/requests/user_deactivations_spec.rb
+++ b/spec/requests/user_deactivations_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "User Activations", type: :request do
   let(:active_user) { create(:user, role: subject_user_role) }
   let(:inactive_user) { create(:user, :inactive, role: subject_user_role) }
 
-  describe "GET /bo/users/activate/:id" do
+  describe "GET /bo/users/deactivate/:id" do
     context "when a super user is signed in" do
       let(:user) { create(:user, role: current_user_role) }
       before(:each) do
@@ -16,55 +16,19 @@ RSpec.describe "User Activations", type: :request do
       end
 
       context "when the current user has permission to activate the user" do
-        context "when the user to be activated is inactive" do
+        let(:current_user_role) { :finance_super }
+        let(:subject_user_role) { :finance }
+
+        context "when the user to be deactivated is active" do
           it "renders the new template" do
-            get "/bo/users/#{inactive_user.id}/activate"
+            get "/bo/users/#{active_user.id}/deactivate"
             expect(response).to render_template(:new)
           end
         end
 
-        context "when the user to be activated is already active" do
+        context "when the user to be deactivated is already inactive" do
           it "redirects to the user list" do
-            get "/bo/users/#{active_user.id}/activate"
-            expect(response).to redirect_to(users_path)
-          end
-        end
-      end
-
-      context "when the current user does not have permission to activate the user" do
-        let(:current_user_role) { :finance_super }
-
-        it "redirects to a permission error" do
-          get "/bo/users/#{inactive_user.id}/activate"
-          expect(response).to redirect_to("/bo/pages/permission")
-        end
-      end
-    end
-  end
-
-  describe "POST /bo/users/activate" do
-    context "when a super user is signed in" do
-      let(:user) { create(:user, role: current_user_role) }
-      before(:each) do
-        sign_in(user)
-      end
-
-      context "when the current user has permission to activate the user" do
-        context "when the user to be activated is inactive" do
-          it "redirects to the user list" do
-            post "/bo/users/#{inactive_user.id}/activate"
-            expect(response).to redirect_to(users_path)
-          end
-
-          it "activates the user" do
-            post "/bo/users/#{inactive_user.id}/activate"
-            expect(inactive_user.reload.active?).to eq(true)
-          end
-        end
-
-        context "when the user to be activated is already active" do
-          it "redirects to the user list" do
-            post "/bo/users/#{active_user.id}/activate"
+            get "/bo/users/#{inactive_user.id}/deactivate"
             expect(response).to redirect_to(users_path)
           end
         end
@@ -74,7 +38,49 @@ RSpec.describe "User Activations", type: :request do
         let(:subject_user_role) { :finance }
 
         it "redirects to a permission error" do
-          post "/bo/users/#{inactive_user.id}/activate"
+          get "/bo/users/#{active_user.id}/deactivate"
+          expect(response).to redirect_to("/bo/pages/permission")
+        end
+      end
+    end
+  end
+
+  describe "POST /bo/users/deactivate" do
+    context "when a super user is signed in" do
+      let(:user) { create(:user, role: current_user_role) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      context "when the current user has permission to activate the user" do
+        let(:current_user_role) { :finance_super }
+        let(:subject_user_role) { :finance }
+
+        context "when the user to be deactivated is active" do
+          it "redirects to the user list" do
+            post "/bo/users/#{active_user.id}/deactivate"
+            expect(response).to redirect_to(users_path)
+          end
+
+          it "deactivates the user" do
+            post "/bo/users/#{active_user.id}/deactivate"
+            expect(active_user.reload.active?).to eq(false)
+          end
+        end
+
+        context "when the user to be deactivated is already inactive" do
+          it "redirects to the user list" do
+            post "/bo/users/#{inactive_user.id}/deactivate"
+            expect(response).to redirect_to(users_path)
+          end
+        end
+      end
+
+      context "when the current user does not have permission to activate the user" do
+        let(:current_user_role) { :finance_super }
+
+        it "redirects to a permission error" do
+          post "/bo/users/#{active_user.id}/deactivate"
           expect(response).to redirect_to("/bo/pages/permission")
         end
       end

--- a/spec/requests/user_deactivations_spec.rb
+++ b/spec/requests/user_deactivations_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "User Activations", type: :request do
   let(:active_user) { create(:user, role: subject_user_role) }
   let(:inactive_user) { create(:user, :inactive, role: subject_user_role) }
 
-  describe "GET /bo/users/deactivate/:id" do
+  describe "GET /bo/users/:id/deactivate" do
     context "when a super user is signed in" do
       let(:user) { create(:user, role: current_user_role) }
       before(:each) do
@@ -45,7 +45,7 @@ RSpec.describe "User Activations", type: :request do
     end
   end
 
-  describe "POST /bo/users/deactivate" do
+  describe "POST /bo/users/:id/deactivate" do
     context "when a super user is signed in" do
       let(:user) { create(:user, role: current_user_role) }
       before(:each) do

--- a/spec/support/shared_examples/abilities/active_and_inactive_examples.rb
+++ b/spec/support/shared_examples/abilities/active_and_inactive_examples.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "active and inactive examples" do
+  context "when the user is active" do
+    let(:active) { true }
+
+    it "should be able to use the back office" do
+      should be_able_to(:use_back_office, :all)
+    end
+  end
+
+  context "when the user is inactive" do
+    let(:active) { false }
+
+    it "should not be able to use the back office" do
+      should_not be_able_to(:use_back_office, :all)
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-762

Super users should have the ability to activate and deactivate accounts of their group (eg agency supers can deactivate agency accounts, but not finance accounts).

If a user logs into a deactivated account, they should see a message telling them the account is disabled. They should not be able to access any information or make any changes. Active accounts can access and use the system as normal.

This means we can deal with revoking access to the system without entirely deleting all record of the user (which will be important for version control, etc later on).