### PR TITLE
Fix issue when missing finance details

### DIFF
--- a/app/presenters/reports/boxi/key_person_presenter.rb
+++ b/app/presenters/reports/boxi/key_person_presenter.rb
@@ -4,15 +4,11 @@ module Reports
   module Boxi
     class KeyPersonPresenter < WasteCarriersEngine::BasePresenter
       def flagged_for_review
-        return unless conviction_search_result
-
-        conviction_search_result.match_result
+        conviction_search_result&.match_result
       end
 
       def review_flag_timestamp
-        return unless conviction_search_result
-
-        conviction_search_result.searched_at
+        conviction_search_result&.searched_at
       end
     end
   end

--- a/app/presenters/reports/boxi/registration_presenter.rb
+++ b/app/presenters/reports/boxi/registration_presenter.rb
@@ -5,7 +5,7 @@ module Reports
     class RegistrationPresenter < WasteCarriersEngine::BasePresenter
       delegate :status, :route, :revoked_reason, to: :metadata, prefix: true
 
-      delegate :balance, to: :finance_details, prefix: true
+      delegate :balance, to: :finance_details, prefix: true, allow_nil: true
       delegate :match_result, to: :conviction_search_result, prefix: true, allow_nil: true
 
       def finance_details_balance


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-738

While working on a bug which appears on on old lower tier registrations missing finance_details, I have re-checked the boxi code to make sure I account for missing finance_details everywere and done some fixes.