### PR TITLE
Add renewing after create to write off

### DIFF
--- a/app/controllers/write_off_forms_controller.rb
+++ b/app/controllers/write_off_forms_controller.rb
@@ -3,6 +3,7 @@
 class WriteOffFormsController < ApplicationController
   include CanFetchResource
   include FinanceDetailsHelper
+  include CanRenewIfPossible
 
   prepend_before_action :authenticate_user!
 


### PR DESCRIPTION
We have realised that the write off, when done on a renewal, should renew the registration if possible as any payment operation. This adds the correct concern to do that and update the test suite