### PR TITLE
Add edit ability

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -35,6 +35,7 @@ class Ability
     can :renew, :all
     can :view_certificate, WasteCarriersEngine::Registration
     can :order_copy_cards, WasteCarriersEngine::Registration
+    can :edit, WasteCarriersEngine::Registration
 
     can :review_convictions, :all
 

--- a/spec/support/shared_examples/abilities/agency_examples.rb
+++ b/spec/support/shared_examples/abilities/agency_examples.rb
@@ -12,6 +12,10 @@ RSpec.shared_examples "agency examples" do
     should be_able_to(:renew, WasteCarriersEngine::Registration)
   end
 
+  it "should be able to edit a registration" do
+    should be_able_to(:edit, WasteCarriersEngine::Registration)
+  end
+
   it "should be able to review convictions" do
     should be_able_to(:review_convictions, WasteCarriersEngine::RenewingRegistration)
   end

--- a/spec/support/shared_examples/abilities/finance_admin_examples.rb
+++ b/spec/support/shared_examples/abilities/finance_admin_examples.rb
@@ -46,6 +46,10 @@ RSpec.shared_examples "finance_admin examples" do
     should_not be_able_to(:revoke, WasteCarriersEngine::Registration)
   end
 
+  it "should not be able to edit a registration" do
+    should_not be_able_to(:edit, WasteCarriersEngine::Registration)
+  end
+
   it "should not be able to record a cheque payment" do
     should_not be_able_to(:record_cheque_payment, WasteCarriersEngine::RenewingRegistration)
   end

--- a/spec/support/shared_examples/abilities/finance_examples.rb
+++ b/spec/support/shared_examples/abilities/finance_examples.rb
@@ -49,6 +49,10 @@ RSpec.shared_examples "finance examples" do
     should_not be_able_to(:revoke, WasteCarriersEngine::Registration)
   end
 
+  it "should not be able to edit a registration" do
+    should_not be_able_to(:edit, WasteCarriersEngine::Registration)
+  end
+
   it "should not be able to record a postal order payment" do
     should_not be_able_to(:record_postal_order_payment, WasteCarriersEngine::RenewingRegistration)
   end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-827

This PR adds a new 'edit' ability for all users in the agency role group.

It doesn't actually do anything yet, but when the edit feature is used, this will be used to make sure only back office agency users can edit - not finance users or front office users.