### PR TITLE
Add base boxi report generator service

### DIFF
--- a/app/models/reports/boxi/addresses_serializer.rb
+++ b/app/models/reports/boxi/addresses_serializer.rb
@@ -2,7 +2,7 @@
 
 module Reports
   module Boxi
-    class AddressesSerializer < BaseSerializer
+    class AddressesSerializer < ::Reports::Boxi::BaseSerializer
       ATTRIBUTES = {
         uid: "RegistrationUID",
         address_type: "AddressType",

--- a/app/models/reports/boxi/addresses_serializer.rb
+++ b/app/models/reports/boxi/addresses_serializer.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Reports
+  module Boxi
+    class AddressesSerializer < BaseSerializer
+      ATTRIBUTES = {
+        uid: "RegistrationUID",
+        address_type: "AddressType",
+        uprn: "UPRN",
+        house_number: "Premises",
+        address_line_1: "AddressLine1",
+        address_line_2: "AddressLine2",
+        address_line_3: "AddressLine3",
+        address_line_4: "AddressLine4",
+        town_city: "TownCity",
+        postcode: "Postcode",
+        country: "Country",
+        easting: "Easting",
+        northing: "Northing",
+        first_name: "CorrespondentFirstName",
+        last_name: "CorrespondentLastName"
+      }.freeze
+
+      def add_entries_for(registration, uid)
+        registration.addresses.each do |address|
+          csv << parse_address(address, uid)
+        end
+      end
+
+      def parse_address(address, uid)
+        ATTRIBUTES.map do |key, _value|
+          if key == :uid
+            uid
+          else
+            address.public_send(key)
+          end
+        end
+      end
+
+      def file_name
+        "addresses.csv"
+      end
+    end
+  end
+end

--- a/app/models/reports/boxi/base_serializer.rb
+++ b/app/models/reports/boxi/base_serializer.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "csv"
+
+module Reports
+  module Boxi
+    class BaseSerializer
+      delegate :close, to: :csv
+
+      def initialize(destination_dir)
+        @destination_dir = destination_dir
+      end
+
+      private
+
+      attr_reader :destination_dir
+
+      def csv
+        @_csv ||= open_csv
+      end
+
+      def open_csv
+        file_path = File.join(destination_dir, file_name)
+        csv = CSV.open(file_path, "w+", force_quotes: true)
+
+        # Add headers
+        csv << self.class::ATTRIBUTES.values
+
+        csv
+      end
+    end
+  end
+end

--- a/app/services/reports/boxi_export_service.rb
+++ b/app/services/reports/boxi_export_service.rb
@@ -9,15 +9,7 @@ module Reports
 
     def run
       Dir.mktmpdir do |dir_path|
-        # TODO: Implement serializers
-        # Boxi::AddressesSerializer.export_to_file(dir_path)
-        # Boxi::KeyPeopleSerializer.export_to_file(dir_path)
-        # Boxi::OrderItems.export_to_file(dir_path)
-        # Boxi::OrdersSerializer.export_to_file(dir_path)
-        # Boxi::OrderItemsSerializer.export_to_file(dir_path)
-        # Boxi::PaymentsSerializer.export_to_file(dir_path)
-        # Boxi::RegistrationsSerializer.export_to_file(dir_path)
-        # Boxi::SignOffsSerializer.export_to_file(dir_path)
+        GenerateBoxiFilesService.run(dir_path)
 
         zip_export_files(dir_path)
 

--- a/app/services/reports/generate_boxi_files_service.rb
+++ b/app/services/reports/generate_boxi_files_service.rb
@@ -4,14 +4,14 @@ module Reports
   class GenerateBoxiFilesService < ::WasteCarriersEngine::BaseService
     ALL_SERIALIZERS = [
       # TODO
-      Boxi::AddressesSerializer#,
+      Boxi::AddressesSerializer
       # Boxi::KeyPeopleSerializer,
       # Boxi::OrderItemsSerializer,
       # Boxi::OrdersSerializer,
       # Boxi::PaymentsSerializer,
       # Boxi::RegistrationsSerializer,
       # Boxi::SignOffsSerializer
-    ]
+    ].freeze
 
     attr_reader :dir_path
 

