### PR TITLE
Fix flash messages colours

### DIFF
--- a/app/assets/stylesheets/partials/_flash-messages.scss
+++ b/app/assets/stylesheets/partials/_flash-messages.scss
@@ -1,13 +1,13 @@
 .error-summary.flash-message {
-  border-color: #00703c;
-  background-color: #00703c;
+  border-color: #1d70b8;
+  background-color: #1d70b8;
   color: #ffffff;
   font-size: 24px;
 }
 
 .error-summary.flash-success {
-  border-color: #1d70b8;
-  background-color: #1d70b8;
+  border-color: #00703c;
+  background-color: #00703c;
   color: #ffffff;
   font-size: 24px;
 }


### PR DESCRIPTION
Currently, we had the `flash-message` being blue and `flash-success` being green.
We actually want them to be the other way round so that the success message is green.