### PR TITLE
Fix default email protocol

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -16,7 +16,7 @@ Rails.application.configure do
   config.action_controller.perform_caching = false
 
   # Sending e-mails is required for user management and registration e-mails
-  config.action_mailer.default_url_options = { host: config.wcrs_back_office_url, protocol: "http" }
+  config.action_mailer.default_url_options = { host: config.wcrs_back_office_url, protocol: "https" }
 
   # Don't care if the mailer can't send (if set to false)
   config.action_mailer.raise_delivery_errors = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -83,7 +83,7 @@ Rails.application.configure do
   config.log_formatter = ::Logger::Formatter.new
 
   # Sending e-mails is required for user management and registration e-mails
-  config.action_mailer.default_url_options = { host: config.wcrs_back_office_url, protocol: "http" }
+  config.action_mailer.default_url_options = { host: config.wcrs_back_office_url, protocol: "https" }
 
   # Don't care if the mailer can't send (if set to false)
   config.action_mailer.raise_delivery_errors = false

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -33,7 +33,7 @@ Rails.application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
   # Required for testing user invitations
-  config.action_mailer.default_url_options = { host: config.wcrs_back_office_url, protocol: "http" }
+  config.action_mailer.default_url_options = { host: config.wcrs_back_office_url, protocol: "https" }
 
   # Randomize the order test cases are executed.
   config.active_support.test_order = :random


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-760

During QA of the 'invite user' feature, we spotted that the email confirmation link did not work as expected when opened directly into incognito mode.

This turned out to be because of the default protocol being `http`. This may just be an issue on our test environments, but we should default to `https` anyway.