### PR TITLE
Fix broken 'Finished' link on renewal end pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,7 @@ gem "defra_ruby_aws", "~> 0.2.0"
 # Use the waste carriers engine for the user journey
 gem "waste_carriers_engine",
     git: "https://github.com/DEFRA/waste-carriers-engine",
-    branch: "master"
+    branch: "fix/renewal-finished-button"
 
 # Use the defra ruby mocks engine to add support for mocking external services
 # in live environment. Essentially with this gem added and enabled the app

--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,7 @@ gem "defra_ruby_aws", "~> 0.2.0"
 # Use the waste carriers engine for the user journey
 gem "waste_carriers_engine",
     git: "https://github.com/DEFRA/waste-carriers-engine",
-    branch: "fix/renewal-finished-button"
+    branch: "master"
 
 # Use the defra ruby mocks engine to add support for mocking external services
 # in live environment. Essentially with this gem added and enabled the app

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: a7ba0e71fa7706cc0112c4edd51c1d88b3ef9cf9
-  branch: master
+  revision: d30482d13b85915eed3c4b61fde9979576ef4cdb
+  branch: fix/renewal-finished-button
   specs:
     waste_carriers_engine (0.0.1)
       aasm (~> 4.12)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: d30482d13b85915eed3c4b61fde9979576ef4cdb
-  branch: fix/renewal-finished-button
+  revision: 22da686eef0025d478ecb0cdf2328d949fc6085d
+  branch: master
   specs:
     waste_carriers_engine (0.0.1)
       aasm (~> 4.12)

--- a/app/helpers/waste_carriers_engine/journey_links_helper.rb
+++ b/app/helpers/waste_carriers_engine/journey_links_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  module JourneyLinksHelper
+    def renewal_finished_link(reg_identifier:)
+      main_app.renewing_registration_path(reg_identifier: reg_identifier)
+    end
+  end
+end

--- a/config/locales/waste_carriers_engine.en.yml
+++ b/config/locales/waste_carriers_engine.en.yml
@@ -1,6 +1,5 @@
 en:
   waste_carriers_engine:
-    dashboard_link: "/registrations"
     renewal_received_forms:
       new:
         conviction_check_subheading: This renewal requires a conviction check

--- a/spec/helpers/waste_carriers_engine/journey_links_helper_spec.rb
+++ b/spec/helpers/waste_carriers_engine/journey_links_helper_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe WasteCarriersEngine::JourneyLinksHelper, type: :helper do
+    describe "renewal_finished_link" do
+      it "returns the correct value" do
+        reg_identifier = build(:renewing_registration).reg_identifier
+        expected_path = "/bo/renewing-registrations/#{reg_identifier}"
+
+        expect(helper.renewal_finished_link(reg_identifier: reg_identifier)).to eq(expected_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-859

We spotted that the 'Finished' button on the 'Renewal complete' and 'Renewal received' buttons was not behaving properly.

This PR overrides the new default in the engine to direct back office users to the 'view details' page. If the renewing registration no longer exists, they will be redirected to the page for the registration instead.

---

Depends on https://github.com/DEFRA/waste-carriers-engine/pull/647