### PR TITLE
Set a worldpay response type

### DIFF
--- a/app/services/process_refund_service.rb
+++ b/app/services/process_refund_service.rb
@@ -50,9 +50,7 @@ class ProcessRefundService < WasteCarriersEngine::BaseService
     refund.updated_by_user = user.email
     refund.comment = refund_comment
 
-    if card_payment?
-      refund.world_pay_payment_status = "AUTHORISED"
-    end
+    refund.world_pay_payment_status = "AUTHORISED" if card_payment?
 
     refund
   end

--- a/app/services/process_refund_service.rb
+++ b/app/services/process_refund_service.rb
@@ -50,6 +50,10 @@ class ProcessRefundService < WasteCarriersEngine::BaseService
     refund.updated_by_user = user.email
     refund.comment = refund_comment
 
+    if card_payment?
+      refund.world_pay_payment_status = "AUTHORISED"
+    end
+
     refund
   end
 
@@ -62,7 +66,7 @@ class ProcessRefundService < WasteCarriersEngine::BaseService
   end
 
   def refund_comment
-    return I18n.t("refunds.comments.card") if payment.worldpay?
+    return I18n.t("refunds.comments.card") if card_payment?
 
     I18n.t("refunds.comments.manual")
   end

--- a/spec/services/process_refund_service_spec.rb
+++ b/spec/services/process_refund_service_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe ProcessRefundService do
           expect(refund).to receive(:amount=).with(-500)
           expect(refund).to receive(:registration_reference=).with("registration_reference")
           expect(refund).to receive(:updated_by_user=).with("user@example.com")
+          expect(refund).to receive(:world_pay_payment_status=).with("AUTHORISED")
 
           expect(I18n).to receive(:t).with("refunds.comments.card").and_return(description)
           expect(refund).to receive(:comment=).with(description)


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-811

This adds the code that sets a worldpay status. In the old code, this is just arbitrarly set to `AUTHORISED`. This is used when showing that a payment has already been refunded, and as we want to show the user the same exact info as per old system, we need this value to be set.