### PR TITLE
Reword copy cards link

### DIFF
--- a/config/locales/shared/registrations.en.yml
+++ b/config/locales/shared/registrations.en.yml
@@ -68,7 +68,7 @@ en:
             transfer: "Transfer to another account"
             edit: "Edit registration"
             view_confirmation_letter: "View certificate"
-            order_copy_cards: "Order copy cards"
+            order_copy_cards: "Order registration cards"
             payment_details: "Payment details"
             revoke: "Cease or revoke"
       expired_panel:


### PR DESCRIPTION
We decided that we should be consistent in calling extra cards `Registration cards` rather than `copy cards`, hence this fix the wording on the details page link