### PR TITLE
Fix finance role permissions

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -47,10 +47,10 @@ class Ability
     permissions_for_agency_user
 
     can :view_revoked_reasons, :all
-    can :refund, :all
     can :cease, WasteCarriersEngine::Registration
     can :revoke, WasteCarriersEngine::Registration
 
+    can :refund, :all
     can :record_cash_payment, :all
     can :record_cheque_payment, :all
     can :record_postal_order_payment, :all

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -36,10 +36,6 @@ class Ability
     can :view_certificate, WasteCarriersEngine::Registration
     can :order_copy_cards, WasteCarriersEngine::Registration
 
-    can :record_cash_payment, :all
-    can :record_cheque_payment, :all
-    can :record_postal_order_payment, :all
-
     can :review_convictions, :all
 
     can :revert_to_payment_summary, :all
@@ -54,6 +50,10 @@ class Ability
     can :refund, :all
     can :cease, WasteCarriersEngine::Registration
     can :revoke, WasteCarriersEngine::Registration
+
+    can :record_cash_payment, :all
+    can :record_cheque_payment, :all
+    can :record_postal_order_payment, :all
     can :write_off_small, WasteCarriersEngine::FinanceDetails do |finance_details|
       finance_details.zero_difference_balance <= write_off_agency_user_cap
     end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -82,6 +82,8 @@ class Ability
   end
 
   def permissions_for_finance_super_user
+    permissions_for_finance_admin_user
+
     can :manage_back_office_users, User
     # rubocop:disable Style/SymbolProc
     can :modify_user, User do |user|

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -66,6 +66,7 @@ RSpec.describe Ability, type: :model do
     let(:role) { "finance_super" }
 
     include_examples "finance_super examples"
+    include_examples "finance_admin examples"
 
     include_examples "non-developer examples"
 
@@ -75,6 +76,7 @@ RSpec.describe Ability, type: :model do
   context "when the user role is finance_admin" do
     let(:role) { "finance_admin" }
 
+    include_examples "below finance_super examples"
     include_examples "finance_admin examples"
 
     include_examples "non-developer examples"

--- a/spec/requests/cash_payment_forms_spec.rb
+++ b/spec/requests/cash_payment_forms_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "CashPaymentForms", type: :request do
 
   describe "GET /bo/resources/:_id/payments/cash" do
     context "when a valid user is signed in" do
-      let(:user) { create(:user, :agency) }
+      let(:user) { create(:user, :agency_with_refund) }
       before(:each) do
         sign_in(user)
       end
@@ -70,7 +70,7 @@ RSpec.describe "CashPaymentForms", type: :request do
     end
 
     context "when a valid user is signed in" do
-      let(:user) { create(:user, :agency) }
+      let(:user) { create(:user, :agency_with_refund) }
 
       before(:each) do
         sign_in(user)

--- a/spec/requests/cheque_payment_forms_spec.rb
+++ b/spec/requests/cheque_payment_forms_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "ChequePaymentForms", type: :request do
 
   describe "GET /bo/resource/:_id/payments/cheque" do
     context "when a valid user is signed in" do
-      let(:user) { create(:user, :agency) }
+      let(:user) { create(:user, :agency_with_refund) }
       before(:each) do
         sign_in(user)
       end
@@ -69,7 +69,7 @@ RSpec.describe "ChequePaymentForms", type: :request do
     end
 
     context "when a valid user is signed in" do
-      let(:user) { create(:user, :agency) }
+      let(:user) { create(:user, :agency_with_refund) }
       before(:each) do
         sign_in(user)
       end

--- a/spec/requests/postal_order_payment_forms_spec.rb
+++ b/spec/requests/postal_order_payment_forms_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "PostalOrderPaymentForms", type: :request do
 
   describe "GET /bo/resources/:_id/payments/postal-order" do
     context "when a valid user is signed in" do
-      let(:user) { create(:user, :agency) }
+      let(:user) { create(:user, :agency_with_refund) }
       before(:each) do
         sign_in(user)
       end
@@ -69,7 +69,7 @@ RSpec.describe "PostalOrderPaymentForms", type: :request do
     end
 
     context "when a valid user is signed in" do
