### PR TITLE
Clean up action link helpers

### DIFF
--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -16,17 +16,6 @@ module ActionLinksHelper
     ad_privacy_policy_path(resource.reg_identifier)
   end
 
-  def convictions_link_for(resource)
-    if a_transient_registration?(resource)
-      transient_registration_convictions_path(resource.reg_identifier)
-    # TODO: re-implement when internal route exists https://eaflood.atlassian.net/browse/RUBY-786
-    # elsif a_registration?(resource)
-    #   "#{Rails.configuration.wcrs_backend_url}/registrations/#{resource.id}/approve"
-    else
-      "#"
-    end
-  end
-
   def renew_link_for(resource)
     ad_privacy_policy_path(resource.reg_identifier)
   end
@@ -103,13 +92,6 @@ module ActionLinksHelper
     return false unless can?(:order_copy_cards, WasteCarriersEngine::Registration)
 
     resource.active? && resource.upper_tier?
-  end
-
-  def display_convictions_link_for?(resource)
-    return false unless display_transient_registration_links?(resource) || display_registration_links?(resource)
-    return false unless can?(:review_convictions, WasteCarriersEngine::Registration)
-
-    resource.pending_manual_conviction_check?
   end
 
   def display_renew_link_for?(resource)

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -35,12 +35,6 @@ module ActionLinksHelper
     ad_privacy_policy_path(resource.reg_identifier)
   end
 
-  def transfer_link_for(resource)
-    return "#" unless a_registration?(resource)
-
-    new_registration_registration_transfer_path(resource.reg_identifier)
-  end
-
   def display_details_link_for?(resource)
     a_transient_registration?(resource) || a_registration?(resource)
   end

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/ModuleLength
 module ActionLinksHelper
   def details_link_for(resource)
     if a_transient_registration?(resource)
@@ -130,4 +129,3 @@ module ActionLinksHelper
     true
   end
 end
-# rubocop:enable Metrics/ModuleLength

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -7,8 +7,6 @@ module ActionLinksHelper
       renewing_registration_path(resource.reg_identifier)
     elsif a_registration?(resource)
       registration_path(resource.reg_identifier)
-    else
-      "#"
     end
   end
 

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -13,8 +13,6 @@ module ActionLinksHelper
   end
 
   def resume_link_for(resource)
-    return "#" unless a_transient_registration?(resource)
-
     ad_privacy_policy_path(resource.reg_identifier)
   end
 
@@ -30,8 +28,6 @@ module ActionLinksHelper
   end
 
   def renew_link_for(resource)
-    return "#" unless a_registration?(resource)
-
     ad_privacy_policy_path(resource.reg_identifier)
   end
 

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -158,7 +158,7 @@
                     <% end %>
                   <% if display_transfer_link_for?(result) %>
                     <li>
