### PR TITLE
Add view details for registrations payments

### DIFF
--- a/app/controllers/finance_details_controller.rb
+++ b/app/controllers/finance_details_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class FinanceDetailsController < ApplicationController
+  before_action :authenticate_user!
+
+  def show
+    find_registration(params[:registration_reg_identifier])
+
+    @finance_details = @registration.finance_details
+  end
+
+  private
+
+  def find_registration(reg_identifier)
+    @registration = WasteCarriersEngine::Registration.where(reg_identifier: reg_identifier).first
+  end
+end

--- a/app/helpers/finance_details_helper.rb
+++ b/app/helpers/finance_details_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module FinanceDetailsHelper
+  def display_pence_as_pounds_and_cents(pence)
+    pounds = pence.to_f / 100
+
+    format("%<pounds>.2f", pounds: pounds)
+  end
+end

--- a/app/views/finance_details/show.html.erb
+++ b/app/views/finance_details/show.html.erb
@@ -18,20 +18,10 @@
     <% if @registration.pending_payment? %>
       <%= render "shared/registrations/pending_payment_panel", resource: @registration %>
     <% end %>
-
   </div>
 </div>
 
-<div class="grid-row">
-  <div class="column-full">
-    <%= link_to t(".links.enter_payment"), "#TODO", class: "button" %>
-    <%= link_to t(".links.reverse_payment"), "#TODO", class: "button" %>
-    <%= link_to t(".links.write_off_l"), "#TODO", class: "button" %>
-    <%= link_to t(".links.write_off_s"), "#TODO", class: "button" %>
-    <%= link_to t(".links.adjust_charge"), "#TODO", class: "button" %>
-    <%= link_to t(".links.refund"), "#TODO", class: "button" %>
-  </div>
-</div>
+<%= render "shared/registrations/finance_action_links", registration: @registration %>
 
 <%= render "shared/registrations/charges_and_amendments", finance_details: @finance_details %>
 <%= render "shared/registrations/payment_history", finance_details: @finance_details %>

--- a/app/views/finance_details/show.html.erb
+++ b/app/views/finance_details/show.html.erb
@@ -1,0 +1,38 @@
+<div class="grid-row">
+  <div class="column-full">
+    <%= render("waste_carriers_engine/shared/back", back_path: registration_path(@registration.reg_identifier)) %>
+
+    <h1 class="heading-large">
+      <%= t(".heading", reg_identifier: @registration.reg_identifier) %>
+    </h1>
+
+    <%= render("shared/message", message: flash[:message]) if flash[:message].present? %>
+    <%= render("shared/error", error: flash[:error], details: flash[:error_details]) if flash[:error].present? %>
+  </div>
+</div>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render "shared/company_details_panel", registration: @registration %>
+
+    <% if @registration.pending_payment? %>
+      <%= render "shared/registrations/pending_payment_panel", resource: @registration %>
+    <% end %>
+
+  </div>
+</div>
+
+<div class="grid-row">
+  <div class="column-full">
+    <%= link_to t(".links.enter_payment"), "#TODO", class: "button" %>
+    <%= link_to t(".links.reverse_payment"), "#TODO", class: "button" %>
+    <%= link_to t(".links.write_off_l"), "#TODO", class: "button" %>
+    <%= link_to t(".links.write_off_s"), "#TODO", class: "button" %>
+    <%= link_to t(".links.adjust_charge"), "#TODO", class: "button" %>
+    <%= link_to t(".links.refund"), "#TODO", class: "button" %>
+  </div>
+</div>
+
+<%= render "shared/registrations/charges_and_amendments", finance_details: @finance_details %>
+<%= render "shared/registrations/payment_history", finance_details: @finance_details %>
+<%= render "shared/registrations/balance", finance_details: @finance_details %>