-      let(:user) { create(:user, :agency) }
+      let(:user) { create(:user, :agency_with_refund) }
       before(:each) do
         sign_in(user)
       end

--- a/spec/support/shared_examples/abilities/agency_examples.rb
+++ b/spec/support/shared_examples/abilities/agency_examples.rb
@@ -28,18 +28,6 @@ RSpec.shared_examples "agency examples" do
     should be_able_to(:revert_to_payment_summary, WasteCarriersEngine::RenewingRegistration)
   end
 
-  it "should be able to record a cash payment" do
-    should be_able_to(:record_cash_payment, WasteCarriersEngine::RenewingRegistration)
-  end
-
-  it "should be able to record a cheque payment" do
-    should be_able_to(:record_cheque_payment, WasteCarriersEngine::RenewingRegistration)
-  end
-
-  it "should be able to record a postal order payment" do
-    should be_able_to(:record_postal_order_payment, WasteCarriersEngine::RenewingRegistration)
-  end
-
   # All agency users should NOT be able to do this:
 
   it "should not be able to modify finance users" do

--- a/spec/support/shared_examples/abilities/agency_with_refund_examples.rb
+++ b/spec/support/shared_examples/abilities/agency_with_refund_examples.rb
@@ -13,6 +13,18 @@ RSpec.shared_examples "agency_with_refund examples" do
     should be_able_to(:cease, WasteCarriersEngine::Registration)
   end
 
+  it "should be able to record a cash payment" do
+    should be_able_to(:record_cash_payment, WasteCarriersEngine::RenewingRegistration)
+  end
+
+  it "should be able to record a cheque payment" do
+    should be_able_to(:record_cheque_payment, WasteCarriersEngine::RenewingRegistration)
+  end
+
+  it "should be able to record a postal order payment" do
+    should be_able_to(:record_postal_order_payment, WasteCarriersEngine::RenewingRegistration)
+  end
+
   context ":write_off_small" do
     let(:finance_details) { build(:finance_details, balance: balance) }
 

--- a/spec/support/shared_examples/abilities/below_agency_with_refund_examples.rb
+++ b/spec/support/shared_examples/abilities/below_agency_with_refund_examples.rb
@@ -17,6 +17,18 @@ RSpec.shared_examples "below agency_with_refund examples" do
     should_not be_able_to(:revoke, WasteCarriersEngine::Registration)
   end
 
+  it "should not be able to record a cash payment" do
+    should_not be_able_to(:record_cash_payment, WasteCarriersEngine::RenewingRegistration)
+  end
+
+  it "should not be able to record a cheque payment" do
+    should_not be_able_to(:record_cheque_payment, WasteCarriersEngine::RenewingRegistration)
+  end
+
+  it "should not be able to record a postal order payment" do
+    should_not be_able_to(:record_postal_order_payment, WasteCarriersEngine::RenewingRegistration)
+  end
+
   it "should not be able to write off small" do
     should_not be_able_to(:write_off_small, WasteCarriersEngine::FinanceDetails)
   end

--- a/spec/support/shared_examples/abilities/below_finance_super_examples.rb
+++ b/spec/support/shared_examples/abilities/below_finance_super_examples.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "below finance_super examples" do
+  it "should not be able to manage back office users" do
+    should_not be_able_to(:manage_back_office_users, User)
+  end
+
+  it "should not be able to modify finance users" do
+    user = build(:user, :finance)
+    should_not be_able_to(:modify_user, user)
+  end
+end

--- a/spec/support/shared_examples/abilities/finance_admin_examples.rb
+++ b/spec/support/shared_examples/abilities/finance_admin_examples.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples "finance_admin examples" do
-  # Finance admin users can only do two things:
+  # finance_admin and finance_super users should be able to do this:
+
   it "should be able to record a worldpay payment" do
     should be_able_to(:record_worldpay_missed_payment, WasteCarriersEngine::RenewingRegistration)
   end
@@ -10,7 +11,7 @@ RSpec.shared_examples "finance_admin examples" do
     should be_able_to(:view_certificate, WasteCarriersEngine::Registration)
   end
 
