### PR TITLE
Add 'invite new user' feature

### DIFF
--- a/app/controllers/user_invitations_controller.rb
+++ b/app/controllers/user_invitations_controller.rb
@@ -14,4 +14,8 @@ class UserInvitationsController < Devise::InvitationsController
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:invite, keys: [:role])
   end
+
+  def after_invite_path_for(_resource)
+    users_path
+  end
 end

--- a/app/controllers/user_invitations_controller.rb
+++ b/app/controllers/user_invitations_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class UserInvitationsController < Devise::InvitationsController
+  before_action :configure_permitted_parameters
+
+  private
+
+  # This allows us to include a role on the user invitation form
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:invite, keys: [:role])
+  end
+end

--- a/app/controllers/user_invitations_controller.rb
+++ b/app/controllers/user_invitations_controller.rb
@@ -1,9 +1,14 @@
 # frozen_string_literal: true
 
 class UserInvitationsController < Devise::InvitationsController
+  before_action :authorize, only: %i[new create]
   before_action :configure_permitted_parameters
 
   private
+
+  def authorize
+    authorize! :manage_back_office_users, current_user
+  end
 
   # This allows us to include a role on the user invitation form
   def configure_permitted_parameters

--- a/app/controllers/user_invitations_controller.rb
+++ b/app/controllers/user_invitations_controller.rb
@@ -7,7 +7,7 @@ class UserInvitationsController < Devise::InvitationsController
   before_action :configure_permitted_parameters
 
   def create
-    if selected_role_is_valid?(params.dig(:user, :role))
+    if selected_role_is_in_allowed_group?(params.dig(:user, :role))
       super
     else
       new
@@ -27,9 +27,5 @@ class UserInvitationsController < Devise::InvitationsController
 
   def after_invite_path_for(_resource)
     users_path
-  end
-
-  def selected_role_is_valid?(role)
-    current_user_group_roles(current_user).include?(role)
   end
 end

--- a/app/controllers/user_invitations_controller.rb
+++ b/app/controllers/user_invitations_controller.rb
@@ -1,8 +1,18 @@
 # frozen_string_literal: true
 
 class UserInvitationsController < Devise::InvitationsController
+  include UsersHelper
+
   before_action :authorize, only: %i[new create]
   before_action :configure_permitted_parameters
+
+  def create
+    if selected_role_is_valid?(params.dig(:user, :role))
+      super
+    else
+      new
+    end
+  end
 
   private
 
@@ -17,5 +27,9 @@ class UserInvitationsController < Devise::InvitationsController
 
   def after_invite_path_for(_resource)
     users_path
+  end
+
+  def selected_role_is_valid?(role)
+    current_user_group_roles(current_user).include?(role)
   end
 end

--- a/app/controllers/user_roles_controller.rb
+++ b/app/controllers/user_roles_controller.rb
@@ -23,12 +23,8 @@ class UserRolesController < ApplicationController
     @old_role = User.find(@user.id).role
   end
 
-  def selected_role_is_valid?(role)
-    current_user_group_roles(current_user).include?(role)
-  end
-
   def successful_role_change?
     role = params.dig(:user, :role)
-    selected_role_is_valid?(role) && @user.change_role(role)
+    selected_role_is_in_allowed_group?(role) && @user.change_role(role)
   end
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -24,4 +24,8 @@ module UsersHelper
 
     raise CanCan::AccessDenied
   end
+
+  def selected_role_is_in_allowed_group?(role)
+    current_user_group_roles(current_user).include?(role)
+  end
 end

--- a/app/views/devise/invitations/edit.html.erb
+++ b/app/views/devise/invitations/edit.html.erb
@@ -15,27 +15,25 @@
 
       <%= f.hidden_field :invitation_token %>
 
