### PR TITLE
Fix dates in boxi export

### DIFF
--- a/app/models/reports/boxi/order_items_serializer.rb
+++ b/app/models/reports/boxi/order_items_serializer.rb
@@ -24,13 +24,15 @@ module Reports
       private
 
       def parse_order_item(order_item, uid, order_uid)
+        presenter = OrderItemPresenter.new(order_item, nil)
+
         ATTRIBUTES.map do |key, _value|
           if key == :uid
             uid
           elsif key == :order_uid
             order_uid
           else
-            order_item.public_send(key)
+            presenter.public_send(key)
           end
         end
       end

--- a/app/models/reports/boxi/orders_serializer.rb
+++ b/app/models/reports/boxi/orders_serializer.rb
@@ -25,13 +25,15 @@ module Reports
       private
 
       def parse_order(order, uid, order_uid)
+        presenter = OrderPresenter.new(order, nil)
+
         ATTRIBUTES.map do |key, _value|
           if key == :uid
             uid
           elsif key == :order_uid
             order_uid
           else
-            order.public_send(key)
+            presenter.public_send(key)
           end
         end
       end

--- a/app/presenters/reports/boxi/key_person_presenter.rb
+++ b/app/presenters/reports/boxi/key_person_presenter.rb
@@ -8,7 +8,7 @@ module Reports
       end
 
       def review_flag_timestamp
-        conviction_search_result&.searched_at
+        conviction_search_result&.searched_at&.to_datetime&.to_formatted_s(:calendar_date_and_local_time)
       end
     end
   end

--- a/app/presenters/reports/boxi/order_item_presenter.rb
+++ b/app/presenters/reports/boxi/order_item_presenter.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Reports
+  module Boxi
+    class OrderItemPresenter < WasteCarriersEngine::BasePresenter
+      def last_updated
+        super&.to_datetime&.to_formatted_s(:calendar_date_and_local_time)
+      end
+    end
+  end
+end

--- a/app/presenters/reports/boxi/order_presenter.rb
+++ b/app/presenters/reports/boxi/order_presenter.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Reports
+  module Boxi
+    class OrderPresenter < WasteCarriersEngine::BasePresenter
+      def date_created
+        super&.to_datetime&.to_formatted_s(:calendar_date_and_local_time)
+      end
+
+      def date_last_updated
+        super&.to_datetime&.to_formatted_s(:calendar_date_and_local_time)
+      end
+    end
+  end
+end

--- a/spec/models/reports/boxi/order_items_serializer_spec.rb
+++ b/spec/models/reports/boxi/order_items_serializer_spec.rb
@@ -30,6 +30,7 @@ module Reports
 
         it "creates an entry in the csv for each order_item in the registration" do
           order = double(:order)
+          presenter = double(:presenter)
           order_item = double(:order_item)
           finance_details = double(:finance_details)
 
@@ -46,12 +47,13 @@ module Reports
           expect(registration).to receive(:finance_details).and_return(finance_details)
           expect(finance_details).to receive(:orders).and_return([order])
           expect(order).to receive(:order_items).and_return([order_item])
+          expect(OrderItemPresenter).to receive(:new).with(order_item, nil).and_return(presenter)
 
-          expect(order_item).to receive(:type).and_return("type")
-          expect(order_item).to receive(:amount).and_return("amount")
-          expect(order_item).to receive(:description).and_return("description")
-          expect(order_item).to receive(:reference).and_return("reference")
-          expect(order_item).to receive(:last_updated).and_return("last_updated")
+          expect(presenter).to receive(:type).and_return("type")
+          expect(presenter).to receive(:amount).and_return("amount")
+          expect(presenter).to receive(:description).and_return("description")
+          expect(presenter).to receive(:reference).and_return("reference")
+          expect(presenter).to receive(:last_updated).and_return("last_updated")
 
           expect(csv).to receive(:<<).with(values)
 

