### PR TITLE
Calculate the correct amount for refund

### DIFF
--- a/app/services/process_refund_service.rb
+++ b/app/services/process_refund_service.rb
@@ -2,9 +2,11 @@
 
 class ProcessRefundService < WasteCarriersEngine::BaseService
   def run(finance_details:, payment:, user:)
+    @finance_details = finance_details
     @payment = payment
     @user = user
 
+    return false if amount_to_refund == 0
     return false if card_payment? && !card_refund_result
 
     finance_details.payments << build_refund
@@ -17,17 +19,26 @@ class ProcessRefundService < WasteCarriersEngine::BaseService
 
   private
 
-  attr_reader :payment, :user
+  attr_reader :payment, :user, :finance_details
 
   def card_refund_result
-    @_card_refund_result ||= ::Worldpay::RefundService.run(payment: payment)
+    @_card_refund_result ||= ::Worldpay::RefundService.run(payment: payment, amount: amount_to_refund)
+  end
+
+  def amount_to_refund
+    # We can never refund unless there have been an overpayment.
+    return 0 unless finance_details.balance.negative?
+
+    overpayment = (-1 * finance_details.balance)
+
+    [overpayment, payment.amount].min
   end
 
   def build_refund
     refund = WasteCarriersEngine::Payment.new(payment_type: WasteCarriersEngine::Payment::REFUND)
 
     refund.order_key = "#{payment.order_key}_REFUNDED"
-    refund.amount = payment.amount * -1
+    refund.amount = amount_to_refund
     refund.date_entered = Date.current
     refund.date_received = Date.current
     refund.registration_reference = payment.registration_reference

--- a/app/services/process_refund_service.rb
+++ b/app/services/process_refund_service.rb
@@ -29,6 +29,7 @@ class ProcessRefundService < WasteCarriersEngine::BaseService
     # We can never refund unless there have been an overpayment.
     return 0 unless finance_details.balance.negative?
 
+    # A quick maths trick to convert a negative value to a postive one
     overpayment = (-1 * finance_details.balance)
 
     [overpayment, payment.amount].min

--- a/app/services/process_refund_service.rb
+++ b/app/services/process_refund_service.rb
@@ -6,7 +6,7 @@ class ProcessRefundService < WasteCarriersEngine::BaseService
     @payment = payment
     @user = user
 
-    return false if amount_to_refund == 0
+    return false if amount_to_refund.zero?
     return false if card_payment? && !card_refund_result
 
     finance_details.payments << build_refund

--- a/app/services/worldpay/refund_service.rb
+++ b/app/services/worldpay/refund_service.rb
@@ -5,10 +5,10 @@ module Worldpay
     include ::WasteCarriersEngine::CanSendWorldpayRequest
     include ::WasteCarriersEngine::CanBuildWorldpayXml
 
-    def run(payment:)
+    def run(payment:, amount:)
       return false unless payment.worldpay? || payment.worldpay_missed?
 
-      xml = build_refund_xml(payment)
+      xml = build_refund_xml(payment, amount)
       response = send_request(xml)
 
       parsed_reponse = Nokogiri::XML(response)
@@ -18,7 +18,7 @@ module Worldpay
 
     private
 
-    def build_refund_xml(payment)
+    def build_refund_xml(payment, amount)
       builder = Nokogiri::XML::Builder.new do |xml|
         build_doctype(xml)
 
@@ -26,7 +26,7 @@ module Worldpay
           xml.modify do
             xml.orderModification(orderCode: payment.order_key) do
               xml.refund do
-                xml.amount(value: payment.amount, currencyCode: "GBP", exponent: 2)
+                xml.amount(value: amount, currencyCode: "GBP", exponent: 2)
               end
             end
           end

--- a/spec/factories/finance_details.rb
+++ b/spec/factories/finance_details.rb
@@ -17,6 +17,17 @@ FactoryBot.define do
       after(:build, :create, &:update_balance)
     end
 
+    trait :has_overpaid_order_and_payment do
+      orders { [build(:order, :has_required_data)] }
+      payments do
+        [
+          build(:payment, :bank_transfer, amount: 100_500),
+          build(:payment, :bank_transfer, amount: 500)
+        ]
+      end
+      after(:build, :create, &:update_balance)
+    end
+
     trait :zero_balance do
       balance { 0 }
     end

--- a/spec/factories/renewing_registration.rb
+++ b/spec/factories/renewing_registration.rb
@@ -12,6 +12,10 @@ FactoryBot.define do
     # Create a new registration when initializing
     initialize_with { new(reg_identifier: create(:registration, :expires_soon).reg_identifier) }
 
+    trait :overpaid do
+      finance_details { build(:finance_details, :has_overpaid_order_and_payment) }
+    end
+
     trait :ready_to_renew do
       declared_convictions { "no" }
       workflow_state { "renewal_received_form" }

--- a/spec/requests/refunds_spec.rb
+++ b/spec/requests/refunds_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Refunds", type: :request do
   describe "GET /bo/finance_details/:_id/refunds" do
     context "when a valid user is signed in" do
       let(:user) { create(:user) }
-      let(:renewing_registration) { create(:renewing_registration) }
+      let(:renewing_registration) { create(:renewing_registration, :overpaid) }
 
       before(:each) do
         sign_in(user)
@@ -32,7 +32,7 @@ RSpec.describe "Refunds", type: :request do
   describe "GET /bo/finance_details/:_id/refunds/new" do
     context "when a valid user is signed in" do
       let(:user) { create(:user) }
