### PR TITLE
Fix bug in BOXI export

### DIFF
--- a/app/presenters/reports/boxi/sign_off_presenter.rb
+++ b/app/presenters/reports/boxi/sign_off_presenter.rb
@@ -3,10 +3,6 @@
 module Reports
   module Boxi
     class SignOffPresenter < WasteCarriersEngine::BasePresenter
-      def confirmed
-        super&.to_datetime&.to_formatted_s(:calendar_date_and_local_time)
-      end
-
       def confirmed_at
         super&.to_datetime&.to_formatted_s(:calendar_date_and_local_time)
       end

--- a/spec/presenters/reports/boxi/sign_off_presenter_spec.rb
+++ b/spec/presenters/reports/boxi/sign_off_presenter_spec.rb
@@ -9,14 +9,6 @@ module Reports
 
       subject { described_class.new(payment, nil) }
 
-      describe "#confirmed" do
-        it "returns a formatted date" do
-          expect(payment).to receive(:confirmed).and_return(Date.new(2019, 11, 11))
-
-          expect(subject.confirmed).to eq("2019-11-11T00:00Z")
-        end
-      end
-
       describe "#confirmed_at" do
         it "returns a formatted date" do
           expect(payment).to receive(:confirmed_at).and_return(Date.new(2019, 11, 11))

--- a/spec/services/reports/generate_boxi_files_service_spec.rb
+++ b/spec/services/reports/generate_boxi_files_service_spec.rb
@@ -9,7 +9,7 @@ module Reports
   RSpec.describe GenerateBoxiFilesService do
     describe ".run" do
       it "generates CSV files for the boxi exports in a given folder" do
-        create(:registration, :has_orders_and_payments)
+        create(:registration, :has_orders_and_payments, :has_flagged_conviction_check)
 
         temp_dir = Dir.mktmpdir
 
@@ -19,43 +19,50 @@ module Reports
         addresses_file_path = File.join(temp_dir, "addresses.csv")
 
         expect(File.exist?(addresses_file_path)).to be_truthy
-        expect(File.read(addresses_file_path)).to_not be_empty
+        file_lines = File.readlines(addresses_file_path)
+        expect(file_lines.count).to be >= 2
 
         # Test key_people file gets created
         key_people_path = File.join(temp_dir, "key_people.csv")
 
         expect(File.exist?(key_people_path)).to be_truthy
-        expect(File.read(key_people_path)).to_not be_empty
+        file_lines = File.readlines(key_people_path)
+        expect(file_lines.count).to be >= 2
 
         # Test order_items file gets created
         order_items_path = File.join(temp_dir, "order_items.csv")
 
         expect(File.exist?(order_items_path)).to be_truthy
-        expect(File.read(order_items_path)).to_not be_empty
+        file_lines = File.readlines(order_items_path)
+        expect(file_lines.count).to be >= 2
 
         # Test order file gets created
         orders_path = File.join(temp_dir, "orders.csv")
 
         expect(File.exist?(orders_path)).to be_truthy
-        expect(File.read(orders_path)).to_not be_empty
+        file_lines = File.readlines(orders_path)
+        expect(file_lines.count).to be >= 2
 
         # Test payments file gets created
         orders_path = File.join(temp_dir, "payments.csv")
 
         expect(File.exist?(orders_path)).to be_truthy
-        expect(File.read(orders_path)).to_not be_empty
+        file_lines = File.readlines(orders_path)
+        expect(file_lines.count).to be >= 2
 
         # Test registrations file gets created
         registrations_path = File.join(temp_dir, "registrations.csv")
 
         expect(File.exist?(registrations_path)).to be_truthy
-        expect(File.read(registrations_path)).to_not be_empty
+        file_lines = File.readlines(registrations_path)
+        expect(file_lines.count).to be >= 2
 
         # Test sign_offs file gets created
         sign_offs_path = File.join(temp_dir, "sign_offs.csv")
 
         expect(File.exist?(sign_offs_path)).to be_truthy
-        expect(File.read(sign_offs_path)).to_not be_empty
+        file_lines = File.readlines(sign_offs_path)
+        expect(file_lines.count).to be >= 2
       end
     end
   end


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-738

This fixes a bug in the generation of sign_offs files.
It also enhance the test so that we are sure we are at least testing a base scenario for insertion in all files. The curent code was never actually testing that a sign_off object passed through the feature without errors, we only had unit test coverage for it.