--- a/spec/models/reports/boxi/orders_serializer_spec.rb
+++ b/spec/models/reports/boxi/orders_serializer_spec.rb
@@ -34,6 +34,7 @@ module Reports
         it "creates an entry in the csv for each order in the registration" do
           order = double(:order)
           finance_details = double(:finance_details)
+          presenter = double(:presenter)
 
           values = [
             0,
@@ -50,15 +51,16 @@ module Reports
 
           expect(registration).to receive(:finance_details).and_return(finance_details)
           expect(finance_details).to receive(:orders).and_return([order])
+          expect(OrderPresenter).to receive(:new).with(order, nil).and_return(presenter)
 
-          expect(order).to receive(:order_code).and_return("order_code")
-          expect(order).to receive(:payment_method).and_return("payment_method")
-          expect(order).to receive(:total_amount).and_return("total_amount")
-          expect(order).to receive(:description).and_return("description")
-          expect(order).to receive(:merchant_id).and_return("merchant_id")
-          expect(order).to receive(:date_created).and_return("date_created")
-          expect(order).to receive(:date_last_updated).and_return("date_last_updated")
-          expect(order).to receive(:updated_by_user).and_return("updated_by_user")
+          expect(presenter).to receive(:order_code).and_return("order_code")
+          expect(presenter).to receive(:payment_method).and_return("payment_method")
+          expect(presenter).to receive(:total_amount).and_return("total_amount")
+          expect(presenter).to receive(:description).and_return("description")
+          expect(presenter).to receive(:merchant_id).and_return("merchant_id")
+          expect(presenter).to receive(:date_created).and_return("date_created")
+          expect(presenter).to receive(:date_last_updated).and_return("date_last_updated")
+          expect(presenter).to receive(:updated_by_user).and_return("updated_by_user")
 
           expect(csv).to receive(:<<).with(values)
 

--- a/spec/presenters/reports/boxi/key_person_presenter_spec.rb
+++ b/spec/presenters/reports/boxi/key_person_presenter_spec.rb
@@ -54,7 +54,7 @@ module Reports
             searched_at = Time.new(2019, 11, 19)
 
             expect(conviction_search_result).to receive(:searched_at).and_return(searched_at)
-            expect(subject.review_flag_timestamp).to eq("2019-11-19T00:00Z")
+            expect(subject.review_flag_timestamp.to_s).to eq("2019-11-19T00:00Z")
           end
         end
       end

--- a/spec/presenters/reports/boxi/order_item_presenter_spec.rb
+++ b/spec/presenters/reports/boxi/order_item_presenter_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Reports
+  module Boxi
+    RSpec.describe OrderItemPresenter do
+      let(:order_item) { double(:order_item) }
+
+      subject { described_class.new(order_item, nil) }
+
+      describe "#last_updated" do
+        it "returns the date as a formatted string" do
+          last_updated = Time.new(2019, 11, 19)
+
+          expect(order_item).to receive(:last_updated).and_return(last_updated)
+          expect(subject.last_updated.to_s).to eq("2019-11-19T00:00Z")
+        end
+      end
+    end
+  end
+end

--- a/spec/presenters/reports/boxi/order_presenter_spec.rb
+++ b/spec/presenters/reports/boxi/order_presenter_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Reports
+  module Boxi
+    RSpec.describe OrderPresenter do
+      let(:order) { double(:order) }
+
+      subject { described_class.new(order, nil) }
+
+      describe "#date_created" do
+        it "returns the date as a formatted string" do
+          date_created = Time.new(2019, 11, 19)
+
+          expect(order).to receive(:date_created).and_return(date_created)
+          expect(subject.date_created.to_s).to eq("2019-11-19T00:00Z")
+        end
+      end
+
+      describe "#date_last_updated" do
+        it "returns the date as a formatted string" do
+          date_last_updated = Time.new(2019, 11, 19)
+
+          expect(order).to receive(:date_last_updated).and_return(date_last_updated)
+          expect(subject.date_last_updated.to_s).to eq("2019-11-19T00:00Z")
+        end
+      end
+    end
+  end
+end

--- a/spec/presenters/reports/boxi/payment_presenter_spec.rb
+++ b/spec/presenters/reports/boxi/payment_presenter_spec.rb
@@ -13,7 +13,7 @@ module Reports
         it "returns a formatted date" do
           expect(payment).to receive(:date_received).and_return(Date.new(2019, 11, 11))
 
-          expect(subject.date_received).to eq("2019-11-11T00:00Z")
+          expect(subject.date_received.to_s).to eq("2019-11-11T00:00Z")
         end
       end
 
@@ -21,7 +21,7 @@ module Reports
         it "returns a formatted date" do
           expect(payment).to receive(:date_entered).and_return(Date.new(2019, 11, 11))
 
-          expect(subject.date_entered).to eq("2019-11-11T00:00Z")
+          expect(subject.date_entered.to_s).to eq("2019-11-11T00:00Z")
         end
       end
     end

--- a/spec/presenters/reports/boxi/registration_presenter_spec.rb
+++ b/spec/presenters/reports/boxi/registration_presenter_spec.rb
@@ -27,7 +27,7 @@ module Reports
           expect(registration).to receive(:metaData).and_return(metadata)
           expect(metadata).to receive(:date_registered).and_return(Date.new(2019, 11, 11))
 
-          expect(subject.metadata_date_registered).to eq("2019-11-11T00:00Z")
+          expect(subject.metadata_date_registered.to_s).to eq("2019-11-11T00:00Z")
         end
       end
 
@@ -38,7 +38,7 @@ module Reports
           expect(registration).to receive(:metaData).and_return(metadata)
           expect(metadata).to receive(:date_activated).and_return(Date.new(2019, 11, 11))
 
-          expect(subject.metadata_date_activated).to eq("2019-11-11T00:00Z")
+          expect(subject.metadata_date_activated.to_s).to eq("2019-11-11T00:00Z")
         end
       end
 
@@ -49,7 +49,7 @@ module Reports
           expect(registration).to receive(:metaData).and_return(metadata)
           expect(metadata).to receive(:last_modified).and_return(Date.new(2019, 11, 11))
 
-          expect(subject.metadata_date_last_modified).to eq("2019-11-11T00:00Z")
+          expect(subject.metadata_date_last_modified.to_s).to eq("2019-11-11T00:00Z")
         end
       end
 
@@ -60,7 +60,7 @@ module Reports
           expect(registration).to receive(:conviction_search_result).and_return(conviction_search_result)
           expect(conviction_search_result).to receive(:searched_at).and_return(Date.new(2019, 11, 11))
 
-          expect(subject.conviction_search_result_searched_at).to eq("2019-11-11T00:00Z")
+          expect(subject.conviction_search_result_searched_at.to_s).to eq("2019-11-11T00:00Z")
         end
       end
 
@@ -68,7 +68,7 @@ module Reports
         it "returns a formatted date" do
           expect(registration).to receive(:expires_on).and_return(Date.new(2019, 11, 11))
 
-          expect(subject.expires_on).to eq("2019-11-11T00:00Z")
+          expect(subject.expires_on.to_s).to eq("2019-11-11T00:00Z")
         end
       end
     end

--- a/spec/presenters/reports/boxi/sign_off_presenter_spec.rb
+++ b/spec/presenters/reports/boxi/sign_off_presenter_spec.rb
@@ -13,7 +13,7 @@ module Reports
         it "returns a formatted date" do
           expect(payment).to receive(:confirmed_at).and_return(Date.new(2019, 11, 11))
 
-          expect(subject.confirmed_at).to eq("2019-11-11T00:00Z")
+          expect(subject.confirmed_at.to_s).to eq("2019-11-11T00:00Z")
         end
       end
     end


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-738

There were multiple issues with dates on the boxi export. First, seems like RSpec `eq` will not cast a date to string authomatically, hence to reproduce the observed bug in the test suite I had to add a `:to_s` cast to all value returned by the method. Also, some serializers were missing a presenter entirely or the date were not casted using the correct time format.