### PR TITLE
Add payment details view for transient registrations

### DIFF
--- a/app/controllers/transient_finance_details_controller.rb
+++ b/app/controllers/transient_finance_details_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class TransientFinanceDetailsController < ApplicationController
+  before_action :authenticate_user!
+
+  def show
+    find_registration(params[:transient_registration_token])
+
+    @finance_details = @transient_registration.finance_details
+  end
+
+  private
+
+  def find_registration(token)
+    @transient_registration = WasteCarriersEngine::TransientRegistration.where(token: token).first
+  end
+end

--- a/app/presenters/renewing_registration_presenter.rb
+++ b/app/presenters/renewing_registration_presenter.rb
@@ -22,7 +22,7 @@ class RenewingRegistrationPresenter < BaseRegistrationPresenter
   end
 
   def finance_details_link
-    @view.transient_registration_payments_path(reg_identifier)
+    @view.transient_registration_transient_payments_path(reg_identifier)
   end
 
   private

--- a/app/views/shared/registrations/_balance.html.erb
+++ b/app/views/shared/registrations/_balance.html.erb
@@ -21,9 +21,9 @@
           <td>
             <% case %>
             <% when finance_details.balance > 0 %>
-              <%= t(".overpaid") %>
-            <% when finance_details.balance < 0 %>
               <%= t(".needs_payment") %>
+            <% when finance_details.balance < 0 %>
+              <%= t(".overpaid") %>
             <% when finance_details.balance == 0 %>
               <%= t(".paid_in_full") %>
             <% end %>

--- a/app/views/shared/registrations/_pending_payment_panel.html.erb
+++ b/app/views/shared/registrations/_pending_payment_panel.html.erb
@@ -3,10 +3,10 @@
     <%= t(".status.headings.pending_payment") %>
   </h2>
   <p>
-    <%= t(".status.messages.pending_payment", total: display_pence_as_pounds(resource.finance_details_balance)) %>
+    <%= t(".status.messages.pending_payment", total: display_pence_as_pounds(resource.finance_details.balance)) %>
   </p>
   <!-- TODO: delete condition when internal route exists https://eaflood.atlassian.net/browse/RUBY-786 -->
   <% if display_payment_link_for?(resource) %>
-    <%= link_to t(".status.actions.payment_button"), resource.finance_details_link, class: 'button' %>
+    <%= link_to t(".status.actions.payment_button"), transient_registration_transient_payments_path(resource.reg_identifier), class: 'button' %>
   <% end %>
 </div>

--- a/app/views/transient_finance_details/show.html.erb
+++ b/app/views/transient_finance_details/show.html.erb
@@ -1,0 +1,28 @@
+<div class="grid-row">
+  <div class="column-full">
+    <%= render("waste_carriers_engine/shared/back", back_path: registration_path(@transient_registration.reg_identifier)) %>
+
+    <h1 class="heading-large">
+      <%= t(".heading", reg_identifier: @transient_registration.reg_identifier) %>
+    </h1>
+
+    <%= render("shared/message", message: flash[:message]) if flash[:message].present? %>
+    <%= render("shared/error", error: flash[:error], details: flash[:error_details]) if flash[:error].present? %>
+  </div>
+</div>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render "shared/company_details_panel", registration: @transient_registration %>
+
+    <% if @transient_registration.pending_payment? %>
+      <%= render "shared/registrations/pending_payment_panel", resource: @transient_registration %>
+    <% end %>
+  </div>
+</div>
+
+<%= render "shared/registrations/finance_action_links", registration: @transient_registration %>
+
+<%= render "shared/registrations/charges_and_amendments", finance_details: @finance_details %>
+<%= render "shared/registrations/payment_history", finance_details: @finance_details %>
+<%= render "shared/registrations/balance", finance_details: @finance_details %>

--- a/config/locales/transient_finance_details.en.yml
+++ b/config/locales/transient_finance_details.en.yml
@@ -1,0 +1,4 @@
+en:
+  transient_finance_details:
+    show:
+      heading: "Payment details for %{reg_identifier}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,18 +57,22 @@ Rails.application.routes.draw do
                   as: :registration_transfer_success
             end
 
-  # These routes uses `token` to identify the correct transient object (#TODO: merge with other routes when they move to token)
+  # These routes uses `token` to identify the correct transient object
+  # TODO: merge with other routes when they move to token
   resources :transient_registrations,
             only: [],
             param: :token,
             path: "/bo/transient-registrations",
             path_names: { show: "/:token" } do
-              resource :finance_details,
-                         controller: :transient_finance_details,
-                         only: :show
+              resource(
+                :finance_details,
+                controller: :transient_finance_details,
+                only: :show
+              )
             end
 
-  # These routes uses `reg_identifier` to identify the correct transient object (#TODO: Make it token)
+  # These routes uses `reg_identifier` to identify the correct transient object
+  # TODO: Change these routes to use :token rather than :reg_identifier
   resources :transient_registrations,
             only: [],
             param: :reg_identifier,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,6 +57,18 @@ Rails.application.routes.draw do
                   as: :registration_transfer_success
             end
 
+  # These routes uses `token` to identify the correct transient object (#TODO: merge with other routes when they move to token)
+  resources :transient_registrations,
+            only: [],
+            param: :token,
+            path: "/bo/transient-registrations",
+            path_names: { show: "/:token" } do
+              resource :finance_details,
+                         controller: :transient_finance_details,
+                         only: :show
+            end
+
+  # These routes uses `reg_identifier` to identify the correct transient object (#TODO: Make it token)
   resources :transient_registrations,
             only: [],
             param: :reg_identifier,

--- a/spec/presenters/renewing_registration_presenter_spec.rb
+++ b/spec/presenters/renewing_registration_presenter_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe RenewingRegistrationPresenter do
       reg_identifier = double(:reg_identifier)
 
       expect(renewing_registration).to receive(:reg_identifier).and_return(reg_identifier)
-      expect(view_context).to receive(:transient_registration_payments_path).with(reg_identifier).and_return(link)
+      expect(view_context).to receive(:transient_registration_transient_payments_path).with(reg_identifier).and_return(link)
 
       expect(subject.finance_details_link).to eq(link)
     end

--- a/spec/requests/transient_finance_details_spec.rb
+++ b/spec/requests/transient_finance_details_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "FinanceDetails", type: :request do
+  describe "GET /bo/transient-registrations/:token/finance_details" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
+      let(:transient_registration) { create(:renewing_registration, :has_finance_details) }
+
+      before(:each) do
+        sign_in(user)
+      end
+
+      it "renders the show template and returns a 200 status" do
+        get transient_registration_finance_details_path(transient_registration.token)
+
+        expect(response).to render_template(:show)
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context "when a user is not signed in" do
+      it "redirects to the sign-in page" do
+        get transient_registration_finance_details_path("doo")
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-808

This adds the code necessary to show the payment details view for transient registrations

<img width="1037" alt="Screenshot 2020-01-02 at 11 14 12" src="https://user-images.githubusercontent.com/1385397/71664493-06ecbb00-2d51-11ea-8bfd-06f93bac1109.png">
