### PR TITLE
Unify refund headers

### DIFF
--- a/app/views/refunds/new.html.erb
+++ b/app/views/refunds/new.html.erb
@@ -3,11 +3,7 @@
     <%= render("waste_carriers_engine/shared/back", back_path: finance_details_refunds_path(@registration._id)) %>
 
     <h1 class="heading-large">
-      <% if @payment.worldpay? || @payment.worldpay_missed? %>
-        <%= t(".heading.card") %>
-      <% else %>
-        <%= t(".heading.cash") %>
-      <% end %>
+      <%= t(".heading") %>
     </h1>
   </div>
 </div>

--- a/config/locales/refunds.en.yml
+++ b/config/locales/refunds.en.yml
@@ -21,9 +21,7 @@ en:
       refund_payment_alt: "Refund payment from %{date} by %{method} for %{amount}"
     new:
       title: "Confirm refund"
-      heading:
-        card: "Confirm the card payment refund"
-        cash: "Confirm the cash payment refund"
+      heading: "Confirm the payment refund"
       transaction_to_refund: "Transaction to refund"
       total_amount_paid: "Total amount paid"
       total_amount_due: "Total amount due"


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-811

QA have decided that the header distinguishing between only `card` and `cash` is confusing, and have decided to change the wireframe to unify the feature under a unique header instead.