### PR TITLE
Add support for mocking external services

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,16 @@ gem "waste_carriers_engine",
     git: "https://github.com/DEFRA/waste-carriers-engine",
     branch: "master"
 
+# Use the defra ruby mocks engine to add support for mocking external services
+# in live environment. Essentially with this gem added and enabled the app
+# also becomes a 'mock' for external services like companies house.
+# This then allows us to performance test our services without fear of being
+# reported for causing undue loads on the external services we use.
+# With the environment properly configured, when any app in an environment needs
+# to call Companies House, instead it will call this app which will mock the end
+# point and return the response expected.
+gem "defra_ruby_mocks", "~> 1.0"
+
 # Allows us to automatically generate the change log from the tags, issues,
 # labels and pull requests on GitHub. Added as a dependency so all dev's have
 # access to it to generate a log, and so they are using the same version.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,8 @@ GEM
     debug_inspector (0.0.3)
     defra_ruby_aws (0.2.0)
       aws-sdk-s3
+    defra_ruby_mocks (1.0.0)
+      rails (~> 4.2.11.1)
     defra_ruby_style (0.1.3)
       rubocop (~> 0.75)
     defra_ruby_validators (2.2.0)
@@ -390,6 +392,7 @@ DEPENDENCIES
   coffee-rails (~> 4.1.0)
   database_cleaner
   defra_ruby_aws (~> 0.2.0)
+  defra_ruby_mocks (~> 1.0)
   defra_ruby_style
   devise (>= 4.4.3)
   devise_invitable (~> 1.7.0)

--- a/config/initializers/defra_ruby_mocks.rb
+++ b/config/initializers/defra_ruby_mocks.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+DefraRubyMocks.configure do |configuration|
+  # Enable the mock routes mounted in this app if the environment is configured
+  # for it
+  configuration.enable = ENV["WCRS_MOCK_ENABLED"] || false
+  # Set how long the mock should delay before responding. In the engine itself
+  # the default is 1000ms (1 second)
+  configuration.delay = ENV["WCRS_MOCK_DELAY"] || 1000
+end

--- a/config/initializers/waste_carriers_engine.rb
+++ b/config/initializers/waste_carriers_engine.rb
@@ -3,4 +3,10 @@
 WasteCarriersEngine.configure do |configuration|
   # Companies house API config
   configuration.companies_house_api_key = ENV["WCRS_COMPANIES_HOUSE_API_KEY"]
+
+  # We only want to alter the companies house URL if mocking is enabled. Else
+  # the url is handled by the defra-ruby-validators gem from the wcr engine
+  if ENV["WCRS_MOCK_ENABLED"].to_s.downcase == "true"
+    configuration.companies_house_host = ENV["WCRS_MOCK_FO_COMPANIES_HOUSE_URL"]
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -157,6 +157,8 @@ Rails.application.routes.draw do
       to: "user_migrations#results",
       as: :user_migration_results
 
+  mount DefraRubyMocks::Engine => "/bo/mocks"
+
   mount WasteCarriersEngine::Engine => "/bo", as: "basic_app_engine"
 end
 # rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
We have created a new engine in the DefraRuby namespace called [defra_ruby_mocks](https://github.com/DEFRA/defra-ruby-mocks).

Going forward this will allow us to mock external services like Companies House, and in the future Worldpay.

We only really need to do this when running performance tests. We want to put as much of the service under load as possible, but at the same time we don't want to get into trouble for overloading these external services, or worst case get accused of a DDOS attack.

So by providing an alternate end point that can accept the same request, and return what the service needs, we can replace them when we need to.

That endpoint is our existing apps. We have chosen to do it in this way to avoid the additional complexity of managing and maintaining another service across all our environments (if deployment was simple for us it's not the way we would have gone!)

So we'll be mounting the engine into both our [Front-office](https://github.com/DEFRA/waste-carriers-front-office) and [Back-office](https://github.com/DEFRA/waste-carriers-back-office) apps. We need to do this so each can treat the other as the mock endpoint (Ruby being single threaded means the rails apps can't call themselves)

This change adds the mocks engine to this app, including the initializer, which for now will give us the ability to mock companies house.

It also updates the [waste-carriers-engine](https://github.com/DEFRA/waste-carriers-engine) config. If mocking is enabled we want to tell the engine to use a different url for companies house lookups to allow us to override what the Companies house url is.

As both apps need to configure themselves to look at the other in an environment, we can't just update the `WCRS_COMPANIES_HOUSE_URL` as this is shared by everything.

Hence we have added logic to check if mocks are enabled. If they are, we refer to a different env var to get the URL to use. When mocks are not enabled, everything remains as it currently is.