### PR TITLE
Fix bug on finance details heading lower tier old reg

### DIFF
--- a/app/presenters/base_registration_presenter.rb
+++ b/app/presenters/base_registration_presenter.rb
@@ -21,6 +21,10 @@ class BaseRegistrationPresenter < WasteCarriersEngine::BasePresenter
     end
   end
 
+  def show_no_finance_details_data?
+    upper_tier? && finance_details.blank?
+  end
+
   def finance_details_balance
     finance_details.balance
   end

--- a/app/views/shared/registrations/_finance_details.html.erb
+++ b/app/views/shared/registrations/_finance_details.html.erb
@@ -1,7 +1,7 @@
 <h2 class="heading-medium">
   <% if resource.unpaid_balance? %>
     <%= t(".finance_information.heading_with_amount_owed", amount: display_pence_as_pounds(resource.finance_details.balance)) %>
-  <% elsif resource.finance_details.blank? %>
+  <% elsif resource.show_no_finance_details_data? %>
     <%= t(".finance_information.balance.no_data") %>
   <% else %>
     <%= t(".finance_information.heading") %>

--- a/spec/presenters/base_registration_presenter_spec.rb
+++ b/spec/presenters/base_registration_presenter_spec.rb
@@ -13,6 +13,44 @@ RSpec.describe BaseRegistrationPresenter do
     end
   end
 
+  describe "#show_no_finance_details_data?" do
+    before do
+      expect(registration).to receive(:upper_tier?).and_return(upper_tier)
+    end
+
+    context "when the registration is an upper tier" do
+      let(:upper_tier) { true }
+
+      before do
+        expect(registration).to receive(:finance_details).and_return(finance_details)
+      end
+
+      context "when finance details object is missing" do
+        let(:finance_details) { nil }
+
+        it "returns true" do
+          expect(subject.show_no_finance_details_data?).to be_truthy
+        end
+      end
+
+      context "when finance details object is present" do
+        let(:finance_details) { "Something" }
+
+        it "returns false" do
+          expect(subject.show_no_finance_details_data?).to be_falsey
+        end
+      end
+    end
+
+    context "when the registration is a lower tier registration" do
+      let(:upper_tier) { false }
+
+      it "returns false" do
+        expect(subject.show_no_finance_details_data?).to be_falsey
+      end
+    end
+  end
+
   describe "#finance_details_balance" do
     it "returns the finance details balance" do
       finance_details = double(:finance_details)


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-799

The bug was due to the fact that old lower tier registrations have no `finance_details` object attached to them. This add new rules for the no finance details header to show and move the logic to the presenter.