### PR TITLE
Add 'developer' user role

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -18,6 +18,7 @@ class Ability
     permissions_for_agency_user if agency_user?(user)
     permissions_for_agency_user_with_refund if agency_user_with_refund?(user)
     permissions_for_agency_super_user if agency_super_user?(user)
+    permissions_for_agency_user if developer?(user)
   end
 
   def assign_finance_user_permissions(user)
@@ -109,5 +110,9 @@ class Ability
 
   def finance_super_user?(user)
     user.role == "finance_super"
+  end
+
+  def developer?(user)
+    user.role == "developer"
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -18,7 +18,7 @@ class Ability
     permissions_for_agency_user if agency_user?(user)
     permissions_for_agency_user_with_refund if agency_user_with_refund?(user)
     permissions_for_agency_super_user if agency_super_user?(user)
-    permissions_for_agency_user if developer?(user)
+    permissions_for_developer_user if developer?(user)
   end
 
   def assign_finance_user_permissions(user)
@@ -84,6 +84,12 @@ class Ability
       user.in_finance_group?
     end
     # rubocop:enable Style/SymbolProc
+  end
+
+  def permissions_for_developer_user
+    permissions_for_agency_user
+
+    can :import_conviction_data, :all
   end
 
   # Checks to see if role matches

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,7 +43,8 @@ class User
 
   AGENCY_ROLES = %w[agency
                     agency_with_refund
-                    agency_super].freeze
+                    agency_super
+                    developer].freeze
 
   FINANCE_ROLES = %w[finance
                      finance_admin

--- a/app/services/user_migration_service.rb
+++ b/app/services/user_migration_service.rb
@@ -85,8 +85,11 @@ class UserMigrationService < ::WasteCarriersEngine::BaseService
     # So when syncing agency users, if the role found in the back office is
     # an admin role, we leave it as is rather than overwriting it (in the
     # back office admins can do pretty much anything hence only one user
-    # needed)
-    return bo_user.role if bo_user && admin_role?(bo_user.role)
+    # needed).
+    # We also don't want to overwrite developer permissions, as this role
+    # did not exist in the old frontend, so developer accounts may be
+    # categorised as agency users there.
+    return bo_user.role if bo_user && role_should_not_be_modified?(bo_user.role)
     return "agency" unless user.role_ids
 
     determine_role(user)
@@ -115,8 +118,8 @@ class UserMigrationService < ::WasteCarriersEngine::BaseService
     bo_user.role != backend_role
   end
 
-  def admin_role?(role)
-    %w[agency_super finance_super].include?(role)
+  def role_should_not_be_modified?(role)
+    %w[agency_super finance_super developer].include?(role)
   end
 
   def add_result(email, role, action)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,6 +44,7 @@ en:
           finance_admin: "Finance admin user"
           agency_super: "Agency super user"
           finance_super: "Finance super user"
+          developer: "Developer"
 
   # Kaminari overrides
   helpers:

--- a/config/locales/user_migrations.en.yml
+++ b/config/locales/user_migrations.en.yml
@@ -44,5 +44,6 @@ en:
             finance_admin: "finance admin"
             agency_super: "agency super"
             finance_super: "finance super"
+            developer: "developer"
       no_results: "No results"
       user_button: "Return to manage back office users"

--- a/config/locales/user_roles.en.yml
+++ b/config/locales/user_roles.en.yml
@@ -10,4 +10,5 @@ en:
         finance_admin: "%{email} is currently a finance admin user."
         agency_super: "%{email} is currently an agency super user."
         finance_super: "%{email} is currently a finance super user."
+        developer: "%{email} is currently a developer."
       submit_button: "Change role"

--- a/config/locales/users.en.yml
+++ b/config/locales/users.en.yml
@@ -19,6 +19,7 @@ en:
           finance_admin: "finance admin"
           agency_super: "agency super"
           finance_super: "finance super"
+          developer: "developer"
         statuses:
           active: "active"
           deactivated: "deactivated"

--- a/db/seeds/users.json
+++ b/db/seeds/users.json
@@ -47,6 +47,10 @@
     {
       "email" : "finance-admin-user@wcr.gov.uk",
       "role" : "finance_admin"
+    },
+    {
+      "email" : "developer@wcr.gov.uk",
+      "role" : "developer"
     }
   ]
 }

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -37,5 +37,9 @@ FactoryBot.define do
     trait :finance_super do
       role { "finance_super" }
     end
