### PR TITLE
Hide refund button unless overpayment

### DIFF
--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -57,6 +57,12 @@ module ActionLinksHelper
     resource.upper_tier?
   end
 
+  def display_refund_link_for?(resource)
+    return false if resource.balance >= 0
+
+    can?(:refund, resource)
+  end
+
   def display_payment_details_link_for?(resource)
     # TODO: delete next line filter when internal route exists https://eaflood.atlassian.net/browse/RUBY-786
     return false if a_registration?(resource)

--- a/app/views/shared/registrations/_finance_action_links.html.erb
+++ b/app/views/shared/registrations/_finance_action_links.html.erb
@@ -6,7 +6,7 @@
     <%= link_to t(".write_off_s"), "#TODO", class: "button" %>
     <%= link_to t(".adjust_charge"), "#TODO", class: "button" %>
 
-    <% if can?(:refund, @registration) %>
+    <% if display_refund_link_for?(@registration.finance_details) %>
       <%= link_to t(".refund"), finance_details_refunds_path(@registration._id), class: "button" %>
     <% end %>
   </div>

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -137,6 +137,46 @@ RSpec.describe ActionLinksHelper, type: :helper do
     end
   end
 
+  describe "#display_refund_link_for?" do
+    let(:resource) { build(:finance_details, balance: balance) }
+
+    context "when the resource has a positive balance" do
+      let(:balance) { 5 }
+
+      it "returns false" do
+        expect(helper.display_refund_link_for?(resource)).to be_falsey
+      end
+    end
+
+    context "when the resource has a balance of 0" do
+      let(:balance) { 0 }
+
+      it "returns false" do
+        expect(helper.display_refund_link_for?(resource)).to be_falsey
+      end
+    end
+
+    context "when the resource has a negative balance" do
+      let(:balance) { -20 }
+
+      context "when the user has the permissions to refund" do
+        it "returns true" do
+          expect(helper).to receive(:can?).with(:refund, resource).and_return(true)
+
+          expect(helper.display_refund_link_for?(resource)).to be_truthy
+        end
+      end
+
+      context "when the user does not have the permissions to refund" do
+        it "returns false" do
+          expect(helper).to receive(:can?).with(:refund, resource).and_return(false)
+
+          expect(helper.display_refund_link_for?(resource)).to be_falsey
+        end
+      end
+    end
+  end
+
   describe "#display_resume_link_for?" do
     context "when the result is not a RenewingRegistration" do
       let(:result) { build(:registration) }


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-811

Hide the refund button unless the registration has an overpayment