### PR TITLE
Add edit link to registration details page

### DIFF
--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -68,11 +68,10 @@ module ActionLinksHelper
   end
 
   def display_edit_link_for?(resource)
-    # TODO: delete next line filter when internal route exists https://eaflood.atlassian.net/browse/RUBY-786
-    return false if a_registration?(resource)
     return false unless display_registration_links?(resource)
+    return false unless can?(:edit, WasteCarriersEngine::Registration)
 
-    can?(:update, WasteCarriersEngine::Registration)
+    resource.active?
   end
 
   def display_certificate_link_for?(resource)

--- a/app/views/shared/registrations/_action_links_panel.html.erb
+++ b/app/views/shared/registrations/_action_links_panel.html.erb
@@ -26,7 +26,7 @@
 
     <% if display_edit_link_for?(resource) %>
       <li>
-        <%= link_to t(".actions_box.links.edit"), "#" %>
+        <%= link_to t(".actions_box.links.edit"), WasteCarriersEngine::Engine.routes.url_helpers.new_edit_form_path(resource.reg_identifier) %>
       </li>
     <% end %>
 

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -314,30 +314,33 @@ RSpec.describe ActionLinksHelper, type: :helper do
     context "when the resource is a registration" do
       let(:resource) { build(:registration) }
 
-      it "returns false" do
-        expect(helper.display_edit_link_for?(resource)).to eq(false)
+      before do
+        expect(helper).to receive(:can?).with(:edit, WasteCarriersEngine::Registration).and_return(can)
       end
 
-      # TODO: re-implement when internal route exists https://eaflood.atlassian.net/browse/RUBY-786
-      # before do
-      #   expect(helper).to receive(:can?).with(:update, WasteCarriersEngine::Registration).and_return(can)
-      # end
+      context "when the user has permission for editing" do
+        let(:can) { true }
 
-      # context "when the user has permission for revoking" do
-      #   let(:can) { true }
+        before do
+          expect(resource).to receive(:active?).and_return(active)
+        end
 
-      #   it "returns true" do
-      #     expect(helper.display_edit_link_for?(resource)).to be_truthy
-      #   end
-      # end
+        context "when the resource is active" do
+          let(:active) { true }
 
-      # context "when the user has no permission for revoking" do
-      #   let(:can) { false }
+          it "returns true" do
+            expect(helper.display_edit_link_for?(resource)).to be_truthy
+          end
+        end
 
-      #   it "returns false" do
-      #     expect(helper.display_edit_link_for?(resource)).to be_falsey
-      #   end
-      # end
+        context "when the resource is not active" do
+          let(:active) { false }
+
+          it "returns false" do
+            expect(helper.display_edit_link_for?(resource)).to be_falsey
+          end
+        end
+      end
     end
 
     context "when the resource is a transient registration" do


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-828

This PR adds the edit link to the registration details page, allowing users to start or continue an edit. It should only be visible to users with an agency role.