### PR TITLE
[WIP] Do not show link to finance page if there is no finance details

### DIFF
--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -58,6 +58,7 @@ module ActionLinksHelper
   end
 
   def display_refund_link_for?(resource)
+    return false unless resource.present?
     return false if resource.balance >= 0
 
     can?(:refund, resource)

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -54,11 +54,10 @@ module ActionLinksHelper
   end
 
   def display_payment_link_for?(resource)
-    resource.upper_tier?
+    resource.upper_tier? && resource.finance_details.present?
   end
 
   def display_refund_link_for?(resource)
-    return false unless resource.present?
     return false if resource.balance >= 0
 
     can?(:refund, resource)

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -140,6 +140,12 @@ RSpec.describe ActionLinksHelper, type: :helper do
   describe "#display_refund_link_for?" do
     let(:resource) { build(:finance_details, balance: balance) }
 
+    context "when the resource is nil" do
+      it "returns false" do
+        expect(helper.display_refund_link_for?(nil)).to be_falsey
+      end
+    end
+
     context "when the resource has a positive balance" do
       let(:balance) { 5 }
 

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -140,12 +140,6 @@ RSpec.describe ActionLinksHelper, type: :helper do
   describe "#display_refund_link_for?" do
     let(:resource) { build(:finance_details, balance: balance) }
 
-    context "when the resource is nil" do
-      it "returns false" do
-        expect(helper.display_refund_link_for?(nil)).to be_falsey
-      end
-    end
-
     context "when the resource has a positive balance" do
       let(:balance) { 5 }
 
@@ -242,7 +236,8 @@ RSpec.describe ActionLinksHelper, type: :helper do
   end
 
   describe "#display_payment_link_for?" do
-    let(:resource) { double(:resource) }
+    let(:finance_details) { "foo" }
+    let(:resource) { double(:resource, finance_details: finance_details) }
 
     before do
       expect(resource).to receive(:upper_tier?).and_return(upper_tier)
@@ -251,8 +246,18 @@ RSpec.describe ActionLinksHelper, type: :helper do
     context "when the resource is an upper tier" do
       let(:upper_tier) { true }
 
-      it "returns true" do
-        expect(helper.display_payment_link_for?(resource)).to be_truthy
+      context "when the resource has finance details" do
+        it "returns true" do
+          expect(helper.display_payment_link_for?(resource)).to be_truthy
+        end
+      end
+
+      context "when the resource has no finance details" do
+        let(:finance_details) { nil }
+
+        it "returns false" do
+          expect(helper.display_payment_link_for?(resource)).to be_falsey
+        end
       end
     end
 


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-808

QA have reported an error thrown by the page being visited from a transient registration that was still in progress. This was due to the fact that the page expect the presence of a `finance_details` object in the registration, but in case of in-progress registration there is none. Hence we shouldn't show the link there.