-                      <%= link_to transfer_link_for(result) do %>
+                      <%= link_to new_registration_registration_transfer_path(result.reg_identifier) do %>
                         <%= t(".results.actions.transfer.link_text") %>
                         <span class="visually-hidden">
                           <%= t(".results.actions.transfer.visually_hidden_text",

--- a/app/views/shared/registrations/_action_links_panel.html.erb
+++ b/app/views/shared/registrations/_action_links_panel.html.erb
@@ -18,7 +18,7 @@
 
     <% if display_transfer_link_for?(resource) %>
       <li>
-        <%= link_to t(".actions_box.links.transfer"), transfer_link_for(resource) %>
+        <%= link_to t(".actions_box.links.transfer"), new_registration_registration_transfer_path(resource.reg_identifier) %>
       </li>
     <% end %>
 

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -107,14 +107,6 @@ RSpec.describe ActionLinksHelper, type: :helper do
         expect(helper.resume_link_for(resource)).to eq(ad_privacy_policy_path(resource.reg_identifier))
       end
     end
-
-    context "when the resource is not a transient_registration" do
-      let(:resource) { build(:registration) }
-
-      it "returns the correct path" do
-        expect(helper.resume_link_for(resource)).to eq("#")
-      end
-    end
   end
 
   describe "convictions_link_for" do
@@ -151,14 +143,6 @@ RSpec.describe ActionLinksHelper, type: :helper do
 
       it "returns the correct path" do
         expect(helper.renew_link_for(resource)).to eq(ad_privacy_policy_path(resource.reg_identifier))
-      end
-    end
-
-    context "when the resource is not a registration" do
-      let(:resource) { create(:renewing_registration) }
-
-      it "returns the correct path" do
-        expect(helper.renew_link_for(resource)).to eq("#")
       end
     end
   end

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -163,24 +163,6 @@ RSpec.describe ActionLinksHelper, type: :helper do
     end
   end
 
-  describe "transfer_link_for" do
-    context "when the resource is a registration" do
-      let(:resource) { create(:registration) }
-
-      it "returns the correct path" do
-        expect(helper.transfer_link_for(resource)).to eq(new_registration_registration_transfer_path(resource.reg_identifier))
-      end
-    end
-
-    context "when the resource is not a registration" do
-      let(:resource) { create(:renewing_registration) }
-
-      it "returns the correct path" do
-        expect(helper.transfer_link_for(resource)).to eq("#")
-      end
-    end
-  end
-
   describe "#display_details_link_for?" do
     context "when the resource is a Registration" do
       let(:resource) { build(:registration) }

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -19,14 +19,6 @@ RSpec.describe ActionLinksHelper, type: :helper do
         expect(helper.details_link_for(resource)).to eq(registration_path(resource.reg_identifier))
       end
     end
-
-    context "when the resource is not a registration or a renewing registration" do
-      let(:resource) { double(:resource) }
-
-      it "returns a default path" do
-        expect(helper.details_link_for(resource)).to eq("#")
-      end
-    end
   end
 
   describe "#display_write_off_small_link_for?" do

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -109,34 +109,6 @@ RSpec.describe ActionLinksHelper, type: :helper do
     end
   end
 
-  describe "convictions_link_for" do
-    context "when the resource is a transient_registration" do
-      let(:resource) { build(:renewing_registration) }
-
-      it "returns the correct path" do
-        expect(helper.convictions_link_for(resource)).to eq(transient_registration_convictions_path(resource.reg_identifier))
-      end
-    end
-
-    # TODO: re-implement when internal route exists https://eaflood.atlassian.net/browse/RUBY-786
-    # context "when the resource is a registration" do
-    #   let(:resource) { build(:registration) }
-
-    #   it "returns the correct path" do
-    #     path = "#{Rails.configuration.wcrs_backend_url}/registrations/#{resource.id}/approve"
-    #     expect(helper.convictions_link_for(resource)).to eq(path)
-    #   end
-    # end
-
-    context "when the resource is not a registration or a transient_registration" do
-      let(:resource) { nil }
-
-      it "returns the correct path" do
-        expect(helper.convictions_link_for(resource)).to eq("#")
-      end
-    end
-  end
-
   describe "renew_link_for" do
     context "when the resource is a registration" do
       let(:resource) { create(:registration) }
@@ -540,166 +512,84 @@ RSpec.describe ActionLinksHelper, type: :helper do
     # end
   end
 
-  describe "#display_convictions_link_for?" do
+  describe "#display_renew_link_for?" do
+    context "when the resource is not a Registration" do
+      let(:resource) { build(:renewing_registration) }
+
+      it "returns false" do
+        expect(helper.display_renew_link_for?(resource)).to eq(false)
+      end
+    end
+
     context "when the resource is a Registration" do
       let(:resource) { build(:registration) }
 
-      context "when the resource has been revoked" do
-        before { resource.metaData.status = "REVOKED" }
-
-        it "returns false" do
-          expect(helper.display_convictions_link_for?(resource)).to eq(false)
-        end
-      end
-
       context "when the user does not have permission" do
         before { allow(helper).to receive(:can?).and_return(false) }
-
-        it "returns false" do
-          expect(helper.display_convictions_link_for?(resource)).to eq(false)
-        end
-      end
-
-      context "when the user has permission" do
-        before { allow(helper).to receive(:can?).and_return(true) }
-
-        context "when the resource has no pending convictions check" do
-          let(:resource) { build(:renewing_registration, :does_not_require_conviction_check) }
-
-          it "returns false" do
-            expect(helper.display_convictions_link_for?(resource)).to eq(false)
-          end
-        end
-
-        context "when the resource has a pending convictions check" do
-          let(:resource) { build(:renewing_registration, :requires_conviction_check) }
-
-          it "returns true" do
-            expect(helper.display_convictions_link_for?(resource)).to eq(true)
-          end
-        end
-      end
-    end
-
-    context "when the resource is a RenewingRegistration" do
-      let(:resource) { build(:renewing_registration) }
-
-      context "when the resource has been revoked" do
-        before { resource.metaData.status = "REVOKED" }
-
-        it "returns false" do
-          expect(helper.display_convictions_link_for?(resource)).to eq(false)
-        end
-      end
-
-      context "when the user does not have permission" do
-        before { allow(helper).to receive(:can?).and_return(false) }
-
-        it "returns false" do
-          expect(helper.display_convictions_link_for?(resource)).to eq(false)
-        end
-      end
-
-      context "when the user has permission" do
-        before { allow(helper).to receive(:can?).and_return(true) }
-
-        context "when the resource has no pending convictions check" do
-          let(:resource) { build(:renewing_registration, :does_not_require_conviction_check) }
-
-          it "returns false" do
-            expect(helper.display_convictions_link_for?(resource)).to eq(false)
-          end
-        end
-
-        context "when the resource has a pending convictions check" do
-          let(:resource) { build(:renewing_registration, :requires_conviction_check) }
-
-          it "returns true" do
-            expect(helper.display_convictions_link_for?(resource)).to eq(true)
-          end
-        end
-      end
-    end
-
-    describe "#display_renew_link_for?" do
-      context "when the resource is not a Registration" do
-        let(:resource) { build(:renewing_registration) }
 
         it "returns false" do
           expect(helper.display_renew_link_for?(resource)).to eq(false)
         end
       end
 
-      context "when the resource is a Registration" do
-        let(:resource) { build(:registration) }
+      context "when the user has permission" do
+        before { allow(helper).to receive(:can?).and_return(true) }
 
-        context "when the user does not have permission" do
-          before { allow(helper).to receive(:can?).and_return(false) }
+        context "when the resource cannot begin a renewal" do
+          before { allow(resource).to receive(:can_start_renewal?).and_return(false) }
 
           it "returns false" do
             expect(helper.display_renew_link_for?(resource)).to eq(false)
           end
         end
 
-        context "when the user has permission" do
-          before { allow(helper).to receive(:can?).and_return(true) }
+        context "when the resource can begin a renewal" do
+          before { allow(resource).to receive(:can_start_renewal?).and_return(true) }
 
-          context "when the resource cannot begin a renewal" do
-            before { allow(resource).to receive(:can_start_renewal?).and_return(false) }
-
-            it "returns false" do
-              expect(helper.display_renew_link_for?(resource)).to eq(false)
-            end
-          end
-
-          context "when the resource can begin a renewal" do
-            before { allow(resource).to receive(:can_start_renewal?).and_return(true) }
-
-            it "returns true" do
-              expect(helper.display_renew_link_for?(resource)).to eq(true)
-            end
+          it "returns true" do
+            expect(helper.display_renew_link_for?(resource)).to eq(true)
           end
         end
       end
     end
+  end
 
-    describe "#display_transfer_link_for?" do
-      context "when the resource is not a Registration" do
-        let(:resource) { build(:renewing_registration) }
+  describe "#display_transfer_link_for?" do
+    context "when the resource is not a Registration" do
+      let(:resource) { build(:renewing_registration) }
+
+      it "returns false" do
+        expect(helper.display_transfer_link_for?(resource)).to eq(false)
+      end
+    end
+
+    context "when the resource is a Registration" do
+      let(:resource) { build(:registration) }
+
+      context "when the resource has been revoked or refused" do
+        before { resource.metaData.status = %w[REVOKED REFUSED].sample }
 
         it "returns false" do
           expect(helper.display_transfer_link_for?(resource)).to eq(false)
         end
       end
 
-      context "when the resource is a Registration" do
-        let(:resource) { build(:registration) }
+      context "when the resource is not revoked or refused" do
+        before { resource.metaData.status = %w[ACTIVE EXPIRED PENDING].sample }
 
-        context "when the resource has been revoked or refused" do
-          before { resource.metaData.status = %w[REVOKED REFUSED].sample }
+        context "when the user does not have permission" do
+          before { allow(helper).to receive(:can?).and_return(false) }
 
           it "returns false" do
             expect(helper.display_transfer_link_for?(resource)).to eq(false)
           end
         end
 
-        context "when the resource is not revoked or refused" do
-          before { resource.metaData.status = %w[ACTIVE EXPIRED PENDING].sample }
+        context "when the user has permission" do
+          before { allow(helper).to receive(:can?).and_return(true) }
 
-          context "when the user does not have permission" do
-            before { allow(helper).to receive(:can?).and_return(false) }
-
-            it "returns false" do
-              expect(helper.display_transfer_link_for?(resource)).to eq(false)
-            end
-          end
-
-          context "when the user has permission" do
-            before { allow(helper).to receive(:can?).and_return(true) }
-
-            it "returns true" do
-              expect(helper.display_transfer_link_for?(resource)).to eq(true)
-            end
+          it "returns true" do
+            expect(helper.display_transfer_link_for?(resource)).to eq(true)
           end
         end
       end


### PR DESCRIPTION
This PR exists to clean up some of the helper methods which we don't think we need any more. This came up during discussion of https://github.com/DEFRA/waste-carriers-back-office/pull/646