### PR TITLE
Redirect to BO dashboard after creating new account

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -32,6 +32,10 @@ class ApplicationController < ActionController::Base
     new_user_session_path
   end
 
+  def after_sign_up_path_for(*)
+    bo_path
+  end
+
   rescue_from CanCan::AccessDenied do
     redirect_to "/bo/pages/permission"
   end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-760

Previously BO users who created their an account through an invitation would be redirected to the old backend after setting a password. We want to redirect them to the new back office dashboard instead.