### PR TITLE
Fix links to new payments

### DIFF
--- a/app/forms/payment_form.rb
+++ b/app/forms/payment_form.rb
@@ -70,6 +70,7 @@ class PaymentForm < WasteCarriersEngine::BaseForm
 
   def build_payment(params)
     params[:amount] = convert_amount_to_pence(params[:amount])
+
     self.payment = WasteCarriersEngine::Payment.new_from_non_worldpay(params, order)
   end
 

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -62,6 +62,9 @@ module ActionLinksHelper
   end
 
   def display_payment_link_for?(resource)
+    # TODO: Temporary - for release only. See: https://eaflood.atlassian.net/browse/RUBY-846
+    return false if a_registration?(resource)
+
     resource.upper_tier?
   end
 

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -62,9 +62,6 @@ module ActionLinksHelper
   end
 
   def display_payment_link_for?(resource)
-    # TODO: Temporary - for release only. See: https://eaflood.atlassian.net/browse/RUBY-846
-    return false if a_registration?(resource)
-
     resource.upper_tier?
   end
 

--- a/app/views/shared/registrations/_action_links_panel.html.erb
+++ b/app/views/shared/registrations/_action_links_panel.html.erb
@@ -52,7 +52,7 @@
 
     <% if display_payment_link_for?(resource) %>
       <li>
-        <%= link_to t(".actions_box.links.process_payment"), resource_payments_path(resource._id) %>
+        <%= link_to t(".actions_box.links.process_payment"), new_resource_payment_path(resource._id) %>
       </li>
     <% end %>
 

--- a/app/views/shared/registrations/_finance_action_links.html.erb
+++ b/app/views/shared/registrations/_finance_action_links.html.erb
@@ -1,6 +1,10 @@
 <div class="grid-row">
   <div class="column-full">
-    <%= link_to t(".enter_payment"), "#TODO", class: "button wcr-finance-button" %>
+
+    <% if display_payment_link_for?(registration) %>
+      <%= link_to t(".enter_payment"), new_resource_payment_path(registration._id), class: "button wcr-finance-button" %>
+    <% end %>
+
     <%= link_to t(".reverse_payment"), "#TODO", class: "button wcr-finance-button" %>
 
     <% if display_write_off_large_link_for?(registration.finance_details) %>

--- a/app/views/shared/registrations/_pending_payment_panel.html.erb
+++ b/app/views/shared/registrations/_pending_payment_panel.html.erb
@@ -6,6 +6,6 @@
     <%= t(".status.messages.pending_payment", total: display_pence_as_pounds(resource.finance_details.balance)) %>
   </p>
   <% if display_payment_link_for?(resource) %>
-    <%= link_to t(".status.actions.payment_button"), resource_payments_path(resource._id), class: 'button' %>
+    <%= link_to t(".status.actions.payment_button"), new_resource_payment_path(resource._id), class: 'button' %>
   <% end %>
 </div>


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-826

This fixes some incorrect links and the helper method to show payment links on registrations as well as transient registrations