--- a/app/services/reports/generate_boxi_files_service.rb
+++ b/app/services/reports/generate_boxi_files_service.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Reports
+  class GenerateBoxiFilesService < ::WasteCarriersEngine::BaseService
+    ALL_SERIALIZERS = [
+      # TODO
+      Boxi::AddressesSerializer#,
+      # Boxi::KeyPeopleSerializer,
+      # Boxi::OrderItemsSerializer,
+      # Boxi::OrdersSerializer,
+      # Boxi::PaymentsSerializer,
+      # Boxi::RegistrationsSerializer,
+      # Boxi::SignOffsSerializer
+    ]
+
+    attr_reader :dir_path
+
+    def run(dir_path)
+      @dir_path = dir_path
+
+      registrations.each.with_index do |registration, uid|
+        serializers.each do |serializer|
+          serializer.add_entries_for(registration, uid)
+        end
+      end
+
+      serializers.each(&:close)
+    end
+
+    private
+
+    def registrations
+      @_registrations ||= WasteCarriersEngine::Registration.all
+    end
+
+    def serializers
+      @_serializers ||= ALL_SERIALIZERS.map do |serializer_class|
+        serializer_class.new(dir_path)
+      end
+    end
+  end
+end

--- a/spec/models/reports/boxi/addresses_serializer_spec.rb
+++ b/spec/models/reports/boxi/addresses_serializer_spec.rb
@@ -8,22 +8,22 @@ module Reports
       let(:dir) { "/tmp/test" }
       let(:csv) { double(:csv) }
       let(:headers) do