-      <% if f.object.class.require_password_on_accepting %>
-        <div class="form-group <%= "form-group-error" if resource.errors[:role].any? %>">
-          <%= f.label :password, class: "form-label" do %>
-            <%= t(".password_label") %>
-            <span class="form-hint">
-              <%= t(".password_hint.text") %>
-              <ul class="list list-bullet">
-                <li><%= t(".password_hint.list_item_1") %></li>
-                <li><%= t(".password_hint.list_item_2") %></li>
-                <li><%= t(".password_hint.list_item_3") %></li>
-              </ul>
-            </span>
-          <% end %>
-          <%= f.password_field :password, class: "form-control" %>
-        </div>
+      <div class="form-group <%= "form-group-error" if resource.errors[:role].any? %>">
+        <%= f.label :password, class: "form-label" do %>
+          <%= t(".password_label") %>
+          <span class="form-hint">
+            <%= t(".password_hint.text") %>
+            <ul class="list list-bullet">
+              <li><%= t(".password_hint.list_item_1") %></li>
+              <li><%= t(".password_hint.list_item_2") %></li>
+              <li><%= t(".password_hint.list_item_3") %></li>
+            </ul>
+          </span>
+        <% end %>
+        <%= f.password_field :password, class: "form-control" %>
+      </div>
 
-        <div class="form-group <%= "form-group-error" if resource.errors[:role].any? %>">
-          <%= f.label :password_confirmation, t(".password_confirmation_label"), class: "form-label" %>
-          <%= f.password_field :password_confirmation, class: "form-control" %>
-        </div>
-      <% end %>
+      <div class="form-group <%= "form-group-error" if resource.errors[:role].any? %>">
+        <%= f.label :password_confirmation, t(".password_confirmation_label"), class: "form-label" %>
+        <%= f.password_field :password_confirmation, class: "form-control" %>
+      </div>
 
       <div class="form-group">
         <%= f.submit t(".submit_button"), class: "button" %>

--- a/app/views/devise/invitations/edit.html.erb
+++ b/app/views/devise/invitations/edit.html.erb
@@ -11,14 +11,13 @@
 
        <p><%= t(".paragraph_1") %></p>
 
-      <%= render("waste_exemptions_engine/shared/errors", object: resource) %>
+      <%= render("waste_carriers_engine/shared/errors", object: resource) %>
 
       <%= f.hidden_field :invitation_token %>
 
       <% if f.object.class.require_password_on_accepting %>
-        <% if resource.errors[:password].any? %>
         <div class="form-group <%= "form-group-error" if resource.errors[:role].any? %>">
-          <% f.label :password, class: "form-label" do %>
+          <%= f.label :password, class: "form-label" do %>
             <%= t(".password_label") %>
             <span class="form-hint">
               <%= t(".password_hint.text") %>
@@ -32,7 +31,6 @@
           <%= f.password_field :password, class: "form-control" %>
         </div>
 
-        <% if resource.errors[:password_confirmation].any? %>
         <div class="form-group <%= "form-group-error" if resource.errors[:role].any? %>">
           <%= f.label :password_confirmation, t(".password_confirmation_label"), class: "form-label" %>
           <%= f.password_field :password_confirmation, class: "form-control" %>

--- a/app/views/devise/invitations/edit.html.erb
+++ b/app/views/devise/invitations/edit.html.erb
@@ -9,6 +9,8 @@
          <%= t(".heading") %>
        </h1>
 
+       <p><%= t(".paragraph_1") %></p>
+
       <%= render("waste_exemptions_engine/shared/errors", object: resource) %>
 
       <%= f.hidden_field :invitation_token %>
@@ -16,7 +18,17 @@
       <% if f.object.class.require_password_on_accepting %>
         <% if resource.errors[:password].any? %>
         <div class="form-group <%= "form-group-error" if resource.errors[:role].any? %>">
-          <%= f.label :password, t(".password_label"), class: "form-label" %>
+          <% f.label :password, class: "form-label" do %>
+            <%= t(".password_label") %>
+            <span class="form-hint">
+              <%= t(".password_hint.text") %>
+              <ul class="list list-bullet">
+                <li><%= t(".password_hint.list_item_1") %></li>
+                <li><%= t(".password_hint.list_item_2") %></li>
+                <li><%= t(".password_hint.list_item_3") %></li>
+              </ul>
+            </span>
+          <% end %>
           <%= f.password_field :password, class: "form-control" %>
         </div>
 

