### PR TITLE
Set up ConvictionImportService

### DIFF
--- a/app/services/conviction_import_service.rb
+++ b/app/services/conviction_import_service.rb
@@ -14,7 +14,11 @@ class ConvictionImportService < ::WasteCarriersEngine::BaseService
   private
 
   def parse_data(csv)
-    CSV.parse(csv, headers: true, liberal_parsing: true, skip_blanks: true)
+    CSV.parse(csv,
+              converters: :date,
+              headers: true,
+              liberal_parsing: true,
+              skip_blanks: true)
   end
 
   def add_conviction_record(conviction)

--- a/app/services/conviction_import_service.rb
+++ b/app/services/conviction_import_service.rb
@@ -9,28 +9,26 @@ class ConvictionImportService < ::WasteCarriersEngine::BaseService
     convictions_data.each do |line|
       add_conviction_record(line)
     end
-
-    convictions_data
   end
 
   private
 
   def parse_data(csv)
-    CSV.parse(csv, liberal_parsing: true, skip_blanks: true)
+    CSV.parse(csv, headers: true, liberal_parsing: true, skip_blanks: true)
   end
 
   def add_conviction_record(conviction)
-    attributes = convert_array_to_attributes_hash(conviction)
+    attributes = prepare_attributes(conviction)
     WasteCarriersEngine::ConvictionsCheck::Entity.new(attributes).save
   end
 
-  def convert_array_to_attributes_hash(conviction)
+  def prepare_attributes(conviction)
     {
-      name: conviction[0],
-      date_of_birth: conviction[1],
-      company_number: conviction[2],
-      system_flag: conviction[3],
-      incident_number: conviction[4]
+      name: conviction["Offender"],
+      date_of_birth: conviction["Birth Date"],
+      company_number: conviction["Company No."],
+      system_flag: conviction["System Flag"],
+      incident_number: conviction["Inc Number"]
     }
   end
 end

--- a/app/services/conviction_import_service.rb
+++ b/app/services/conviction_import_service.rb
@@ -2,6 +2,9 @@
 
 require "csv"
 
+class InvalidCSVError < StandardError; end
+class InvalidConvictionDataError < StandardError; end
+
 class ConvictionImportService < ::WasteCarriersEngine::BaseService
   def run(csv)
     convictions_data = parse_data(csv)
@@ -19,9 +22,13 @@ class ConvictionImportService < ::WasteCarriersEngine::BaseService
               headers: true,
               liberal_parsing: true,
               skip_blanks: true)
+  rescue StandardError
+    raise InvalidCSVError
   end
 
   def add_conviction_record(conviction)
+    validate_conviction_data(conviction)
+
     attributes = prepare_attributes(conviction)
     WasteCarriersEngine::ConvictionsCheck::Entity.new(attributes).save
   end
@@ -34,5 +41,21 @@ class ConvictionImportService < ::WasteCarriersEngine::BaseService
       system_flag: conviction["System Flag"],
       incident_number: conviction["Inc Number"]
     }
+  end
+
+  def validate_conviction_data(data)
+    valid_headers?(data) && name_is_present?(data)
+  end
+
+  def valid_headers?(data)
+    return true if data.headers == ["Offender", "Birth Date", "Company No.", "System Flag", "Inc Number"]
+
+    raise InvalidConvictionDataError, "Invalid headers"
+  end
+
+  def name_is_present?(data)
+    return true if data["Offender"].present?
+
+    raise InvalidConvictionDataError, "Offender name missing"
   end
 end

--- a/app/services/conviction_import_service.rb
+++ b/app/services/conviction_import_service.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+require "csv"
+
 class ConvictionImportService < ::WasteCarriersEngine::BaseService
-  def run; end
+  def run(csv)
+    CSV.parse(csv, liberal_parsing: true, skip_blanks: true)
+  end
 end

