### PR TITLE
ConvictionImportService validates DOB if provided

### DIFF
--- a/app/services/conviction_import_service.rb
+++ b/app/services/conviction_import_service.rb
@@ -67,8 +67,20 @@ class ConvictionImportService < ::WasteCarriersEngine::BaseService
   end
 
   def validate_row(row)
-    return if row["Offender"].present?
+    validate_name(row["Offender"]) && validate_date_of_birth(row["Birth Date"])
+  end
+
+  def validate_name(name)
+    return true if name.present?
 
     raise InvalidConvictionDataError, "Offender name missing"
+  end
+
+  def validate_date_of_birth(date_of_birth)
+    return true if date_of_birth.blank?
+
+    Date.parse(date_of_birth)
+  rescue ArgumentError
+    raise InvalidConvictionDataError, "Invalid date of birth"
   end
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-772

We spotted that when an invalid date of birth was entered, MongoDB subbed in a default date of 1/1/1970. We want to allow birthdates to be missing, or a valid date - otherwise, we should throw an error.