--- a/app/views/devise/invitations/edit.html.erb
+++ b/app/views/devise/invitations/edit.html.erb
@@ -1,0 +1,35 @@
+<div class="grid-row">
+  <div class="column-full">
+    <%= form_for resource,
+                 as: resource_name,
+                 url: invitation_path(resource_name),
+                 html: { method: :put } do |f| %>
+
+       <h1 class="heading-large">
+         <%= t(".heading") %>
+       </h1>
+
+      <%= render("waste_exemptions_engine/shared/errors", object: resource) %>
+
+      <%= f.hidden_field :invitation_token %>
+
+      <% if f.object.class.require_password_on_accepting %>
+        <% if resource.errors[:password].any? %>
+        <div class="form-group <%= "form-group-error" if resource.errors[:role].any? %>">
+          <%= f.label :password, t(".password_label"), class: "form-label" %>
+          <%= f.password_field :password, class: "form-control" %>
+        </div>
+
+        <% if resource.errors[:password_confirmation].any? %>
+        <div class="form-group <%= "form-group-error" if resource.errors[:role].any? %>">
+          <%= f.label :password_confirmation, t(".password_confirmation_label"), class: "form-label" %>
+          <%= f.password_field :password_confirmation, class: "form-control" %>
+        </div>
+      <% end %>
+
+      <div class="form-group">
+        <%= f.submit t(".submit_button"), class: "button" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -1,0 +1,28 @@
+<div class="grid-row">
+  <div class="column-full">
+    <%= render("waste_carriers_engine/shared/back", back_path: users_path) %>
+
+    <%= form_for resource,
+                 as: resource_name,
+                 url: invitation_path(resource_name),
+                 html: { method: :post } do |f| %>
+
+      <h1 class="heading-large">
+        <%= t(".heading") %>
+      </h1>
+
+      <%= render("waste_carriers_engine/shared/errors", object: resource) %>
+
+      <% resource.class.invite_key_fields.each do |field| %>
+        <div class="form-group <%= "form-group-error" if resource.errors[:role].any? %>">
+          <%= f.label field, t(".#{field}_label"), class: "form-label" %>
+          <%= f.text_field field, class: "form-control" %>
+        </div>
+      <% end %>
+
+      <div class="form-group">
+        <%= f.submit t(".submit_button"), class: "button" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -20,6 +20,8 @@
         </div>
       <% end %>
 
+      <%= render("shared/select_role", resource: resource, f: f) %>
+
       <div class="form-group">
         <%= f.submit t(".submit_button"), class: "button" %>
       </div>

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -11,6 +11,10 @@
         <%= t(".heading") %>
       </h1>
 
+      <p><%= t(".paragraph_1") %></p>
+      <p><%= t(".paragraph_2") %></p>
+      <p><%= t(".paragraph_3") %></p>
+
       <%= render("waste_carriers_engine/shared/errors", object: resource) %>
 
       <% resource.class.invite_key_fields.each do |field| %>

--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -1,0 +1,14 @@
+<p><%= t(".paragraph_1", email: @resource.email) %></p>
+
+<p><%= t(".paragraph_2", url: root_url) %></p>
+
+<p><%= t(".paragraph_3") %></p>
+
+<p><%= link_to accept_invitation_url(@resource, invitation_token: @token),
+               accept_invitation_url(@resource, invitation_token: @token) %></p>
+
+<% if @resource.invitation_due_at %>
+  <p><%= t(".paragraph_4", due_date: l(@resource.invitation_due_at, format: :accept_until_format)) %></p>
+<% end %>
+
+<p><%= t(".paragraph_5") %></p>