-      let(:renewing_registration) { create(:renewing_registration) }
+      let(:renewing_registration) { create(:renewing_registration, :overpaid) }
       let(:payment) { renewing_registration.finance_details.payments.first }
 
       before(:each) do
@@ -59,7 +59,7 @@ RSpec.describe "Refunds", type: :request do
   describe "POST /bo/finance_details/:_id/refunds/:order_key" do
     context "when a valid user is signed in" do
       let(:user) { create(:user) }
-      let(:renewing_registration) { create(:renewing_registration) }
+      let(:renewing_registration) { create(:renewing_registration, :overpaid) }
       let(:payment) { renewing_registration.finance_details.payments.first }
 
       before(:each) do

--- a/spec/services/process_refund_service_spec.rb
+++ b/spec/services/process_refund_service_spec.rb
@@ -4,14 +4,23 @@ require "rails_helper"
 
 RSpec.describe ProcessRefundService do
   describe ".run" do
-    let(:finance_details) { double(:finance_details) }
+    let(:finance_details) { double(:finance_details, balance: -500) }
     let(:payment) { double(:payment, order_key: "123", registration_reference: "registration_reference", amount: 1_500) }
     let(:user) { double(:user, email: "user@example.com") }
     let(:payments) { double(:payments) }
     let(:refund) { double(:refund) }
+    let(:worldpay) { true }
 
     before do
       allow(payment).to receive(:worldpay?).and_return(worldpay)
+    end
+
+    context "when the amount to refund is 0" do
+      let(:finance_details) { double(:finance_details, balance: 500) }
+
+      it "returns false and does not create a payment" do
+        expect(described_class.run(finance_details: finance_details, payment: payment, user: user)).to be_falsey
+      end
     end
 
     context "when the payment is a card payment" do
@@ -19,7 +28,7 @@ RSpec.describe ProcessRefundService do
 
       context "when a request to worldpay fails" do
         it "returns false and does not create a payment" do
-          expect(Worldpay::RefundService).to receive(:run).with(payment: payment).and_return(false)
+          expect(Worldpay::RefundService).to receive(:run).with(payment: payment, amount: 500).and_return(false)
 
           expect(described_class.run(finance_details: finance_details, payment: payment, user: user)).to be_falsey
         end
@@ -38,14 +47,14 @@ RSpec.describe ProcessRefundService do
           expect(refund).to receive(:order_key=).with("123_REFUNDED")
           expect(refund).to receive(:date_entered=).with(Date.current)
           expect(refund).to receive(:date_received=).with(Date.current)
-          expect(refund).to receive(:amount=).with(-1_500)
+          expect(refund).to receive(:amount=).with(500)
           expect(refund).to receive(:registration_reference=).with("registration_reference")
           expect(refund).to receive(:updated_by_user=).with("user@example.com")
 
           expect(I18n).to receive(:t).with("refunds.comment.card").and_return(description)
           expect(refund).to receive(:comment=).with(description)
 
-          expect(Worldpay::RefundService).to receive(:run).with(payment: payment).and_return(true)
+          expect(Worldpay::RefundService).to receive(:run).with(payment: payment, amount: 500).and_return(true)
 
           expect(described_class.run(finance_details: finance_details, payment: payment, user: user)).to be_truthy
         end
@@ -72,7 +81,7 @@ RSpec.describe ProcessRefundService do
         expect(refund).to receive(:order_key=).with("123_REFUNDED")
         expect(refund).to receive(:date_entered=).with(Date.current)
         expect(refund).to receive(:date_received=).with(Date.current)
-        expect(refund).to receive(:amount=).with(-1_500)
+        expect(refund).to receive(:amount=).with(500)
         expect(refund).to receive(:registration_reference=).with("registration_reference")
         expect(refund).to receive(:updated_by_user=).with("user@example.com")
 

--- a/spec/services/process_refund_service_spec.rb
+++ b/spec/services/process_refund_service_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe ProcessRefundService do
       allow(payment).to receive(:worldpay?).and_return(worldpay)
     end
 
-    context "when the amount to refund is 0" do
+    context "when the registration balance is not negative" do
       let(:finance_details) { double(:finance_details, balance: 500) }
 
       it "returns false and does not create a payment" do

--- a/spec/services/worldpay/refund_service_spec.rb
+++ b/spec/services/worldpay/refund_service_spec.rb
@@ -3,7 +3,7 @@
 module Worldpay
   RSpec.describe RefundService do
     let(:payment) { double(:payment) }
-    let(:result) { described_class.run(payment: payment) }
+    let(:result) { described_class.run(payment: payment, amount: 100) }
 
     describe ".run" do
       context "when the payment is not a worldpay payment nor a worldpay_missed payment" do

--- a/spec/services/worldpay/refund_service_spec.rb
+++ b/spec/services/worldpay/refund_service_spec.rb
@@ -18,7 +18,6 @@ module Worldpay
       context "when the payment is a worldpay payment" do
         before do
           expect(payment).to receive(:worldpay?).and_return(true)
-          expect(payment).to receive(:amount).and_return(100)
           expect(payment).to receive(:order_key).and_return("foo")
         end
 


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-811

We have discovered that the refund should only trigger for outstanding amounts in registrations. This fixes the refund services so that the correct amount is refunded. In case the payment selected for the refund has an amount that is less than the overpaid balance, the refund amount will be set to the payment amount.