### PR TITLE
Reword flash error message for worldpay refunds

### DIFF
--- a/config/locales/refunds.en.yml
+++ b/config/locales/refunds.en.yml
@@ -8,7 +8,7 @@ en:
       card: "Refund: %{refund_status}"
     flash_messages:
       successful: "£%{amount} refunded successfully"
-      error: "There has been a problem communicating with Worldpay. Please try again."
+      error: "Sorry, there has been a problem communicating with Worldpay. Please try again."
     index:
       heading: "Which payment do you want to refund?"
       date: "Date"


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-811

Since the wireframe has no indication of error messages in case something goes wrong in communicating with worldpay, I took the liberty to add a message. I have then passed it through Andrew and now I am apply the suggested changes.