### PR TITLE
Remove change to wrong presenter

### DIFF
--- a/app/presenters/payment_presenter.rb
+++ b/app/presenters/payment_presenter.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class PaymentPresenter < WasteCarriersEngine::BasePresenter
-  include FinanceDetailsHelper
-
   def self.create_from_collection(payments, view)
     payments.map do |payment|
       new(payment, view)
@@ -19,10 +17,6 @@ class PaymentPresenter < WasteCarriersEngine::BasePresenter
     else
       I18n.t(".refunds.refunded_message.manual")
     end
-  end
-
-  def amount
-    super && display_pence_as_pounds_and_cents(super)
   end
 
   private


### PR DESCRIPTION
This change was introduced in: https://github.com/DEFRA/waste-carriers-back-office/commit/8a65d6af
But, this is not a Boxi presenter, is used in the finance details views. Hence rolling it back to its previous status