### PR TITLE
Display 'view certificate' actions link

### DIFF
--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -41,6 +41,12 @@ module ActionLinksHelper
     new_registration_registration_transfer_path(resource.reg_identifier)
   end
 
+  def certificate_link_for(resource)
+    return "#" unless a_registration?(resource)
+
+    registration_certificate_path(resource.reg_identifier)
+  end
+
   def display_details_link_for?(resource)
     a_transient_registration?(resource) || a_registration?(resource)
   end
@@ -99,9 +105,7 @@ module ActionLinksHelper
     can?(:update, WasteCarriersEngine::Registration)
   end
 
-  def display_view_confirmation_letter_link_for?(resource)
-    # TODO: delete next line filter when internal route exists https://eaflood.atlassian.net/browse/RUBY-786
-    return false if a_registration?(resource)
+  def display_certificate_link_for?(resource)
     return false unless display_registration_links?(resource)
     return false unless can?(:view_certificate, WasteCarriersEngine::Registration)
 

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -41,12 +41,6 @@ module ActionLinksHelper
     new_registration_registration_transfer_path(resource.reg_identifier)
   end
 
-  def certificate_link_for(resource)
-    return "#" unless a_registration?(resource)
-
-    registration_certificate_path(resource.reg_identifier)
-  end
-
   def display_details_link_for?(resource)
     a_transient_registration?(resource) || a_registration?(resource)
   end

--- a/app/views/shared/registrations/_action_links_panel.html.erb
+++ b/app/views/shared/registrations/_action_links_panel.html.erb
@@ -32,7 +32,7 @@
 
     <% if display_certificate_link_for?(resource) %>
       <li>
-        <%= link_to t(".actions_box.links.certificate"), certificate_link_for(resource) %>
+        <%= link_to t(".actions_box.links.certificate"), registration_certificate_path(resource.reg_identifier) %>
       </li>
     <% end %>
 

--- a/app/views/shared/registrations/_action_links_panel.html.erb
+++ b/app/views/shared/registrations/_action_links_panel.html.erb
@@ -30,9 +30,9 @@
       </li>
     <% end %>
 
-    <% if display_view_confirmation_letter_link_for?(resource) %>
+    <% if display_certificate_link_for?(resource) %>
       <li>
-        <%= link_to t(".actions_box.links.view_confirmation_letter"), "#" %>
+        <%= link_to t(".actions_box.links.certificate"), certificate_link_for(resource) %>
       </li>
     <% end %>
 

--- a/config/locales/shared/registrations.en.yml
+++ b/config/locales/shared/registrations.en.yml
@@ -67,7 +67,7 @@ en:
             renew: "Renew"
             transfer: "Transfer to another account"
             edit: "Edit registration"
-            view_confirmation_letter: "View certificate"
+            certificate: "View certificate"
             order_copy_cards: "Order registration cards"
             payment_details: "Payment details"
             process_payment: "Process payment"

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -181,24 +181,6 @@ RSpec.describe ActionLinksHelper, type: :helper do
     end
   end
 
-  describe "certificate_link_for" do
-    context "when the resource is a registration" do
-      let(:resource) { create(:registration) }
-
-      it "returns the correct path" do
-        expect(helper.certificate_link_for(resource)).to eq(registration_certificate_path(resource.reg_identifier))
-      end
-    end
-
-    context "when the resource is not a registration" do
-      let(:resource) { create(:renewing_registration) }
-
-      it "returns the correct path" do
-        expect(helper.certificate_link_for(resource)).to eq("#")
-      end
-    end
-  end
-
   describe "#display_details_link_for?" do
     context "when the resource is a Registration" do
       let(:resource) { build(:registration) }

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -181,6 +181,24 @@ RSpec.describe ActionLinksHelper, type: :helper do
     end
   end
 
+  describe "certificate_link_for" do
+    context "when the resource is a registration" do
+      let(:resource) { create(:registration) }
+
+      it "returns the correct path" do
+        expect(helper.certificate_link_for(resource)).to eq(registration_certificate_path(resource.reg_identifier))
+      end
+    end
+
+    context "when the resource is not a registration" do
+      let(:resource) { create(:renewing_registration) }
+
+      it "returns the correct path" do
+        expect(helper.certificate_link_for(resource)).to eq("#")
+      end
+    end
+  end
+
   describe "#display_details_link_for?" do
     context "when the resource is a Registration" do
       let(:resource) { build(:registration) }
@@ -419,57 +437,52 @@ RSpec.describe ActionLinksHelper, type: :helper do
     end
   end
 
-  describe "#display_view_confirmation_letter_link_for?" do
+  describe "#display_certificate_link_for?" do
     context "when the resource is a registration" do
       let(:resource) { build(:registration) }
 
-      it "returns false" do
-        expect(helper.display_view_confirmation_letter_link_for?(resource)).to eq(false)
+      before do
+        expect(helper).to receive(:can?).with(:view_certificate, WasteCarriersEngine::Registration).and_return(can)
       end
 
-      # TODO: re-implement when internal route exists https://eaflood.atlassian.net/browse/RUBY-786
-      # before do
-      #   expect(helper).to receive(:can?).with(:view_certificate, WasteCarriersEngine::Registration).and_return(can)
-      # end
+      context "when the user has permission to view the certificate" do
+        let(:can) { true }
 
-      # context "when the user has permission for revoking" do
-      #   let(:can) { true }
+        before do
+          expect(resource).to receive(:active?).and_return(active)
+        end
 
-      #   before do
-      #     expect(resource).to receive(:active?).and_return(active)
-      #   end
+        context "when the resource is active" do
+          let(:active) { true }
 
-      #   context "when the resource is active" do
-      #     let(:active) { true }
+          it "returns true" do
+            expect(helper.display_certificate_link_for?(resource)).to be_truthy
+          end
+        end
 
-      #     it "returns true" do
-      #       expect(helper.display_view_confirmation_letter_link_for?(resource)).to be_truthy
-      #     end
-      #   end
+        context "when the resource is not active" do
+          let(:active) { false }
 
-      #   context "when the resource is not active" do
-      #     let(:active) { false }
+          it "returns false" do
+            expect(helper.display_certificate_link_for?(resource)).to be_falsey
+          end
+        end
+      end
 
-      #     it "returns false" do
-      #       expect(helper.display_view_confirmation_letter_link_for?(resource)).to be_falsey
-      #     end
-      #   end
-      # end
+      context "when the user has no permission to view the certificate" do
+        let(:can) { false }
 
-      # context "when the user has no permission for revoking" do
-      #   let(:can) { false }
-
-      #   it "returns false" do
-      #     expect(helper.display_view_confirmation_letter_link_for?(resource)).to be_falsey
-      #   end
-      # end
+        it "returns false" do
+          expect(helper.display_certificate_link_for?(resource)).to be_falsey
+        end
+      end
     end
 
     context "when the resource is a transient registration" do
       let(:resource) { build(:renewing_registration) }
 
       it "returns false" do
-        expect(helper.display_view_confirmation_letter_link_for?(resource)).to be_falsey
+        expect(helper.display_certificate_link_for?(resource)).to be_falsey
       end
     end
   end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-834

Now that we have the certificate in the back office, we can display this action link again.

It also renames the methods to be more accurate.