-  # Everything else is off-limits.
+  # finance_admin and finance_super users should not be able to do this:
 
   it "should not be able to update a transient registration" do
     should_not be_able_to(:update, WasteCarriersEngine::RenewingRegistration)
@@ -73,17 +74,8 @@ RSpec.shared_examples "finance_admin examples" do
     should_not be_able_to(:transfer_registration, WasteCarriersEngine::Registration)
   end
 
-  it "should not be able to manage back office users" do
-    should_not be_able_to(:manage_back_office_users, User)
-  end
-
   it "should not be able to modify agency users" do
     user = build(:user, :agency)
-    should_not be_able_to(:modify_user, user)
-  end
-
-  it "should not be able to modify finance users" do
-    user = build(:user, :finance)
     should_not be_able_to(:modify_user, user)
   end
 end

--- a/spec/support/shared_examples/abilities/finance_super_examples.rb
+++ b/spec/support/shared_examples/abilities/finance_super_examples.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples "finance_super examples" do
-  # Finance super users can only manage users:
   it "should be able to manage back office users" do
     should be_able_to(:manage_back_office_users, User)
   end
@@ -9,73 +8,5 @@ RSpec.shared_examples "finance_super examples" do
   it "should be able to modify finance users" do
     user = build(:user, :finance)
     should be_able_to(:modify_user, user)
-  end
-
-  # Everything else is off-limits.
-
-  it "should not be able to view the certificate" do
-    should_not be_able_to(:view_certificate, WasteCarriersEngine::Registration)
-  end
-
-  it "should not be able to update a transient registration" do
-    should_not be_able_to(:update, WasteCarriersEngine::RenewingRegistration)
-  end
-
-  it "should not be able to renew" do
-    should_not be_able_to(:renew, WasteCarriersEngine::RenewingRegistration)
-    should_not be_able_to(:renew, WasteCarriersEngine::Registration)
-  end
-
-  it "should not be able to refund a payment" do
-    should_not be_able_to(:refund, WasteCarriersEngine::Registration)
-  end
-
-  it "should not be able to record a cash payment" do
-    should_not be_able_to(:record_cash_payment, WasteCarriersEngine::RenewingRegistration)
-  end
-
-  it "should not be able to cease a registration" do
-    should_not be_able_to(:cease, WasteCarriersEngine::Registration)
-  end
-
-  it "should not be able to revoke a registration" do
-    should_not be_able_to(:revoke, WasteCarriersEngine::Registration)
-  end
-
-  it "should not be able to record a cheque payment" do
-    should_not be_able_to(:record_cheque_payment, WasteCarriersEngine::RenewingRegistration)
-  end
-
-  it "should not be able to record a postal order payment" do
-    should_not be_able_to(:record_postal_order_payment, WasteCarriersEngine::RenewingRegistration)
-  end
-
-  it "should not be able to record a bank transfer payment" do
-    should_not be_able_to(:record_bank_transfer_payment, WasteCarriersEngine::RenewingRegistration)
-  end
-
-  it "should not be able to record a worldpay payment" do
-    should_not be_able_to(:record_worldpay_missed_payment, WasteCarriersEngine::RenewingRegistration)
-  end
-
-  it "should not be able to review convictions" do
-    should_not be_able_to(:review_convictions, WasteCarriersEngine::RenewingRegistration)
-  end
-
-  it "should not be able to view revoked reasons" do
-    should_not be_able_to(:view_revoked_reasons, WasteCarriersEngine::RenewingRegistration)
-  end
-
-  it "should not be able to revert to payment summary" do
-    should_not be_able_to(:revert_to_payment_summary, WasteCarriersEngine::RenewingRegistration)
-  end
-
-  it "should not be able to transfer a registration" do
-    should_not be_able_to(:transfer_registration, WasteCarriersEngine::Registration)
-  end
-
-  it "should not be able to modify agency users" do
-    user = build(:user, :agency)
-    should_not be_able_to(:modify_user, user)
   end
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-884

We need to make a number of fixes to the permissions for our finance roles.

Notably:

- The `finance_user` type exists solely to deal with bank transfer payments
- `finance_super` should be able to do everything a `finance-admin` can do, plus the extra user management bits
- `agency_user`s should not be able to do anything financial

This PR should update all our permissions to match the spreadsheet.