### PR TITLE
Remove expired panel from renewing registration details page

### DIFF
--- a/app/views/renewing_registrations/show.html.erb
+++ b/app/views/renewing_registrations/show.html.erb
@@ -55,10 +55,6 @@
           <%= render "shared/registrations/ceased_revoked_panel", resource: @transient_registration %>
         <% end %>
 
-        <% if @transient_registration.expired? %>
-          <%= render "shared/registrations/expired_panel", resource: @transient_registration %>
-        <% end %>
-
         <%= render "shared/registrations/company_details_panel", resource: @transient_registration %>
 
         <%= render "shared/registrations/contact_and_business_details_panels", resource: @transient_registration %>


### PR DESCRIPTION
We have been reported a bug for which requesting the details page of a Renewing registration created AFTER the expire date of a registration was returning a 500 error.
Further debugging showed that the problem is in the fact that the Renewing Registration does not implement methods used in that partial to decide what info to show.
We have realised that the panel should actually never show for renewing registrations. Hence this removes it entirely.