-        [
-          "RegistrationUID",
-          "AddressType",
-          "UPRN",
-          "Premises",
-          "AddressLine1",
-          "AddressLine2",
-          "AddressLine3",
-          "AddressLine4",
-          "TownCity",
-          "Postcode",
-          "Country",
-          "Easting",
-          "Northing",
-          "CorrespondentFirstName",
-          "CorrespondentLastName"
+        %w[
+          RegistrationUID
+          AddressType
+          UPRN
+          Premises
+          AddressLine1
+          AddressLine2
+          AddressLine3
+          AddressLine4
+          TownCity
+          Postcode
+          Country
+          Easting
+          Northing
+          CorrespondentFirstName
+          CorrespondentLastName
         ]
       end
       subject { described_class.new(dir) }

--- a/spec/models/reports/boxi/addresses_serializer_spec.rb
+++ b/spec/models/reports/boxi/addresses_serializer_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Reports
+  module Boxi
+    RSpec.describe AddressesSerializer do
+      let(:dir) { "/tmp/test" }
+      let(:csv) { double(:csv) }
+      let(:headers) do
+        [
+          "RegistrationUID",
+          "AddressType",
+          "UPRN",
+          "Premises",
+          "AddressLine1",
+          "AddressLine2",
+          "AddressLine3",
+          "AddressLine4",
+          "TownCity",
+          "Postcode",
+          "Country",
+          "Easting",
+          "Northing",
+          "CorrespondentFirstName",
+          "CorrespondentLastName"
+        ]
+      end
+      subject { described_class.new(dir) }
+
+      before do
+        expect(CSV).to receive(:open).and_return(csv)
+        expect(csv).to receive(:<<).with(headers)
+      end
+
+      describe "#add_entries_for" do
+        let(:registration) { double(:registration) }
+
+        it "creates an entry in the csv for each address in the registration" do
+          address = double(:address)
+
+          values = [
+            0,
+            "address_type",
+            "uprn",
+            "house_number",
+            "address_line_1",
+            "address_line_2",
+            "address_line_3",
+            "address_line_4",
+            "town_city",
+            "postcode",
+            "country",
+            "easting",
+            "northing",
+            "first_name",
+            "last_name"
+          ]
+
+          expect(registration).to receive(:addresses).and_return([address])
+          expect(address).to receive(:address_type).and_return("address_type")
+          expect(address).to receive(:uprn).and_return("uprn")
+          expect(address).to receive(:house_number).and_return("house_number")
+          expect(address).to receive(:address_line_1).and_return("address_line_1")
+          expect(address).to receive(:address_line_2).and_return("address_line_2")
+          expect(address).to receive(:address_line_3).and_return("address_line_3")
+          expect(address).to receive(:address_line_4).and_return("address_line_4")
+          expect(address).to receive(:town_city).and_return("town_city")
+          expect(address).to receive(:postcode).and_return("postcode")
+          expect(address).to receive(:country).and_return("country")
+          expect(address).to receive(:easting).and_return("easting")
+          expect(address).to receive(:northing).and_return("northing")
+          expect(address).to receive(:first_name).and_return("first_name")
+          expect(address).to receive(:last_name).and_return("last_name")
+
+          expect(csv).to receive(:<<).with(values)
+
+          subject.add_entries_for(registration, 0)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/reports/boxi_export_service_spec.rb
+++ b/spec/services/reports/boxi_export_service_spec.rb
@@ -15,6 +15,7 @@ module Reports
         # populate test dir
         File.open(file_path, "w")
 
+        expect(GenerateBoxiFilesService).to receive(:run).with(temp_dir)
         expect(Dir).to receive(:mktmpdir).and_yield(temp_dir)
         expect(Zip::File).to receive(:open).and_yield(zipfile)
         expect(zipfile).to receive(:add).with("test_file.csv", file_path)

--- a/spec/services/reports/generate_boxi_files_service_spec.rb
+++ b/spec/services/reports/generate_boxi_files_service_spec.rb
@@ -9,7 +9,7 @@ module Reports
   RSpec.describe GenerateBoxiFilesService do
     describe ".run" do
       it "generates CSV files for the boxi exports in a given folder" do
-        registration = create(:registration)
+        create(:registration)
 
         temp_dir = Dir.mktmpdir
 
@@ -18,7 +18,7 @@ module Reports
         # Test addresses file gets created
         addresses_file_path = File.join(temp_dir, "addresses.csv")
 
-        expect(File.exists?(addresses_file_path)).to be_truthy
+        expect(File.exist?(addresses_file_path)).to be_truthy
         expect(File.read(addresses_file_path)).to_not be_empty
 
         # TODO

--- a/spec/services/reports/generate_boxi_files_service_spec.rb
+++ b/spec/services/reports/generate_boxi_files_service_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# This is an integration test.
+# Since is not easy to integration testing AWS exported files, this is the highest entry point
+# in the functionality which allow us to integration test the BOXI export feature
+module Reports
+  RSpec.describe GenerateBoxiFilesService do
+    describe ".run" do
+      it "generates CSV files for the boxi exports in a given folder" do
+        registration = create(:registration)
+
+        temp_dir = Dir.mktmpdir
+
+        described_class.run(temp_dir)
+
+        # Test addresses file gets created
+        addresses_file_path = File.join(temp_dir, "addresses.csv")
+
+        expect(File.exists?(addresses_file_path)).to be_truthy
+        expect(File.read(addresses_file_path)).to_not be_empty
+
+        # TODO
+        # Test key_people file gets created
+        # Test order_items file gets created
+        # Test order file gets created
+        # Test payments file gets created
+        # Test registrations file gets created
+        # Test sign_offs file gets created
+      end
+    end
+  end
+end


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-738

Since with MongoDb all our entities are embedded documents, in order to optimise our algorithm we have to change approach from what we have done with WEX. We only want to fetch all registrations once, and for each of them we will add an entry to all the correct files. This is achieved through an additional service which will run the query and deleage to each parser the job of adding the correct entries to the respective files.
An integration test for the BOXI export functionality has been added as a result of this.
The different file serializers will come in separate PRs.