--- a/app/views/devise/mailer/invitation_instructions.txt.erb
+++ b/app/views/devise/mailer/invitation_instructions.txt.erb
@@ -1,0 +1,13 @@
+<%= t(".paragraph_1", email: @resource.email) %>
+
+<%= t(".paragraph_2", url: root_url) %>
+
+<%= t(".paragraph_3") %>
+
+<%= accept_invitation_url(@resource, invitation_token: @token) %>
+
+<% if @resource.invitation_due_at %>
+  <%= t(".paragraph_4", due_date: l(@resource.invitation_due_at, format: :accept_until_format)) %>
+<% end %>
+
+<%= t(".paragraph_5") %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -10,6 +10,7 @@
 
 <div class="grid-row">
   <div class="column-full">
+    <p><%= link_to t(".options.invite_link"), new_user_invitation_path %></p>
     <p><%= link_to t(".options.migrate_link"), new_user_migration_path %></p>
   </div>
 </div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -37,10 +37,12 @@
                   <%= t(".user_list.roles.#{user.role}") %>
                 </td>
                 <td>
-                  <% if user.active? %>
-                    <%= t(".user_list.statuses.active") %>
-                  <% else %>
+                  <% if !user.active? %>
                     <%= t(".user_list.statuses.deactivated") %>
+                  <% elsif user.invitation_token.present? %>
+                    <%= t(".user_list.statuses.invited") %>
+                  <% else %>
+                    <%= t(".user_list.statuses.active") %>
                   <% end %>
                 </td>
                 <td>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -53,7 +53,7 @@ Rails.application.configure do
   # Raises error for missing translations
   config.action_view.raise_on_missing_translations = true
 
-  config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
+  config.action_mailer.default_url_options = { host: config.wcrs_back_office_url, protocol: "http" }
 
   # The rails web console allows you to execute arbitrary code on the server. By
   # default, only requests coming from IPv4 and IPv6 localhosts are allowed.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -32,6 +32,8 @@ Rails.application.configure do
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
+  # Required for testing user invitations
+  config.action_mailer.default_url_options = { host: config.wcrs_back_office_url, protocol: "http" }
 
   # Randomize the order test cases are executed.
   config.active_support.test_order = :random

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -128,6 +128,10 @@ Devise.setup do |config|
   # the user will need to manually log in after accepting the invite.
   config.allow_insecure_sign_in_after_accept = true
 
+  # If this is true, run validations on the new user before sending the invite.
+  # If false, validate when they accept.
+  config.validate_on_invite = true
+
   # ==> Configuration for :confirmable
   # A period that the user is allowed to access the website even without
   # confirming their account. For instance, if set to 2.days, the user will be

--- a/config/locales/devise_invitable.en.yml
+++ b/config/locales/devise_invitable.en.yml
@@ -31,14 +31,12 @@ en:
         submit_button: "Create account"
     mailer:
       invitation_instructions:
-        subject: "Invitation instructions"
-        hello: "Hello %{email}"
-        someone_invited_you: "You have been invited to join the service. Accept this invitation by clicking the link below. You can only use this link once."
-        accept: "Accept invitation"
-        ignore: "If you don't want to accept the invitation please ignore this email.<br />Your account won't be created until you access the link above and set your password."
+        subject: "Confirm a waste carriers back office account"
+        paragraph_1: "Hello %{email}"
+        paragraph_2: "You have been added as a user to the back office system for the waste carriers service (%{url})"
+        paragraph_3: "Use the link below to confirm this."
+        paragraph_4: "This link will expire on %{due_date}."
+        paragraph_5: "If you don't want to confirm the account, please ignore this email."
   time:
     formats:
-      devise:
-        mailer:
-          invitation_instructions:
-            accept_until_format: "%B %d, %Y %I:%M %p"
+      accept_until_format: "%e %B %Y at %l:%M%P"

--- a/config/locales/devise_invitable.en.yml
+++ b/config/locales/devise_invitable.en.yml
@@ -12,8 +12,9 @@ en:
       no_invitations_remaining: "No invitations remaining"
       invitation_removed: "Your invitation was removed"
       new:
-        header: "Send invitation"
-        submit_button: "Send an invitation"
+        heading: "Invite a new user"
+        email_label: "Email"
+        submit_button: "Send invitation"
       edit:
         header: "Set your password"
         submit_button: "Set my password"

--- a/config/locales/devise_invitable.en.yml
+++ b/config/locales/devise_invitable.en.yml
@@ -20,7 +20,7 @@ en:
         submit_button: "Send invitation"
       edit:
         heading: "Create a new back office account"
-        pragraph_1: "To finish setting up your account, you need to create a password."
+        paragraph_1: "To finish setting up your account, you need to create a password."
         password_label: "Password"
         password_hint:
           text: "It must:"

--- a/config/locales/devise_invitable.en.yml
+++ b/config/locales/devise_invitable.en.yml
@@ -16,8 +16,10 @@ en:
         email_label: "Email"
         submit_button: "Send invitation"
       edit:
-        header: "Set your password"
-        submit_button: "Set my password"
+        heading: "Accept your invitation"
+        password_label: "Password"
+        password_confirmation_label: "Confirm password"
+        submit_button: "Create account"
     mailer:
       invitation_instructions:
         subject: "Invitation instructions"

--- a/config/locales/devise_invitable.en.yml
+++ b/config/locales/devise_invitable.en.yml
@@ -19,8 +19,14 @@ en:
         email_label: "Email"
         submit_button: "Send invitation"
       edit:
-        heading: "Accept your invitation"
+        heading: "Create a new back office account"
+        pragraph_1: "To finish setting up your account, you need to create a password."
         password_label: "Password"
+        password_hint:
+          text: "It must:"
+          list_item_1: "have at least 8 characters"
+          list_item_2: "include some numbers"
+          list_item_3: "have a mix of lower and upper case letters"
         password_confirmation_label: "Confirm password"
         submit_button: "Create account"
     mailer:

--- a/config/locales/devise_invitable.en.yml
+++ b/config/locales/devise_invitable.en.yml
@@ -13,6 +13,9 @@ en:
       invitation_removed: "Your invitation was removed"
       new:
         heading: "Invite a new user"
+        paragraph_1: "The new user will receive an email containing a confirmation link."
+        paragraph_2: "They must follow the link and create a password before they can access this system."
+        paragraph_3: "Email links expire after 2 weeks."
         email_label: "Email"
         submit_button: "Send invitation"
       edit:

--- a/config/locales/users.en.yml
+++ b/config/locales/users.en.yml
@@ -4,6 +4,7 @@ en:
       title: "Manage back office users"
       heading: "Manage back office users"
       options:
+        invite_link: "Invite a new user"
         migrate_link: "Migrate users from backend"
       user_list:
         th:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   root to: "application#redirect_root_to_dashboard"
 
   devise_for :users,
-             controllers: { sessions: "sessions" },
+             controllers: { invitations: "user_invitations", sessions: "sessions" },
              path: "/bo/users",
              path_names: { sign_in: "sign_in", sign_out: "sign_out" }
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,8 +8,7 @@ Rails.application.routes.draw do
   devise_for :users,
              controllers: { sessions: "sessions" },
              path: "/bo/users",
-             path_names: { sign_in: "sign_in", sign_out: "sign_out" },
-             skip: [:invitations]
+             path_names: { sign_in: "sign_in", sign_out: "sign_out" }
 
   get "/bo" => "dashboards#index"
   get "/bo/convictions" => "convictions_dashboards#index", as: :convictions

--- a/spec/requests/user_invitations_spec.rb
+++ b/spec/requests/user_invitations_spec.rb
@@ -42,9 +42,9 @@ RSpec.describe "User Invitations", type: :request do
         sign_in(user)
       end
 
-      it "redirects to the root path" do
+      it "redirects to the users path" do
         post "/bo/users/invitation", params
-        expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to(users_path)
       end
 
       it "creates a new user" do