--- a/app/views/shared/registrations/_balance.html.erb
+++ b/app/views/shared/registrations/_balance.html.erb
@@ -1,0 +1,38 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <h2 class="heading-medium">
+      <%= t(".heading") %>
+    </h2>
+
+    <table>
+      <tbody>
+        <thead>
+          <tr>
+            <th>
+              <%= t(".status") %>
+            </th>
+            <th class="numeric">
+              <%= t(".amount") %>
+            </th>
+          </tr>
+        </thead>
+
+        <tr>
+          <td>
+            <% case %>
+            <% when finance_details.balance > 0 %>
+              <%= t(".overpaid") %>
+            <% when finance_details.balance < 0 %>
+              <%= t(".needs_payment") %>
+            <% when finance_details.balance == 0 %>
+              <%= t(".paid_in_full") %>
+            <% end %>
+          </td>
+          <td class="numeric">
+            <%= display_pence_as_pounds_and_cents(finance_details.balance) %>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/shared/registrations/_charges_and_amendments.html.erb
+++ b/app/views/shared/registrations/_charges_and_amendments.html.erb
@@ -1,0 +1,41 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <h2 class="heading-medium">
+      <%= t(".heading") %>
+    </h2>
+
+    <table>
+      <tbody>
+        <thead>
+          <tr>
+            <th>
+              <%= t(".date") %>
+            </th>
+            <th>
+              <%= t(".charge") %>
+            </th>
+            <th class="numeric">
+              <%= t(".amount") %>
+            </th>
+          </tr>
+        </thead>
+
+        <% @finance_details.orders.each do |order| %>
+          <% order.order_items.each do |order_item| %>
+            <tr>
+              <td>
+                <%= order.date_created.to_formatted_s(:day_month_year_time_slashes) %>
+              </td>
+              <td>
+                <%= order_item.description %>
+              </td>
+              <td class="numeric">
+                <%= display_pence_as_pounds_and_cents(order_item.amount) %>
+              </td>
+            </tr>
+          <% end %>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/shared/registrations/_finance_action_links.html.erb
+++ b/app/views/shared/registrations/_finance_action_links.html.erb
@@ -1,0 +1,10 @@
+<div class="grid-row">
+  <div class="column-full">
+    <%= link_to t(".links.enter_payment"), "#TODO", class: "button" %>
+    <%= link_to t(".links.reverse_payment"), "#TODO", class: "button" %>
+    <%= link_to t(".links.write_off_l"), "#TODO", class: "button" %>
+    <%= link_to t(".links.write_off_s"), "#TODO", class: "button" %>
+    <%= link_to t(".links.adjust_charge"), "#TODO", class: "button" %>
+    <%= link_to t(".links.refund"), "#TODO", class: "button" %>
+  </div>
+</div>

--- a/app/views/shared/registrations/_finance_action_links.html.erb
+++ b/app/views/shared/registrations/_finance_action_links.html.erb
@@ -1,10 +1,10 @@
 <div class="grid-row">
   <div class="column-full">
-    <%= link_to t(".links.enter_payment"), "#TODO", class: "button" %>
-    <%= link_to t(".links.reverse_payment"), "#TODO", class: "button" %>
-    <%= link_to t(".links.write_off_l"), "#TODO", class: "button" %>
-    <%= link_to t(".links.write_off_s"), "#TODO", class: "button" %>
-    <%= link_to t(".links.adjust_charge"), "#TODO", class: "button" %>
-    <%= link_to t(".links.refund"), "#TODO", class: "button" %>
+    <%= link_to t(".enter_payment"), "#TODO", class: "button" %>
+    <%= link_to t(".reverse_payment"), "#TODO", class: "button" %>
+    <%= link_to t(".write_off_l"), "#TODO", class: "button" %>
+    <%= link_to t(".write_off_s"), "#TODO", class: "button" %>
+    <%= link_to t(".adjust_charge"), "#TODO", class: "button" %>
+    <%= link_to t(".refund"), "#TODO", class: "button" %>
   </div>
 </div>

--- a/app/views/shared/registrations/_payment_history.html.erb
+++ b/app/views/shared/registrations/_payment_history.html.erb
@@ -1,0 +1,51 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <h2 class="heading-medium">
+      <%= t(".heading") %>
+    </h2>
+
+    <table>
+      <tbody>
+        <thead>
+          <tr>
+            <th>
+              <%= t(".date") %>
+            </th>
+            <th>
+              <%= t(".method") %>
+            </th>
+            <th>
+              <%= t(".reference") %>
+            </th>
+            <th>
+              <%= t(".comment") %>
+            </th>
+            <th class="numeric">
+              <%= t(".amount") %>
+            </th>
+          </tr>
+        </thead>
+
+        <% @finance_details.payments.each do |payment| %>
+          <tr>
+            <td>
+              <%= payment.date_received.to_formatted_s(:day_month_year_time_slashes) %>
+            </td>
+            <td>
+              <%= t(".payment_type.#{payment.payment_type}") %>
+            </td>
+            <td>
+              <%= payment.order_key %>/<%= payment.registration_reference %>
+            </td>
+            <td>
+              <%= payment.comment %>
+            </td>
+            <td class="numeric">
+              <%= display_pence_as_pounds_and_cents(payment.amount) %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -2,6 +2,8 @@
 
 # For example: 04/12/2019
 Time::DATE_FORMATS[:day_month_year_slashes] = "%d/%m/%Y"
+# For example: 04/12/2019 15:01
+Time::DATE_FORMATS[:day_month_year_time_slashes] = "%d/%m/%Y %H:%M"
 # For example: Monday 2 December 2019 at 6:53pm
 Time::DATE_FORMATS[:weekday_day_month_year_at_time] = "%A %e %B %Y at %l:%M%P"
 # For example: 2 December 2019

--- a/config/locales/finance_details.en.yml
+++ b/config/locales/finance_details.en.yml
@@ -1,0 +1,11 @@
+en:
+  finance_details:
+    show:
+      heading: "Payment details for %{reg_identifier}"
+      links:
+        enter_payment: "Enter payment"
+        reverse_payment: "Reverse payment"
+        write_off_l: "Write off (Form L)"
+        write_off_s: "Write off (small)"
+        adjust_charge: "Adjust charge"
+        refund: "Refund"

