### PR TITLE
Add page to import convictions

### DIFF
--- a/app/controllers/conviction_imports_controller.rb
+++ b/app/controllers/conviction_imports_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class ConvictionImportsController < ApplicationController
+  before_action :authorize
+
+  def new; end
+
+  def create
+    redirect_to bo_path
+  end
+
+  private
+
+  def authorize
+    authorize! :import_conviction_data, current_user
+  end
+end

--- a/app/controllers/conviction_imports_controller.rb
+++ b/app/controllers/conviction_imports_controller.rb
@@ -6,6 +6,7 @@ class ConvictionImportsController < ApplicationController
   def new; end
 
   def create
+    add_flash_message
     redirect_to bo_path
   end
 
@@ -13,5 +14,14 @@ class ConvictionImportsController < ApplicationController
 
   def authorize
     authorize! :import_conviction_data, current_user
+  end
+
+  def add_flash_message
+    conviction_records_count = WasteCarriersEngine::ConvictionsCheck::Entity.count
+
+    flash[:success] = I18n.t(
+      "conviction_imports.flash_messages.successful",
+      count: conviction_records_count
+    )
   end
 end

--- a/app/controllers/conviction_imports_controller.rb
+++ b/app/controllers/conviction_imports_controller.rb
@@ -6,8 +6,12 @@ class ConvictionImportsController < ApplicationController
   def new; end
 
   def create
-    add_flash_message
-    redirect_to bo_path
+    if data_updated_successfully?
+      add_success_flash_message
+      redirect_to bo_path
+    else
+      render :new
+    end
   end
 
   private
@@ -16,12 +20,27 @@ class ConvictionImportsController < ApplicationController
     authorize! :import_conviction_data, current_user
   end
 
-  def add_flash_message
+  def data_updated_successfully?
+    ConvictionImportService.run(params[:data])
+    true
+  rescue StandardError => e
+    add_error_flash_message(e)
+    false
+  end
+
+  def add_success_flash_message
     conviction_records_count = WasteCarriersEngine::ConvictionsCheck::Entity.count
 
     flash[:success] = I18n.t(
       "conviction_imports.flash_messages.successful",
       count: conviction_records_count
+    )
+  end
+
+  def add_error_flash_message(error)
+    flash[:error] = I18n.t(
+      "conviction_imports.flash_messages.error",
+      error: error
     )
   end
 end

--- a/app/views/conviction_imports/new.html.erb
+++ b/app/views/conviction_imports/new.html.erb
@@ -8,8 +8,35 @@
 
     <p><%= t(".paragraph_1") %></p>
 
-    <%= button_to t(".button"),
-                  conviction_imports_path,
-                  class: "button" %>
+    <%= render("shared/error", message: flash[:error], details: flash[:error_details]) if flash[:error].present? %>
+
+    <%= form_tag(conviction_imports_path) do %>
+      <div class="form-group">
+        <label class="form-label" for="data">
+          <%= t(".textarea_label") %>
+          <span class="form-hint">
+            <%= t(".textarea_hint_1") %>
+            <br>
+            <%= t(".textarea_hint_2") %>
+          </span>
+        </label>
+        <%= text_area_tag :data, nil, rows: 10, class: "form-control form-control-3-4" %>
+      </div>
+
+      <div class="form-group">
+        <div class="notice">
+          <i class="icon icon-important">
+            <span class="visually-hidden">Warning</span>
+          </i>
+          <strong class="bold-small">
+            <%= t(".warning") %>
+          </strong>
+        </div>
+      </div>
+
+      <div class="form-group">
+        <%= submit_tag t(".button"), class: "button" %>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/conviction_imports/new.html.erb
+++ b/app/views/conviction_imports/new.html.erb
@@ -1,0 +1,15 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render("waste_carriers_engine/shared/back", back_path: bo_path) %>
+
+    <h1 class="heading-large">
+      <%= t(".heading") %>
+    </h1>
+
+    <p><%= t(".paragraph_1") %></p>
+
+    <%= button_to t(".button"),
+                  conviction_imports_path,
+                  class: "button" %>
+  </div>
+</div>

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -19,6 +19,7 @@
 
 <div class="grid-row">
   <div class="column-full">
