### PR TITLE
Fix wonky validation on user invite form

### DIFF
--- a/app/controllers/user_invitations_controller.rb
+++ b/app/controllers/user_invitations_controller.rb
@@ -7,10 +7,10 @@ class UserInvitationsController < Devise::InvitationsController
   before_action :configure_permitted_parameters
 
   def create
-    if selected_role_is_in_allowed_group?(params.dig(:user, :role))
-      super
-    else
+    if selected_role_is_not_in_valid_group?
       new
+    else
+      super
     end
   end
 
@@ -27,5 +27,13 @@ class UserInvitationsController < Devise::InvitationsController
 
   def after_invite_path_for(_resource)
     users_path
+  end
+
+  def selected_role_is_not_in_valid_group?
+    role = params.dig(:user, :role)
+    return false if role.blank?
+    return false if selected_role_is_in_allowed_group?(role)
+
+    true
   end
 end

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -18,10 +18,16 @@
       <%= render("waste_carriers_engine/shared/errors", object: resource) %>
 
       <% resource.class.invite_key_fields.each do |field| %>
-        <div class="form-group <%= "form-group-error" if resource.errors[:role].any? %>">
-          <%= f.label field, t(".#{field}_label"), class: "form-label" %>
-          <%= f.text_field field, class: "form-control" %>
-        </div>
+        <fieldset id="<%= field %>">
+          <% if resource.errors[field].any? %>
+            <span class="error-message"><%= resource.errors[field].join(", ") %></span>
+          <% end %>
+
+          <div class="form-group <%= "form-group-error" if resource.errors[field].any? %>">
+            <%= f.label field, t(".#{field}_label"), class: "form-label" %>
+            <%= f.text_field field, class: "form-control" %>
+          </div>
+        </fieldset>
       <% end %>
 
       <%= render("shared/select_role", resource: resource, f: f) %>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-760

When we POST the invite form, there is an extra check to make sure that the user submitting the form has invited the new user to a group which they have permission for. (Eg a finance super has not invited an agency user).

This check was a little overzealous and was causing the other validation errors to not display correctly. Now it will only fire if the user has submitted a role and the role is invalid. We still don't display a helpful error but since this will only happen if the user is tinkering with the HTML of the form or trying to submit their own custom POST requests, I am not so worried about being helpful.

Also spotted that the link to email errors did not work and the error was not displayed next to the field. This PR fixes that as well.