--- a/spec/requests/user_invitations_spec.rb
+++ b/spec/requests/user_invitations_spec.rb
@@ -15,6 +15,18 @@ RSpec.describe "User Invitations", type: :request do
         expect(response).to render_template(:new)
       end
     end
+
+    context "when a non-super user is signed in" do
+      let(:user) { create(:user, :agency) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      it "redirects to the permissions error page" do
+        get "/bo/users/invitation/new"
+        expect(response).to redirect_to("/bo/pages/permission")
+      end
+    end
   end
 
   describe "POST /bo/users/invitation" do
@@ -45,6 +57,18 @@ RSpec.describe "User Invitations", type: :request do
       it "assigns the correct role to the user" do
         post "/bo/users/invitation", params
         expect(User.find_by(email: email).role).to eq(role)
+      end
+    end
+
+    context "when a non-super user is signed in" do
+      let(:user) { create(:user, :agency) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      it "redirects to the permissions error page" do
+        post "/bo/users/invitation", params
+        expect(response).to redirect_to("/bo/pages/permission")
       end
     end
   end

--- a/spec/requests/user_invitations_spec.rb
+++ b/spec/requests/user_invitations_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "User Invitations", type: :request do
+  describe "GET /bo/users/invitation/new" do
+    context "when a super user is signed in" do
+      let(:user) { create(:user, :agency_super) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      it "renders the new template" do
+        get "/bo/users/invitation/new"
+        expect(response).to render_template(:new)
+      end
+    end
+  end
+
+  describe "POST /bo/users/invitation" do
+    let(:params) do
+      { user: { email: attributes_for(:user)[:email] } }
+    end
+
+    context "when a super user is signed in" do
+      let(:user) { create(:user, :agency_super) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      it "redirects to the root path" do
+        post "/bo/users/invitation", params
+        expect(response).to redirect_to(root_path)
+      end
+
+      it "creates a new user" do
+        old_user_count = User.count
+
+        post "/bo/users/invitation", params
+        expect(User.count).to eq(old_user_count + 1)
+      end
+    end
+  end
+end

--- a/spec/requests/user_invitations_spec.rb
+++ b/spec/requests/user_invitations_spec.rb
@@ -58,6 +58,22 @@ RSpec.describe "User Invitations", type: :request do
         post "/bo/users/invitation", params
         expect(User.find_by(email: email).role).to eq(role)
       end
+
+      context "when the current user does not have permission to select this role" do
+        let(:role) { :finance }
+
+        it "does not create a new user" do
+          old_user_count = User.count
+
+          post "/bo/users/invitation", params
+          expect(User.count).to eq(old_user_count)
+        end
+
+        it "renders the new template" do
+          post "/bo/users/invitation", params
+          expect(response).to render_template(:new)
+        end
+      end
     end
 
     context "when a non-super user is signed in" do

--- a/spec/requests/user_invitations_spec.rb
+++ b/spec/requests/user_invitations_spec.rb
@@ -18,8 +18,10 @@ RSpec.describe "User Invitations", type: :request do
   end
 
   describe "POST /bo/users/invitation" do
+    let(:email) { attributes_for(:user)[:email] }
+    let(:role) { attributes_for(:user)[:role] }
     let(:params) do
-      { user: { email: attributes_for(:user)[:email] } }
+      { user: { email: email, role: role } }
     end
 
     context "when a super user is signed in" do
@@ -38,6 +40,11 @@ RSpec.describe "User Invitations", type: :request do
 
         post "/bo/users/invitation", params
         expect(User.count).to eq(old_user_count + 1)
+      end
+
+      it "assigns the correct role to the user" do
+        post "/bo/users/invitation", params
+        expect(User.find_by(email: email).role).to eq(role)
       end
     end
   end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-760

Back office super users should be able to invite new back office users.

Users will be expected to enter the email address for the new user, select a role, and when submitted behind the scenes the app will create a new user and send an email with a link to the email. The link validates the email address and presents a screen that asks the user to create a password.

Super users should only be able to invite users with roles of their user group - for example, agency supers can invite new agency users, but not new finance users.