+    <%= render("shared/success", message: flash[:success]) if flash[:success].present? %>
     <%= render("shared/message", message: flash[:message]) if flash[:message].present? %>
   </div>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,6 +29,12 @@
                               main_app.users_path %>
                 </li>
               <% end %>
+              <% if can?(:import_conviction_data, current_user) %>
+                <li>
+                  <%= link_to t("layouts.application.menu.conviction_imports"),
+                              main_app.conviction_imports_path %>
+                </li>
+              <% end %>
             </ul>
           </nav>
       <% else %>

--- a/config/locales/conviction_imports.en.yml
+++ b/config/locales/conviction_imports.en.yml
@@ -7,3 +7,4 @@ en:
       button: "Submit data"
     flash_messages:
       successful: "Convictions data has been updated successfully. %{count} records in database."
+      error: "Error occurred while importing data: %{error}"

--- a/config/locales/conviction_imports.en.yml
+++ b/config/locales/conviction_imports.en.yml
@@ -10,5 +10,7 @@ en:
       warning: "This will overwrite all existing conviction data."
       button: "Submit data"
     flash_messages:
-      successful: "Convictions data has been updated successfully. %{count} records in database."
+      successful:
+        one: "Convictions data has been updated successfully. %{count} record in database."
+        other: "Convictions data has been updated successfully. %{count} records in database."
       error: "Error occurred while importing data: %{error}"

--- a/config/locales/conviction_imports.en.yml
+++ b/config/locales/conviction_imports.en.yml
@@ -1,0 +1,7 @@
+en:
+  conviction_imports:
+    new:
+      title: "Import conviction data"
+      heading: "Import conviction data"
+      paragraph_1: "Paste a CSV into this text field to replace the existing convictions data."
+      button: "Submit data"

--- a/config/locales/conviction_imports.en.yml
+++ b/config/locales/conviction_imports.en.yml
@@ -5,3 +5,5 @@ en:
       heading: "Import conviction data"
       paragraph_1: "Paste a CSV into this text field to replace the existing convictions data."
       button: "Submit data"
+    flash_messages:
+      successful: "Convictions data has been updated successfully. %{count} records in database."

--- a/config/locales/conviction_imports.en.yml
+++ b/config/locales/conviction_imports.en.yml
@@ -3,7 +3,11 @@ en:
     new:
       title: "Import conviction data"
       heading: "Import conviction data"
-      paragraph_1: "Paste a CSV into this text field to replace the existing convictions data."
+      paragraph_1: "The service uses this data when checking for conviction matches. To update the matches, paste the contents of a CSV of convictions into the textarea."
+      textarea_label: "Convictions data"
+      textarea_hint_1: "The first line must be the headers, for example:"
+      textarea_hint_2: "Offender,Birth Date,Company No.,System Flag,Inc Number"
+      warning: "This will overwrite all existing conviction data."
       button: "Submit data"
     flash_messages:
       successful: "Convictions data has been updated successfully. %{count} records in database."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,6 +8,7 @@ en:
         dashboard: "Registrations search"
         convictions: "Conviction checks"
         users: "Manage users"
+        conviction_imports: "Import conviction data"
   shared:
     conviction_search_result:
       match_result: "Match result"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -157,6 +157,11 @@ Rails.application.routes.draw do
       to: "user_migrations#results",
       as: :user_migration_results
 
+  resources :conviction_imports,
+            only: %i[new create],
+            path: "/bo/import-convictions",
+            path_names: { new: "" }
+
   mount DefraRubyMocks::Engine => "/bo/mocks"
 
   mount WasteCarriersEngine::Engine => "/bo", as: "basic_app_engine"

