### PR TITLE
Update finance details path

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,7 @@ Rails.application.routes.draw do
   get "/bo/ad-privacy-policy/:reg_identifier", to: "ad_privacy_policy#show", as: :ad_privacy_policy
 
   resources :finance_details,
+            path: "/bo/finance-details",
             only: :show do
               resources :refunds,
                         only: %i[index new create],

--- a/spec/requests/finance_details_spec.rb
+++ b/spec/requests/finance_details_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "FinanceDetails", type: :request do
-  describe "GET /bo/finance_details/:_id" do
+  describe "GET /bo/finance-details/:_id" do
     context "when a valid user is signed in" do
       let(:user) { create(:user) }
 


### PR DESCRIPTION
QA have noticed inconsistency in the use of "_" and "-" in urls. This changes the `finance_details` path to use "-" and also includes `/bo` scope, which I think is related to a bug only observed when running the application on the server where it shares the domain with other applications.