### PR TITLE
Actually fix redirect after accepting user invite

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -32,7 +32,7 @@ class ApplicationController < ActionController::Base
     new_user_session_path
   end
 
-  def after_sign_up_path_for(*)
+  def after_accept_path_for(*)
     bo_path
   end
 

--- a/spec/requests/user_invitations_spec.rb
+++ b/spec/requests/user_invitations_spec.rb
@@ -88,4 +88,29 @@ RSpec.describe "User Invitations", type: :request do
       end
     end
   end
+
+  describe "PUT /bo/users/invitation" do
+    let(:user) { build(:user) }
+    let(:password) { attributes_for(:user)[:password] }
+    let(:params) do
+      {
+        user: {
+          password: password,
+          confirm_password: password,
+          invitation_token: user.raw_invitation_token
+        }
+      }
+    end
+
+    before do
+      user.invite!
+    end
+
+    context "when the user accepts an invitation and sets a valid password" do
+      it "redirects to the back office dashboard path" do
+        put "/bo/users/invitation", params
+        expect(response).to redirect_to(bo_path)
+      end
+    end
+  end
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-760

Previously BO users who created their an account through an invitation would be redirected to the old backend after setting a password. We want to redirect them to the new back office dashboard instead.

My last fix (https://github.com/DEFRA/waste-carriers-back-office/pull/617) didn't work as expected, so hoping this one will actually do the trick. This time we have tests!