### PR TITLE
Fix parsing carriage returns in BOXI export

### DIFF
--- a/app/models/reports/boxi/base_serializer.rb
+++ b/app/models/reports/boxi/base_serializer.rb
@@ -29,10 +29,20 @@ module Reports
         csv
       end
 
+      # This is designed to handle the different types of newline we may find
+      # in a string we are looking to export to a CSV file. For example we
+      # need to go from something like this
+      #
+      #    "regsitered in error!\r\nAG See Pat for info. "
+      #
+      # to this
+      #
+      #    "regsitered in error! AG See Pat for info."
+      #
       def sanitize(string)
-        return unless string.respond_to?(:gsub)
+        return unless string.respond_to?(:squish)
 
-        string.gsub("\n", ".")
+        string.squish
       end
     end
   end

--- a/spec/models/reports/boxi/addresses_serializer_spec.rb
+++ b/spec/models/reports/boxi/addresses_serializer_spec.rb
@@ -76,14 +76,14 @@ module Reports
         end
 
         it "sanitize data before inserting them in the csv" do
-          address = double(:address, address_line_1: "string to sanitize\n").as_null_object
+          address = double(:address, address_line_1: " string to\r\nsanitize\n").as_null_object
 
           allow(registration).to receive(:addresses).and_return([address])
           allow(CSV).to receive(:open).and_return(csv)
 
           allow(csv).to receive(:<<).with(headers)
 
-          expect(csv).to receive(:<<).with(array_including("string to sanitize."))
+          expect(csv).to receive(:<<).with(array_including("string to sanitize"))
 
           subject.add_entries_for(registration, 0)
         end

--- a/spec/models/reports/boxi/key_people_serializer_spec.rb
+++ b/spec/models/reports/boxi/key_people_serializer_spec.rb
@@ -56,7 +56,7 @@ module Reports
 
         it "sanitize data before inserting them in the csv" do
           key_person = double(:key_person)
-          presenter = double(:presenter, position: "string to sanitize\n").as_null_object
+          presenter = double(:presenter, position: " string to\r\nsanitize\n").as_null_object
 
           allow(registration).to receive(:key_people).and_return([key_person])
           allow(KeyPersonPresenter).to receive(:new).with(key_person, nil).and_return(presenter)
@@ -64,7 +64,7 @@ module Reports
           allow(CSV).to receive(:open).and_return(csv)
           allow(csv).to receive(:<<).with(headers)
 
-          expect(csv).to receive(:<<).with(array_including("string to sanitize."))
+          expect(csv).to receive(:<<).with(array_including("string to sanitize"))
 
           subject.add_entries_for(registration, 0)
         end

--- a/spec/models/reports/boxi/order_items_serializer_spec.rb
+++ b/spec/models/reports/boxi/order_items_serializer_spec.rb
@@ -60,7 +60,7 @@ module Reports
 
         it "sanitize data before inserting them in the csv" do
           order = double(:order)
-          presenter = double(:presenter, description: "string to sanitize\n").as_null_object
+          presenter = double(:presenter, description: " string to\r\nsanitize\n").as_null_object
           order_item = double(:order_item)
           finance_details = double(:finance_details)
 
@@ -72,7 +72,7 @@ module Reports
           allow(CSV).to receive(:open).and_return(csv)
           allow(csv).to receive(:<<).with(headers)
 
-          expect(csv).to receive(:<<).with(array_including("string to sanitize."))
+          expect(csv).to receive(:<<).with(array_including("string to sanitize"))
 
           subject.add_entries_for(registration, 0)
         end

--- a/spec/models/reports/boxi/orders_serializer_spec.rb
+++ b/spec/models/reports/boxi/orders_serializer_spec.rb
@@ -67,7 +67,7 @@ module Reports
 
         it "sanitize data before inserting them in the csv" do
           order = double(:order)
-          presenter = double(:presenter, description: "string to sanitize\n").as_null_object
+          presenter = double(:presenter, description: " string to\r\nsanitize\n").as_null_object
           finance_details = double(:finance_details)
 
           allow(registration).to receive(:finance_details).and_return(finance_details)
@@ -77,7 +77,7 @@ module Reports
           allow(CSV).to receive(:open).and_return(csv)
           allow(csv).to receive(:<<).with(headers)
 
-          expect(csv).to receive(:<<).with(array_including("string to sanitize."))
+          expect(csv).to receive(:<<).with(array_including("string to sanitize"))
 
           subject.add_entries_for(registration, 0)
         end

--- a/spec/models/reports/boxi/payments_serializer_spec.rb
+++ b/spec/models/reports/boxi/payments_serializer_spec.rb
@@ -64,7 +64,7 @@ module Reports
 
         it "sanitize data before inserting them in the csv" do
           payment = double(:payment)
-          presenter = double(:presenter, comment: "string to sanitize\n").as_null_object
+          presenter = double(:presenter, comment: " string to\r\nsanitize\n").as_null_object
           finance_details = double(:finance_details)
 
           allow(registration).to receive(:finance_details).and_return(finance_details)
@@ -74,7 +74,7 @@ module Reports
           allow(CSV).to receive(:open).and_return(csv)
           allow(csv).to receive(:<<).with(headers)
 
-          expect(csv).to receive(:<<).with(array_including("string to sanitize."))
+          expect(csv).to receive(:<<).with(array_including("string to sanitize"))
 
           subject.add_entries_for(registration, 0)
         end

--- a/spec/models/reports/boxi/registrations_serializer_spec.rb
+++ b/spec/models/reports/boxi/registrations_serializer_spec.rb
@@ -119,14 +119,14 @@ module Reports
         end
 
         it "sanitize data before inserting them in the csv" do
-          presenter = double(:presenter, metadata_revoked_reason: "string to sanitize\n").as_null_object
+          presenter = double(:presenter, metadata_revoked_reason: " string to\r\nsanitize\n").as_null_object
 
           allow(RegistrationPresenter).to receive(:new).with(registration, nil).and_return(presenter)
 
           allow(CSV).to receive(:open).and_return(csv)
           allow(csv).to receive(:<<).with(headers)
 
-          expect(csv).to receive(:<<).with(array_including("string to sanitize."))
+          expect(csv).to receive(:<<).with(array_including("string to sanitize"))
 
           subject.add_entries_for(registration, 0)
         end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-738

PR #625 tackled a number of issues including finding new lines in the text we are trying to export as CSV. However, it only looked for `"\n"` whereas subsequent tests of the export have highlighted it's actually full-blown carriage returns (`"\r\n"`) we have to deal with. This is no doubt a result that most users of our system are on Windows machines.

So this change is a slight tweak to the existing parser. Rather than getting too clever, we replace the existing `gsub` with a function built into Rails for just this purpose. So now we `squish` em!

https://apidock.com/rails/String/squish