### PR TITLE
Add expire registrations job

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,7 @@ AWS_BOXI_EXPORT_BUCKET=
 # Exports configuration
 EXPORT_SERVICE_EPR_EXPORT_TIME=
 EXPORT_SERVICE_BOXI_EXPORT_TIME=
+EXPIRE_REGISTRATION_EXEMPTION_RUN_TIME=
 
 # Companies House API key
 # The app will make a call to companies house to validate any registration

--- a/app/services/expired_registrations_service.rb
+++ b/app/services/expired_registrations_service.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class ExpiredRegistrationsService < ::WasteCarriersEngine::BaseService
+  def run
+    all_expired_registrations.each(&:expire!)
+  end
+
+  private
+
+  def all_expired_registrations
+    WasteCarriersEngine::Registration.active.upper_tier.expired_at_end_of_today
+  end
+end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -30,3 +30,9 @@ end
 every :day, at: (ENV["EXPORT_SERVICE_BOXI_EXPORT_TIME"] || "22:00"), roles: [:db] do
   rake "reports:export:boxi"
 end
+
+# This is the registration exemptions expiry job which will collect all active upper tier
+# registrations that have an expiry date in the past and will set their state to `EXPIRED`s
+every :day, at: (ENV["EXPIRE_REGISTRATION_EXEMPTION_RUN_TIME"] || "20:00"), roles: [:db] do
+  rake "expire_registration:run"
+end

--- a/lib/tasks/expire_registration.rake
+++ b/lib/tasks/expire_registration.rake
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_relative "../close_airbrake"
+
+namespace :expire_registration do
+  desc "Set the status of expired registations to expired"
+  task run: :environment do
+    ExpiredRegistrationsService.run
+
+    CloseAirbrake.now
+  end
+end

--- a/spec/schedule_spec.rb
+++ b/spec/schedule_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Whenever schedule" do
 
   it "makes sure 'rake' statements exist" do
     rake_jobs = schedule.jobs[:rake]
-    expect(rake_jobs.count).to eq(2)
+    expect(rake_jobs.count).to eq(3)
   end
 
   it "picks up the EPR export run frequency and time" do
@@ -30,5 +30,12 @@ RSpec.describe "Whenever schedule" do
 
     expect(job_details[:every][0]).to eq(:day)
     expect(job_details[:every][1][:at]).to eq("22:00")
+  end
+
+  it "picks up the expire registrations run frequency and time" do
+    job_details = schedule.jobs[:rake].find { |h| h[:task] == "expire_registration:run" }
+
+    expect(job_details[:every][0]).to eq(:day)
+    expect(job_details[:every][1][:at]).to eq("20:00")
   end
 end

--- a/spec/services/expired_registrations_service_spec.rb
+++ b/spec/services/expired_registrations_service_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ExpiredRegistrationsService do
+  describe ".run" do
+    it "expires active upper tier registrations expiring by the end of the current day" do
+      expired_registration = create(:registration, :active, expires_on: Time.now.beginning_of_day + 4.hours)
+      active_registration = create(:registration, :active, expires_on: Time.now.end_of_day + 4.hours)
+      lower_tier_registration = create(:registration, :active, tier: "LOWER", expires_on: Time.now.beginning_of_day + 4.hours)
+
+      expect(expired_registration).to_not be_expired
+      expect(active_registration).to_not be_expired
+      expect(lower_tier_registration).to_not be_expired
+
+      described_class.run
+
+      expired_registration.reload
+      active_registration.reload
+      lower_tier_registration.reload
+
+      expect(expired_registration).to be_expired
+      expect(active_registration).to_not be_expired
+      expect(lower_tier_registration).to_not be_expired
+    end
+  end
+end


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-739

This adds a rake task to expire registrations. It also adds scheduler settings for it to run by default every day at 8pm.