### PR TITLE
Fix buttons vertical distance

### DIFF
--- a/app/assets/stylesheets/partials/_buttons.scss
+++ b/app/assets/stylesheets/partials/_buttons.scss
@@ -12,3 +12,7 @@
   display: inline;
   position: absolute;
 }
+
+.wcr-finance-button {
+  margin-bottom: 10px;
+}

--- a/app/views/shared/registrations/_finance_action_links.html.erb
+++ b/app/views/shared/registrations/_finance_action_links.html.erb
@@ -1,13 +1,13 @@
 <div class="grid-row">
   <div class="column-full">
-    <%= link_to t(".enter_payment"), "#TODO", class: "button" %>
-    <%= link_to t(".reverse_payment"), "#TODO", class: "button" %>
-    <%= link_to t(".write_off_l"), "#TODO", class: "button" %>
-    <%= link_to t(".write_off_s"), "#TODO", class: "button" %>
-    <%= link_to t(".adjust_charge"), "#TODO", class: "button" %>
+    <%= link_to t(".enter_payment"), "#TODO", class: "button wcr-finance-button" %>
+    <%= link_to t(".reverse_payment"), "#TODO", class: "button wcr-finance-button" %>
+    <%= link_to t(".write_off_l"), "#TODO", class: "button wcr-finance-button" %>
+    <%= link_to t(".write_off_s"), "#TODO", class: "button wcr-finance-button" %>
+    <%= link_to t(".adjust_charge"), "#TODO", class: "button wcr-finance-button" %>
 
     <% if display_refund_link_for?(@registration.finance_details) %>
-      <%= link_to t(".refund"), finance_details_refunds_path(@registration._id), class: "button" %>
+      <%= link_to t(".refund"), finance_details_refunds_path(@registration._id), class: "button wcr-finance-button" %>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-808

QA have reported that the button in a 200% zoom does merge together. This is due to the fact that there is no vertical margin set for those buttons. This adds it.
<img width="1435" alt="Screenshot 2020-01-10 at 14 05 44" src="https://user-images.githubusercontent.com/1385397/72158683-b4477a80-33b2-11ea-899a-2ff596c1f62b.png">