+
+    trait :developer do
+      role { "developer" }
+    end
   end
 end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -42,6 +42,16 @@ RSpec.describe Ability, type: :model do
     include_examples "active and inactive examples"
   end
 
+  context "when the user role is developer" do
+    let(:role) { "developer" }
+
+    include_examples "below agency_super examples"
+    include_examples "below agency_with_refund examples"
+    include_examples "agency examples"
+
+    include_examples "active and inactive examples"
+  end
+
   # Finance users do not have ascending permissions.
 
   context "when the user role is finance_super" do

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -19,6 +19,8 @@ RSpec.describe Ability, type: :model do
     include_examples "agency_with_refund examples"
     include_examples "agency examples"
 
+    include_examples "non-developer examples"
+
     include_examples "active and inactive examples"
   end
 
@@ -28,6 +30,8 @@ RSpec.describe Ability, type: :model do
     include_examples "below agency_super examples"
     include_examples "agency_with_refund examples"
     include_examples "agency examples"
+
+    include_examples "non-developer examples"
 
     include_examples "active and inactive examples"
   end
@@ -39,6 +43,8 @@ RSpec.describe Ability, type: :model do
     include_examples "below agency_with_refund examples"
     include_examples "agency examples"
 
+    include_examples "non-developer examples"
+
     include_examples "active and inactive examples"
   end
 
@@ -48,6 +54,8 @@ RSpec.describe Ability, type: :model do
     include_examples "below agency_super examples"
     include_examples "below agency_with_refund examples"
     include_examples "agency examples"
+
+    include_examples "developer examples"
 
     include_examples "active and inactive examples"
   end
@@ -59,6 +67,8 @@ RSpec.describe Ability, type: :model do
 
     include_examples "finance_super examples"
 
+    include_examples "non-developer examples"
+
     include_examples "active and inactive examples"
   end
 
@@ -67,6 +77,8 @@ RSpec.describe Ability, type: :model do
 
     include_examples "finance_admin examples"
 
+    include_examples "non-developer examples"
+
     include_examples "active and inactive examples"
   end
 
@@ -74,6 +86,8 @@ RSpec.describe Ability, type: :model do
     let(:role) { "finance" }
 
     include_examples "finance examples"
+
+    include_examples "non-developer examples"
 
     include_examples "active and inactive examples"
   end

--- a/spec/services/user_migration_service_spec.rb
+++ b/spec/services/user_migration_service_spec.rb
@@ -174,6 +174,29 @@ RSpec.describe UserMigrationService do
 
           expect(run_service).to include(result)
         end
+
+        context "when the back office role is developer" do
+          before do
+            back_office_user.update_attributes(role: "developer")
+          end
+
+          it "does not modify the back office user" do
+            back_office_user_before = back_office_user
+            run_service
+            back_office_user_after = back_office_user.reload
+            expect(back_office_user_before).to eq(back_office_user_after)
+          end
+
+          it "adds the correct value to the results" do
+            result = {
+              action: :skip,
+              email: agency_user.email,
+              role: "developer"
+            }
+
+            expect(run_service).to include(result)
+          end
+        end
       end
     end
   end

--- a/spec/support/shared_examples/abilities/developer_examples.rb
+++ b/spec/support/shared_examples/abilities/developer_examples.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "developer examples" do
+  it "should be able to import conviction data" do
+    should be_able_to(:import_conviction_data, :all)
+  end
+end

--- a/spec/support/shared_examples/abilities/non_developer_examples.rb
+++ b/spec/support/shared_examples/abilities/non_developer_examples.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "non-developer examples" do
+  it "should not be able to import conviction data" do
+    should_not be_able_to(:import_conviction_data, :all)
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-772

We want to be able to update our conviction data from within the app. We'll need a new type of user group for this, called 'developer'.

Developer users will have the same permissions as agency_users to start out with. So we'll just consider them a part of the agency user group.