--- a/app/services/conviction_import_service.rb
+++ b/app/services/conviction_import_service.rb
@@ -49,12 +49,14 @@ class ConvictionImportService < ::WasteCarriersEngine::BaseService
   end
 
   def prepare_attributes(conviction)
+    # Strip whitespace from each one if possible, then call 'presence'
+    # to return nil instead of a blank string
     {
-      name: conviction["Offender"],
+      name: conviction["Offender"]&.strip.presence,
       date_of_birth: conviction["Birth Date"],
-      company_number: conviction["Company No."],
-      system_flag: conviction["System Flag"],
-      incident_number: conviction["Inc Number"]
+      company_number: conviction["Company No."]&.strip.presence,
+      system_flag: conviction["System Flag"]&.strip.presence,
+      incident_number: conviction["Inc Number"]&.strip.presence
     }
   end
 

--- a/app/services/conviction_import_service.rb
+++ b/app/services/conviction_import_service.rb
@@ -4,6 +4,33 @@ require "csv"
 
 class ConvictionImportService < ::WasteCarriersEngine::BaseService
   def run(csv)
+    convictions_data = parse_data(csv)
+
+    convictions_data.each do |line|
+      add_conviction_record(line)
+    end
+
+    convictions_data
+  end
+
+  private
+
+  def parse_data(csv)
     CSV.parse(csv, liberal_parsing: true, skip_blanks: true)
+  end
+
+  def add_conviction_record(conviction)
+    attributes = convert_array_to_attributes_hash(conviction)
+    WasteCarriersEngine::ConvictionsCheck::Entity.new(attributes).save
+  end
+
+  def convert_array_to_attributes_hash(conviction)
+    {
+      name: conviction[0],
+      date_of_birth: conviction[1],
+      company_number: conviction[2],
+      system_flag: conviction[3],
+      incident_number: conviction[4]
+    }
   end
 end

--- a/app/services/conviction_import_service.rb
+++ b/app/services/conviction_import_service.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class ConvictionImportService < ::WasteCarriersEngine::BaseService
+  def run; end
+end

--- a/spec/services/conviction_import_service_spec.rb
+++ b/spec/services/conviction_import_service_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe ConvictionImportService do
 Offender,Birth Date,Company No.,System Flag,Inc Number
 Apex Limited,,11111111,ABC,99999999
 "Doe, John",01/01/1991,,DFG,
+   Whitespace Inc   , , , ,
 )
       end
 
@@ -45,6 +46,18 @@ Apex Limited,,11111111,ABC,99999999
         )
 
         expect { run_service }.to change { matching_person_conviction.count }.from(0).to(1)
+      end
+
+      it "trims excess whitespace" do
+        matching_trimmed_conviction = WasteCarriersEngine::ConvictionsCheck::Entity.where(
+          name: "Whitespace Inc",
+          date_of_birth: nil,
+          company_number: nil,
+          system_flag: nil,
+          incident_number: nil
+        )
+
+        expect { run_service }.to change { matching_trimmed_conviction.count }.from(0).to(1)
       end
 
       it "destroys the old convictions" do

--- a/spec/services/conviction_import_service_spec.rb
+++ b/spec/services/conviction_import_service_spec.rb
@@ -25,6 +25,30 @@ Apex Limited,,11111111,ABC,99999999
 
         expect(run_service).to eq(array_data)
       end
+
+      it "creates valid business convictions" do
+        matching_business_conviction = WasteCarriersEngine::ConvictionsCheck::Entity.where(
+          name: "Apex Limited",
+          date_of_birth: nil,
+          company_number: "11111111",
+          system_flag: "ABC",
+          incident_number: "99999999"
+        )
+
+        expect { run_service }.to change { matching_business_conviction.count }.from(0).to(1)
+      end
+
+      it "creates valid person convictions" do
+        matching_person_conviction = WasteCarriersEngine::ConvictionsCheck::Entity.where(
+          name: "Doe, John",
+          date_of_birth: "01/01/1991",
+          company_number: nil,
+          system_flag: "DFG",
+          incident_number: nil
+        )
+
+        expect { run_service }.to change { matching_person_conviction.count }.from(0).to(1)
+      end
     end
   end
 end