--- a/spec/requests/conviction_imports_spec.rb
+++ b/spec/requests/conviction_imports_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "ConvictionImports", type: :request do
+  describe "GET /bo/import-convictions" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user, :developer) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      it "renders the new template" do
+        get "/bo/import-convictions"
+        expect(response).to render_template(:new)
+      end
+
+      it "returns a 200 response" do
+        get "/bo/import-convictions"
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context "when a non-developer user is signed in" do
+      let(:user) { create(:user, :agency) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      it "redirects to the permissions error page" do
+        get "/bo/import-convictions"
+        expect(response).to redirect_to("/bo/pages/permission")
+      end
+    end
+  end
+
+  describe "POST /bo/import-convictions" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user, :developer) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      it "redirects to the results page" do
+        post "/bo/import-convictions"
+        expect(response).to redirect_to("/bo")
+      end
+    end
+
+    context "when a non-developer user is signed in" do
+      let(:user) { create(:user, :agency) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      it "redirects to the permissions error page" do
+        post "/bo/import-convictions"
+        expect(response).to redirect_to("/bo/pages/permission")
+      end
+    end
+  end
+end

--- a/spec/requests/conviction_imports_spec.rb
+++ b/spec/requests/conviction_imports_spec.rb
@@ -35,6 +35,17 @@ RSpec.describe "ConvictionImports", type: :request do
   end
 
   describe "POST /bo/import-convictions" do
+    let(:params) do
+      {
+        data: %(
+Offender,Birth Date,Company No.,System Flag,Inc Number
+Apex Limited,,11111111,ABC,99999999
+"Doe, John",01/01/1991,,DFG,
+   Whitespace Inc   , , , ,
+)
+      }
+    end
+
     context "when a valid user is signed in" do
       let(:user) { create(:user, :developer) }
       before(:each) do
@@ -42,9 +53,21 @@ RSpec.describe "ConvictionImports", type: :request do
       end
 
       it "redirects to the results page and displays a flash message" do
-        post "/bo/import-convictions"
+        post "/bo/import-convictions", params
+
         expect(response).to redirect_to("/bo")
-        expect(request.flash[:success]).to eq("Convictions data has been updated successfully. 0 records in database.")
+        expect(request.flash[:success]).to eq("Convictions data has been updated successfully. 3 records in database.")
+      end
+
+      context "when invalid data is submitted" do
+        let(:params) { { data: "foo" } }
+
+        it "redirects to the :new template and displays an error message" do
+          post "/bo/import-convictions", params
+
+          expect(response).to render_template(:new)
+          expect(request.flash[:error]).to eq("Error occurred while importing data: Invalid headers")
+        end
       end
     end
 
@@ -55,7 +78,7 @@ RSpec.describe "ConvictionImports", type: :request do
       end
 
       it "redirects to the permissions error page" do
-        post "/bo/import-convictions"
+        post "/bo/import-convictions", params
         expect(response).to redirect_to("/bo/pages/permission")
       end
     end

--- a/spec/requests/conviction_imports_spec.rb
+++ b/spec/requests/conviction_imports_spec.rb
@@ -41,9 +41,10 @@ RSpec.describe "ConvictionImports", type: :request do
         sign_in(user)
       end
 
-      it "redirects to the results page" do
+      it "redirects to the results page and displays a flash message" do
         post "/bo/import-convictions"
         expect(response).to redirect_to("/bo")
+        expect(request.flash[:success]).to eq("Convictions data has been updated successfully. 0 records in database.")
       end
     end
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-772

We want to be able to update conviction check data through the app, rather than using the existing Java service or directly updating the database.

For this we want a new page with a text box, some content that explains what it's for, a warning and a continue button. Submitting a valid CSV in this text box should call the ConvictionImportService and update the data.

Only developer users should be able to access this feature.