### PR TITLE
Log error from completion service without parsing it

### DIFF
--- a/app/controllers/admin_forms_controller.rb
+++ b/app/controllers/admin_forms_controller.rb
@@ -53,7 +53,7 @@ class AdminFormsController < ApplicationController
     renewal_completion_service = WasteCarriersEngine::RenewalCompletionService.new(@transient_registration)
     renewal_completion_service.complete_renewal
   rescue StandardError => e
-    Airbrake.notify(e, reg_identifier: @transient_registration.reg_identifier) if defined?(Airbrake)
-    Rails.logger.error "Failed to complete renewal for #{@transient_registration.reg_identifier}: " + e.to_s
+    Airbrake.notify(e, reg_identifier: @transient_registration.reg_identifier)
+    Rails.logger.error e
   end
 end

--- a/app/controllers/concerns/can_renew_if_possible.rb
+++ b/app/controllers/concerns/can_renew_if_possible.rb
@@ -14,8 +14,8 @@ module CanRenewIfPossible
       renewal_completion_service = WasteCarriersEngine::RenewalCompletionService.new(@resource)
       renewal_completion_service.complete_renewal
     rescue StandardError => e
-      Airbrake.notify(e, reg_identifier: @resource.reg_identifier) if defined?(Airbrake)
-      Rails.logger.error "Failed to complete renewal for #{@resource.reg_identifier}: " + e.to_s
+      Airbrake.notify(e, reg_identifier: @resource.reg_identifier)
+      Rails.logger.error e
     end
   end
 end


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-885

Following on: https://github.com/DEFRA/waste-carriers-engine/pull/660 

We have agreed to add more granular logging around the completion service. It will now return very specific error, hence we don't want to parse those custom errors to the logger any more