--- a/config/locales/finance_details.en.yml
+++ b/config/locales/finance_details.en.yml
@@ -2,10 +2,3 @@ en:
   finance_details:
     show:
       heading: "Payment details for %{reg_identifier}"
-      links:
-        enter_payment: "Enter payment"
-        reverse_payment: "Reverse payment"
-        write_off_l: "Write off (Form L)"
-        write_off_s: "Write off (small)"
-        adjust_charge: "Adjust charge"
-        refund: "Refund"

--- a/config/locales/shared/balance.en.yml
+++ b/config/locales/shared/balance.en.yml
@@ -1,0 +1,10 @@
+en:
+  shared:
+    registrations:
+      balance:
+        heading: "Balance"
+        status: "Status"
+        amount: "Amount in £"
+        overpaid: "There have been an overpayment" # TODO: Check with UCD people
+        needs_payment: "Payment required"
+        paid_in_full: "Paid in full"

--- a/config/locales/shared/balance.en.yml
+++ b/config/locales/shared/balance.en.yml
@@ -5,6 +5,6 @@ en:
         heading: "Balance"
         status: "Status"
         amount: "Amount in £"
-        overpaid: "There have been an overpayment" # TODO: Check with UCD people
+        overpaid: "There has been an overpayment" # TODO: Check with UCD people
         needs_payment: "Payment required"
         paid_in_full: "Paid in full"

--- a/config/locales/shared/charges_and_amendments.en.yml
+++ b/config/locales/shared/charges_and_amendments.en.yml
@@ -1,0 +1,8 @@
+en:
+  shared:
+    registrations:
+      charges_and_amendments:
+        heading: "Charges and amendments"
+        date: "Date"
+        charge: "Charge"
+        amount: "Amount in £"

--- a/config/locales/shared/finance_action_links.en.yml
+++ b/config/locales/shared/finance_action_links.en.yml
@@ -1,0 +1,10 @@
+en:
+  shared:
+    registrations:
+      finance_action_links:
+        enter_payment: "Enter payment"
+        reverse_payment: "Reverse payment"
+        write_off_l: "Write off (Form L)"
+        write_off_s: "Write off (small)"
+        adjust_charge: "Adjust charge"
+        refund: "Refund"

--- a/config/locales/shared/payment_history.en.yml
+++ b/config/locales/shared/payment_history.en.yml
@@ -1,0 +1,17 @@
+en:
+  shared:
+    registrations:
+      payment_history:
+        heading: "Payment history"
+        date: "Date"
+        method: "Method"
+        reference: "Reference"
+        comment: "Comment"
+        amount: "Amount in £"
+        payment_type:
+          CASH: "Cash"
+          CHEQUE: "Cheque"
+          POSTALORDER: "Postal order"
+          BANKTRANSFER: "Bank transfer"
+          WORLDPAY: "WorldPay"
+          WORLDPAY_MISSED: "WorldPay (manually added)"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,9 @@ Rails.application.routes.draw do
                         path: "convictions/reject",
                         path_names: { new: "" }
 
+              resource :finance_details,
+                       only: :show
+
               resources :registration_transfers,
                         only: %i[new create],
                         param: :reg_identifier,

--- a/spec/factories/order.rb
+++ b/spec/factories/order.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
          WasteCarriersEngine::OrderItem.new_copy_cards_item(1)]
       end
       total_amount { order_items.sum { |item| item[:amount] } }
+      date_created { Time.now }
     end
   end
 end

--- a/spec/factories/payment.rb
+++ b/spec/factories/payment.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :payment, class: WasteCarriersEngine::Payment do
     amount { 100 }
-
+    date_received { Time.now }
     trait :bank_transfer do
       payment_type { "BANKTRANSFER" }
     end

--- a/spec/helpers/finance_details_helper_spec.rb
+++ b/spec/helpers/finance_details_helper_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe FinanceDetailsHelper, type: :helper do
+  describe "#display_pence_as_pounds_and_cents" do
+    it "returns a formatted string from a float number with two decimal places" do
+      expect(helper.display_pence_as_pounds_and_cents(1000)).to eq("10.00")
+      expect(helper.display_pence_as_pounds_and_cents(1045)).to eq("10.45")
+    end
+  end
+end

--- a/spec/requests/finance_details_spec.rb
+++ b/spec/requests/finance_details_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "FinanceDetails", type: :request do
+  describe "GET /bo/registrations/:reg_identifier/finance_details" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
+      let(:registration) { create(:registration, :has_orders_and_payments) }
+
+      before(:each) do
+        sign_in(user)
+      end
+
+      it "renders the show template and returns a 200 status" do
+        get registration_finance_details_path(registration.reg_identifier)
+
+        expect(response).to render_template(:show)
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context "when a user is not signed in" do
+      it "redirects to the sign-in page" do
+        get registration_finance_details_path("doo")
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-808

This adds all the necessary code to show a payment details page for registrations only.

<img width="766" alt="Screenshot 2019-12-31 at 16 21 10" src="https://user-images.githubusercontent.com/1385397/71627390-0ab1fd80-2bea-11ea-8b02-557029e3093a.png">
