### PR TITLE
Add process payment button to action list

### DIFF
--- a/app/views/shared/registrations/_action_links_panel.html.erb
+++ b/app/views/shared/registrations/_action_links_panel.html.erb
@@ -50,6 +50,12 @@
       </li>
     <% end %>
 
+    <% if display_payment_link_for?(resource) %>
+      <li>
+        <%= link_to t(".actions_box.links.process_payment"), transient_registration_transient_payments_path(resource.reg_identifier) %>
+      </li>
+    <% end %>
+
     <% if display_cease_or_revoke_link_for?(resource) %>
       <li>
         <%= link_to t(".actions_box.links.revoke"), WasteCarriersEngine::Engine.routes.url_helpers.new_cease_or_revoke_form_path(resource.reg_identifier) %>

--- a/config/locales/shared/registrations.en.yml
+++ b/config/locales/shared/registrations.en.yml
@@ -70,6 +70,7 @@ en:
             view_confirmation_letter: "View certificate"
             order_copy_cards: "Order registration cards"
             payment_details: "Payment details"
+            process_payment: "Process payment"
             revoke: "Cease or revoke"
       expired_panel:
         heading: "Expired on %{date}"


### PR DESCRIPTION
We have noticed that there is a missing link on the action RHS navigation bar on registrations and renewing registrations pages. We probably got rid of it by mistake. This adds it back as per design.