### PR TITLE
View registration certificate in back office

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ env:
     - WCRS_WORLDPAY_MOTO_PASSWORD=
     - WCRS_WORLDPAY_ECOM_USERNAME=
     - WCRS_WORLDPAY_ECOM_PASSWORD=
+    - WCRS_USE_XVFB_FOR_WICKEDPDF=true
 
 language: ruby
 rvm: 2.4.2
@@ -35,6 +36,9 @@ services:
   - mongodb
 before_install:
   - export TZ=UTC
+  - sudo apt-get install xvfb -y
+  - sudo apt-get install ttf-liberation -y
+  - sudo apt-get install wkhtmltopdf -y
   - gem install -v 1.17.2 bundler --no-rdoc --no-ri
 
 before_script:

--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,8 @@ gem "kaminari-mongoid", "~> 1.0"
 # Use Whenever to manage cron tasks
 gem "whenever", "~> 0.10.0"
 
+gem "wicked_pdf"
+
 # Use the Defra Ruby Aws gem for loading files to AWS buckets
 gem "defra_ruby_aws", "~> 0.2.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: c96208caf6ba39c7c436c7362a234bbd5ec945a6
+  revision: cbc99d5419cd93023dd6286f46d6a261de6a8daf
   branch: master
   specs:
     waste_carriers_engine (0.0.1)
@@ -424,6 +424,7 @@ DEPENDENCIES
   webmock (~> 3.4)
   whenever (~> 0.10.0)
   whenever-test (~> 1.0)
+  wicked_pdf
 
 RUBY VERSION
    ruby 2.4.2p198

--- a/app/controllers/certificates_controller.rb
+++ b/app/controllers/certificates_controller.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class CertificatesController < ApplicationController
+  include CanRenderPdf
+
+  def show
+    registration = WasteCarriersEngine::Registration.find_by(reg_identifier: params[:registration_reg_identifier])
+    @presenter = WasteCarriersEngine::CertificatePresenter.new(registration, view_context)
+
+    render pdf: registration.reg_identifier,
+           show_as_html: show_as_html?,
+           layout: false,
+           page_size: "A4",
+           margin: { top: "10mm", bottom: "10mm", left: "10mm", right: "10mm" },
+           print_media_type: true,
+           template: "waste_carriers_engine/pdfs/certificate"
+  end
+end

--- a/app/controllers/concerns/can_render_pdf.rb
+++ b/app/controllers/concerns/can_render_pdf.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module CanRenderPdf
+  extend ActiveSupport::Concern
+
+  def show_as_html?
+    params[:show_as_html] == "true"
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -95,6 +95,8 @@ Rails.application.routes.draw do
               get "transfer/success",
                   to: "registration_transfers#success",
                   as: :registration_transfer_success
+
+              get "certificate", to: "certificates#show", as: :certificate
             end
 
   resources :transient_registrations,

--- a/spec/factories/meta_data.rb
+++ b/spec/factories/meta_data.rb
@@ -3,6 +3,7 @@
 FactoryBot.define do
   factory :metaData, class: WasteCarriersEngine::MetaData do
     date_registered { Time.current }
+    date_activated { Time.current }
     status { :ACTIVE }
     revoked_reason { "reason" }
 
@@ -11,6 +12,7 @@ FactoryBot.define do
     end
 
     trait :pending do
+      date_activated { nil }
       status { :PENDING }
     end
   end

--- a/spec/requests/certificates_spec.rb
+++ b/spec/requests/certificates_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Certificates", type: :request do
+  let(:registration) { create(:registration, :expires_soon) }
+  let(:user) { create(:user, :agency) }
+  before(:each) do
+    sign_in(user)
+  end
+
+  describe "GET /bo/registrations/:reg_identifier/certificate/" do
+    it "responds with a PDF with a filename that includes the registration reference" do
+      get "/bo/registrations/#{registration.reg_identifier}/certificate"
+
+      expect(response.content_type).to eq("application/pdf")
+      expected_content_disposition = "inline; filename=\"#{registration.reference}.pdf\""
+      expect(response.headers["Content-Disposition"]).to eq(expected_content_disposition)
+    end
+
+    it "returns a 200 status code" do
+      get "/bo/registrations/#{registration.reg_identifier}/certificate"
+      expect(response.code).to eq("200")
+    end
+
+    context "when the 'show_as_html' query string is present" do
+      context "and the value is 'true'" do
+        it "responds with HTML" do
+          get "/bo/registrations/#{registration.reg_identifier}/certificate?show_as_html=true"
+          expect(response.content_type).to eq("text/html")
+        end
+      end
+
+      [false, 1, 0, :foo].each do |bad_value|
+        context "and the value is '#{bad_value}'" do
+          it "responds with a PDF" do
+            get "/bo/registrations/#{registration.reg_identifier}/certificate?show_as_html=#{bad_value}"
+            expect(response.content_type).to eq("application/pdf")
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/certificates_spec.rb
+++ b/spec/requests/certificates_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Certificates", type: :request do
       get "/bo/registrations/#{registration.reg_identifier}/certificate"
 
       expect(response.content_type).to eq("application/pdf")
-      expected_content_disposition = "inline; filename=\"#{registration.reference}.pdf\""
+      expected_content_disposition = "inline; filename=\"#{registration.reg_identifier}.pdf\""
       expect(response.headers["Content-Disposition"]).to eq(expected_content_disposition)
     end
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-834

We already email out certificates from the back office with completed renewals.

However, the old backend also has a feature where you can view a certificate on-demand through the back office. The PDF generation is already in place in the engine. We just need to load it from a route.