### PR TITLE
Add flash messages and style for ceased or revoked

### DIFF
--- a/app/assets/stylesheets/partials/_buttons.scss
+++ b/app/assets/stylesheets/partials/_buttons.scss
@@ -5,3 +5,10 @@
 .button-warning {
   @include button($red);
 }
+
+.form-button-link {
+  margin-left: 10px;
+  margin-top: 0.4em;
+  display: inline;
+  position: absolute;
+}

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -18,6 +18,12 @@
 </div>
 
 <div class="grid-row">
+  <div class="column-full">
+    <%= render("shared/message", message: flash[:message]) if flash[:message].present? %>
+  </div>
+</div>
+
+<div class="grid-row">
   <div class="column-two-thirds">
     <div class="form-group">
       <%= form_tag("/bo", method: :get) do %>


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-807

This adds flash messages to appear on dashboard and style for form with link buttons that must align with other forms button

<img width="815" alt="Screenshot 2019-12-30 at 14 54 34" src="https://user-images.githubusercontent.com/1385397/71587215-b6891980-2b14-11ea-88b3-9659c9fba8de.png">
<img width="786" alt="Screenshot 2019-12-30 at 14 54 57" src="https://user-images.githubusercontent.com/1385397/71587216-b721b000-2b14-11ea-82cc-58c31ec9f119.png">