--- a/spec/services/conviction_import_service_spec.rb
+++ b/spec/services/conviction_import_service_spec.rb
@@ -3,13 +3,28 @@
 require "rails_helper"
 
 RSpec.describe ConvictionImportService do
+  let(:csv) {}
   let(:run_service) do
-    ConvictionImportService.run
+    ConvictionImportService.run(csv)
   end
 
   describe "#run" do
-    it "runs" do
-      expect { run_service }.to_not raise_error
+    context "when given CSV in a string as an argument" do
+      let(:csv) do
+        %(
+Apex Limited,,11111111,ABC,99999999
+"Doe, John",01/01/1991,,DFG,
+)
+      end
+
+      it "returns an array of arrays" do
+        array_data = [
+          ["Apex Limited", nil, "11111111", "ABC", "99999999"],
+          ["Doe, John", "01/01/1991", nil, "DFG", nil]
+        ]
+
+        expect(run_service).to eq(array_data)
+      end
     end
   end
 end

--- a/spec/services/conviction_import_service_spec.rb
+++ b/spec/services/conviction_import_service_spec.rb
@@ -33,7 +33,7 @@ Apex Limited,,11111111,ABC,99999999
       it "creates valid person convictions" do
         matching_person_conviction = WasteCarriersEngine::ConvictionsCheck::Entity.where(
           name: "Doe, John",
-          date_of_birth: "01/01/1991",
+          date_of_birth: Date.new(1991, 1, 1),
           company_number: nil,
           system_flag: "DFG",
           incident_number: nil

--- a/spec/services/conviction_import_service_spec.rb
+++ b/spec/services/conviction_import_service_spec.rb
@@ -12,18 +12,10 @@ RSpec.describe ConvictionImportService do
     context "when given CSV in a string as an argument" do
       let(:csv) do
         %(
+Offender,Birth Date,Company No.,System Flag,Inc Number
 Apex Limited,,11111111,ABC,99999999
 "Doe, John",01/01/1991,,DFG,
 )
-      end
-
-      it "returns an array of arrays" do
-        array_data = [
-          ["Apex Limited", nil, "11111111", "ABC", "99999999"],
-          ["Doe, John", "01/01/1991", nil, "DFG", nil]
-        ]
-
-        expect(run_service).to eq(array_data)
       end
 
       it "creates valid business convictions" do

--- a/spec/services/conviction_import_service_spec.rb
+++ b/spec/services/conviction_import_service_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ConvictionImportService do
+  let(:run_service) do
+    ConvictionImportService.run
+  end
+
+  describe "#run" do
+    it "runs" do
+      expect { run_service }.to_not raise_error
+    end
+  end
+end

--- a/spec/services/conviction_import_service_spec.rb
+++ b/spec/services/conviction_import_service_spec.rb
@@ -9,6 +9,11 @@ RSpec.describe ConvictionImportService do
   end
 
   describe "#run" do
+    let(:old_conviction_name) { "Old Conviction" }
+    before do
+      WasteCarriersEngine::ConvictionsCheck::Entity.new(name: old_conviction_name).save
+    end
+
     context "when given CSV in a string as an argument" do
       let(:csv) do
         %(
@@ -41,40 +46,54 @@ Apex Limited,,11111111,ABC,99999999
 
         expect { run_service }.to change { matching_person_conviction.count }.from(0).to(1)
       end
+
+      it "destroys the old convictions" do
+        old_conviction = WasteCarriersEngine::ConvictionsCheck::Entity.where(name: old_conviction_name)
+
+        expect { run_service }.to change { old_conviction.count }.from(1).to(0)
+      end
     end
-  end
 
-  context "when valid CSV data is not provided" do
-    let(:csv) { :not_a_csv }
+    context "when valid CSV data is not provided" do
+      let(:csv) { :not_a_csv }
 
-    it "raises an InvalidCSVError" do
-      expect { run_service }.to raise_error(InvalidCSVError)
+      it "raises an InvalidCSVError and doesn't update any conviction data" do
+        old_conviction = WasteCarriersEngine::ConvictionsCheck::Entity.where(name: old_conviction_name)
+
+        expect { run_service }.to raise_error(InvalidCSVError).and change { old_conviction.count }.by(0)
+      end
     end
-  end
 
-  context "when the CSV does not contain valid convictions headers" do
-    let(:csv) do
-      %(
+    context "when the CSV does not contain valid convictions headers" do
+      let(:csv) do
+        %(
 Ingredient,Quantity,Measurement
 flour,1,cup
 baking soda,2,tablespoons
 )
-    end
-
-    it "raises an InvalidConvictionDataError" do
-      expect { run_service }.to raise_error(InvalidConvictionDataError, "Invalid headers")
-    end
-
-    context "when the CSV does not contain offender names" do
-      let(:csv) do
-        %(
-Offender,Birth Date,Company No.,System Flag,Inc Number
-,,11111111,ABC,99999999
-)
       end
 
-      it "raises an InvalidConvictionDataError" do
-        expect { run_service }.to raise_error(InvalidConvictionDataError, "Offender name missing")
+      it "raises an InvalidConvictionDataError and doesn't update any conviction data" do
+        old_conviction = WasteCarriersEngine::ConvictionsCheck::Entity.where(name: old_conviction_name)
+
+        expect { run_service }.to raise_error(InvalidConvictionDataError, "Invalid headers").and change { old_conviction.count }.by(0)
+      end
+
+      context "when the CSV does not contain offender names" do
+        let(:csv) do
+          %(
+Offender,Birth Date,Company No.,System Flag,Inc Number
+Apex Limited,,11111111,ABC,99999999
+,,11111111,ABC,99999999
+)
+        end
+
+        it "raises an InvalidConvictionDataError and doesn't update any conviction data" do
+          old_conviction = WasteCarriersEngine::ConvictionsCheck::Entity.where(name: old_conviction_name)
+          new_conviction = WasteCarriersEngine::ConvictionsCheck::Entity.where(name: "Apex Limited")
+
+          expect { run_service }.to raise_error(InvalidConvictionDataError, "Offender name missing").and change { old_conviction.count }.by(0).and change { new_conviction.count }.by(0)
+        end
       end
     end
   end

--- a/spec/services/conviction_import_service_spec.rb
+++ b/spec/services/conviction_import_service_spec.rb
@@ -43,4 +43,39 @@ Apex Limited,,11111111,ABC,99999999
       end
     end
   end
+
+  context "when valid CSV data is not provided" do
+    let(:csv) { :not_a_csv }
+
+    it "raises an InvalidCSVError" do
+      expect { run_service }.to raise_error(InvalidCSVError)
+    end
+  end
+
+  context "when the CSV does not contain valid convictions headers" do
+    let(:csv) do
+      %(
+Ingredient,Quantity,Measurement
+flour,1,cup
+baking soda,2,tablespoons
+)
+    end
+
+    it "raises an InvalidConvictionDataError" do
+      expect { run_service }.to raise_error(InvalidConvictionDataError, "Invalid headers")
+    end
+
+    context "when the CSV does not contain offender names" do
+      let(:csv) do
+        %(
+Offender,Birth Date,Company No.,System Flag,Inc Number
+,,11111111,ABC,99999999
+)
+      end
+
+      it "raises an InvalidConvictionDataError" do
+        expect { run_service }.to raise_error(InvalidConvictionDataError, "Offender name missing")
+      end
+    end
+  end
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-772

Currently our convictions data is updated using the old waste-carriers-service in Java. We want to decomission that so we need a way for our new codebase to update the data.

This PR sets up a new ConvictionImportService which is designed to take raw data and update our list of convictions in the database.