### PR TITLE
Remove links for release

### DIFF
--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -70,7 +70,7 @@ module ActionLinksHelper
     # TODO: Temporary - for release only. See: https://eaflood.atlassian.net/browse/RUBY-846
     return false
 
-    resource.upper_tier? && resource.finance_details.present?
+    # resource.upper_tier? && resource.finance_details.present?
   end
 
   def display_cease_or_revoke_link_for?(resource)

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -54,6 +54,9 @@ module ActionLinksHelper
   end
 
   def display_payment_link_for?(resource)
+    # TODO: Temporary - for release only. See: https://eaflood.atlassian.net/browse/RUBY-846
+    return false if a_registration?(resource)
+
     resource.upper_tier?
   end
 
@@ -64,6 +67,9 @@ module ActionLinksHelper
   end
 
   def display_finance_details_link_for?(resource)
+    # TODO: Temporary - for release only. See: https://eaflood.atlassian.net/browse/RUBY-846
+    return false
+
     resource.upper_tier? && resource.finance_details.present?
   end
 

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -68,9 +68,11 @@ module ActionLinksHelper
 
   def display_finance_details_link_for?(resource)
     # TODO: Temporary - for release only. See: https://eaflood.atlassian.net/browse/RUBY-846
-    # resource.upper_tier? && resource.finance_details.present?
+    return false
 
-    false
+    # rubocop:disable Lint/UnreachableCode
+    resource.upper_tier? && resource.finance_details.present?
+    # rubocop:enable Lint/UnreachableCode
   end
 
   def display_cease_or_revoke_link_for?(resource)

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -68,9 +68,9 @@ module ActionLinksHelper
 
   def display_finance_details_link_for?(resource)
     # TODO: Temporary - for release only. See: https://eaflood.atlassian.net/browse/RUBY-846
-    return false
-
     # resource.upper_tier? && resource.finance_details.present?
+
+    false
   end
 
   def display_cease_or_revoke_link_for?(resource)

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -236,27 +236,28 @@ RSpec.describe ActionLinksHelper, type: :helper do
   end
 
   describe "#display_payment_link_for?" do
-    let(:resource) { double(:resource) }
+    # TODO: Temporary - for release only. See: https://eaflood.atlassian.net/browse/RUBY-846
+    # let(:resource) { double(:resource) }
 
-    before do
-      expect(resource).to receive(:upper_tier?).and_return(upper_tier)
-    end
+    # before do
+    #   expect(resource).to receive(:upper_tier?).and_return(upper_tier)
+    # end
 
-    context "when the resource is an upper tier" do
-      let(:upper_tier) { true }
+    # context "when the resource is an upper tier" do
+    #   let(:upper_tier) { true }
 
-      it "returns true" do
-        expect(helper.display_payment_link_for?(resource)).to be_truthy
-      end
-    end
+    #   it "returns true" do
+    #     expect(helper.display_payment_link_for?(resource)).to be_truthy
+    #   end
+    # end
 
-    context "when the resource is not an upper tier" do
-      let(:upper_tier) { false }
+    # context "when the resource is not an upper tier" do
+    #   let(:upper_tier) { false }
 
-      it "returns false" do
-        expect(helper.display_payment_link_for?(resource)).to be_falsey
-      end
-    end
+    #   it "returns false" do
+    #     expect(helper.display_payment_link_for?(resource)).to be_falsey
+    #   end
+    # end
   end
 
   describe "#display_cease_or_revoke_link_for?" do
@@ -474,28 +475,33 @@ RSpec.describe ActionLinksHelper, type: :helper do
     let(:finance_details) { double(:finance_details) }
     let(:resource) { double(:registration, finance_details: finance_details, upper_tier?: upper_tier) }
 
-    context "when the resource is an upper tier" do
-      context "when the resource has finance details" do
-        it "returns true" do
-          expect(helper.display_finance_details_link_for?(resource)).to be_truthy
-        end
-      end
-
-      context "when the resource has no finance details" do
-        let(:finance_details) { nil }
-        it "returns false" do
-          expect(helper.display_finance_details_link_for?(resource)).to be_falsey
-        end
-      end
+    # TODO: Temporary - for release only. See: https://eaflood.atlassian.net/browse/RUBY-846
+    it "returns false" do
+      expect(helper.display_finance_details_link_for?(resource)).to be_falsey
     end
 
-    context "when the resource is not an upper tier" do
-      let(:upper_tier) { false }
+    # context "when the resource is an upper tier" do
+    #   context "when the resource has finance details" do
+    #     it "returns true" do
+    #       expect(helper.display_finance_details_link_for?(resource)).to be_truthy
+    #     end
+    #   end
 
-      it "returns false" do
-        expect(helper.display_finance_details_link_for?(resource)).to be_falsey
-      end
-    end
+    #   context "when the resource has no finance details" do
+    #     let(:finance_details) { nil }
+    #     it "returns false" do
+    #       expect(helper.display_finance_details_link_for?(resource)).to be_falsey
+    #     end
+    #   end
+    # end
+
+    # context "when the resource is not an upper tier" do
+    #   let(:upper_tier) { false }
+
+    #   it "returns false" do
+    #     expect(helper.display_finance_details_link_for?(resource)).to be_falsey
+    #   end
+    # end
   end
 
   describe "#display_convictions_link_for?" do


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-846

In order to not release features that are not finished yet, we want to rermove links to those features for the sake of next release. This will need to be rolled back in: https://eaflood.atlassian.net/browse/RUBY-851