### PR TITLE
Update details link text

### DIFF
--- a/config/locales/dashboard.en.yml
+++ b/config/locales/dashboard.en.yml
@@ -45,7 +45,7 @@ en:
             link_text: "Conviction details"
             visually_hidden_text: "for %{name}"
           details:
-            link_text: "Details"
+            link_text: "Registration details"
             visually_hidden_text: "for %{name}"
           renew:
             link_text: "Renew"


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-802

This changes the link in the dashboard search results from "Details" to "Registration details", as requested by users.