### PR TITLE
Edit permissions for cease and revoke

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -31,8 +31,6 @@ class Ability
   def permissions_for_agency_user
     # This covers everything mounted in the engine and used for the assisted digital journey, including WorldPay
     can :update, WasteCarriersEngine::RenewingRegistration
-    can :cease, WasteCarriersEngine::Registration
-    can :revoke, WasteCarriersEngine::Registration
     can :renew, :all
     can :view_certificate, WasteCarriersEngine::Registration
     can :order_copy_cards, WasteCarriersEngine::Registration
@@ -42,8 +40,6 @@ class Ability
     can :record_postal_order_payment, WasteCarriersEngine::RenewingRegistration
 
     can :review_convictions, :all
-    can :revoke, WasteCarriersEngine::Registration
-    can :cease, WasteCarriersEngine::Registration
 
     can :revert_to_payment_summary, :all
 
@@ -55,6 +51,8 @@ class Ability
 
     can :view_revoked_reasons, :all
     can :refund, :all
+    can :cease, WasteCarriersEngine::Registration
+    can :revoke, WasteCarriersEngine::Registration
   end
 
   def permissions_for_finance_user

--- a/spec/support/shared_examples/abilities/agency_super_examples.rb
+++ b/spec/support/shared_examples/abilities/agency_super_examples.rb
@@ -8,12 +8,4 @@ RSpec.shared_examples "agency_super examples" do
   it "should be able to manage agency users" do
     should be_able_to(:manage_agency_users, User)
   end
-
-  it "should be able to cease a registration" do
-    should be_able_to(:cease, WasteCarriersEngine::Registration)
-  end
-
-  it "should be able to revoke a registration" do
-    should be_able_to(:revoke, WasteCarriersEngine::Registration)
-  end
 end

--- a/spec/support/shared_examples/abilities/agency_super_examples.rb
+++ b/spec/support/shared_examples/abilities/agency_super_examples.rb
@@ -8,4 +8,12 @@ RSpec.shared_examples "agency_super examples" do
   it "should be able to manage agency users" do
     should be_able_to(:manage_agency_users, User)
   end
+
+  it "should be able to cease a registration" do
+    should be_able_to(:cease, WasteCarriersEngine::Registration)
+  end
+
+  it "should be able to revoke a registration" do
+    should be_able_to(:revoke, WasteCarriersEngine::Registration)
+  end
 end

--- a/spec/support/shared_examples/abilities/agency_with_refund_examples.rb
+++ b/spec/support/shared_examples/abilities/agency_with_refund_examples.rb
@@ -8,4 +8,12 @@ RSpec.shared_examples "agency_with_refund examples" do
   it "should be able to refund a payment" do
     should be_able_to(:refund, WasteCarriersEngine::Registration)
   end
+
+  it "should be able to cease a registration" do
+    should be_able_to(:cease, WasteCarriersEngine::Registration)
+  end
+
+  it "should be able to revoke a registration" do
+    should be_able_to(:revoke, WasteCarriersEngine::Registration)
+  end
 end

--- a/spec/support/shared_examples/abilities/below_agency_with_refund_examples.rb
+++ b/spec/support/shared_examples/abilities/below_agency_with_refund_examples.rb
@@ -8,4 +8,12 @@ RSpec.shared_examples "below agency_with_refund examples" do
   it "should not be able to refund a payment" do
     should_not be_able_to(:refund, WasteCarriersEngine::Registration)
   end
+
+  it "should not be able to cease a registration" do
+    should_not be_able_to(:cease, WasteCarriersEngine::Registration)
+  end
+
+  it "should not be able to revoke a registration" do
+    should_not be_able_to(:revoke, WasteCarriersEngine::Registration)
+  end
 end

--- a/spec/support/shared_examples/abilities/finance_admin_examples.rb
+++ b/spec/support/shared_examples/abilities/finance_admin_examples.rb
@@ -29,6 +29,14 @@ RSpec.shared_examples "finance_admin examples" do
     should_not be_able_to(:refund, WasteCarriersEngine::Registration)
   end
 
+  it "should not be able to cease a registration" do
+    should_not be_able_to(:cease, WasteCarriersEngine::Registration)
+  end
+
+  it "should not be able to revoke a registration" do
+    should_not be_able_to(:revoke, WasteCarriersEngine::Registration)
+  end
+
   it "should not be able to record a cheque payment" do
     should_not be_able_to(:record_cheque_payment, WasteCarriersEngine::RenewingRegistration)
   end

--- a/spec/support/shared_examples/abilities/finance_examples.rb
+++ b/spec/support/shared_examples/abilities/finance_examples.rb
@@ -33,6 +33,14 @@ RSpec.shared_examples "finance examples" do
     should_not be_able_to(:record_cheque_payment, WasteCarriersEngine::RenewingRegistration)
   end
 
+  it "should not be able to cease a registration" do
+    should_not be_able_to(:cease, WasteCarriersEngine::Registration)
+  end
+
+  it "should not be able to revoke a registration" do
+    should_not be_able_to(:revoke, WasteCarriersEngine::Registration)
+  end
+
   it "should not be able to record a postal order payment" do
     should_not be_able_to(:record_postal_order_payment, WasteCarriersEngine::RenewingRegistration)
   end

--- a/spec/support/shared_examples/abilities/finance_super_examples.rb
+++ b/spec/support/shared_examples/abilities/finance_super_examples.rb
@@ -33,6 +33,14 @@ RSpec.shared_examples "finance_super examples" do
     should_not be_able_to(:record_cash_payment, WasteCarriersEngine::RenewingRegistration)
   end
 
+  it "should not be able to cease a registration" do
+    should_not be_able_to(:cease, WasteCarriersEngine::Registration)
+  end
+
+  it "should not be able to revoke a registration" do
+    should_not be_able_to(:revoke, WasteCarriersEngine::Registration)
+  end
+
   it "should not be able to record a cheque payment" do
     should_not be_able_to(:record_cheque_payment, WasteCarriersEngine::RenewingRegistration)
   end


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-807

Chris has provided further clarification on who should be able to cease/revoke:

You are right to ask.  It should be anyone in the Carriers admin team so agency with refund users