### PR TITLE
Finance - Add ability to revert a payment

### DIFF
--- a/app/controllers/refunds_controller.rb
+++ b/app/controllers/refunds_controller.rb
@@ -43,7 +43,7 @@ class RefundsController < ApplicationController
   private
 
   def fetch_payment
-    @payment = @resource.finance_details.payments.refundable.find_by(order_key: params[:order_key])
+    @payment = @resource.finance_details.payments.refundable.where(order_key: params[:order_key]).first
   end
 
   def authorise_user!

--- a/app/controllers/resource_forms_controller.rb
+++ b/app/controllers/resource_forms_controller.rb
@@ -6,7 +6,7 @@ class ResourceFormsController < ApplicationController
   include CanFetchResource
 
   prepend_before_action :authenticate_user!
-  before_action :authorize_if_required
+  before_action :authorize_if_required, only: %i[new create]
 
   def new(form_class, form)
     set_up_form(form_class, form)

--- a/app/controllers/reversal_forms_controller.rb
+++ b/app/controllers/reversal_forms_controller.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+class ReversalFormsController < ResourceFormsController
+  include FinanceDetailsHelper
+
+  def index
+    payments = @resource.finance_details.payments.reversible
+    @payments = ::PaymentPresenter.create_from_collection(payments, view_context)
+  end
+
+  def new
+    super(ReversalForm,
+          "reversal_form")
+  end
+
+  def create
+    super(ReversalForm,
+          "reversal_form")
+  end
+
+  private
+
+  def reversal_form_params
+    params.fetch(:reversal_form, {}).permit(:reason)
+  end
+
+  def submit_form(form, params)
+    if form.submit(params)
+      ProcessReversalService.run(
+        finance_details: @resource.finance_details,
+        payment: @payment,
+        user: current_user,
+        reason: form.reason
+      )
+
+      flash[:success] = I18n.t(
+        "reversal_forms.flash_messages.successful",
+        amount: display_pence_as_pounds_and_cents(@payment.amount)
+      )
+
+      redirect_to resource_finance_details_path(@resource._id)
+    else
+      render :new, order_key: params[:order_key]
+    end
+  end
+
+  def payment
+    @payment ||= @resource.finance_details.payments.reversible.where(order_key: params[:order_key]).first
+  end
+
+  def authorize_user
+    authorize! :revert, payment
+  end
+end

--- a/app/controllers/reversal_forms_controller.rb
+++ b/app/controllers/reversal_forms_controller.rb
@@ -49,6 +49,6 @@ class ReversalFormsController < ResourceFormsController
   end
 
   def authorize_user
-    authorize! :revert, payment
+    authorize! :reverse, payment
   end
 end

--- a/app/forms/reversal_form.rb
+++ b/app/forms/reversal_form.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class ReversalForm < WasteCarriersEngine::BaseForm
+  attr_accessor :reason
+
+  validates :reason, presence: true, length: { maximum: 500 }
+
+  def submit(params)
+    # Assign the params for validation
+    self.reason = params[:reason]
+
+    valid?
+  end
+end

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -50,6 +50,12 @@ module ActionLinksHelper
     can?(:refund, resource)
   end
 
+  def display_revert_link?
+    return false unless current_user
+
+    %w[agency_with_refund agency_super finance_admin finance finance_super].include?(current_user.role)
+  end
+
   def display_finance_details_link_for?(resource)
     # TODO: Temporary - for release only. See: https://eaflood.atlassian.net/browse/RUBY-846
     return false

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -51,9 +51,9 @@ module ActionLinksHelper
   end
 
   def display_revert_link?
-    return false unless current_user
+    roles_with_revert_ability = %w[agency_with_refund agency_super finance_admin finance finance_super]
 
-    %w[agency_with_refund agency_super finance_admin finance finance_super].include?(current_user.role)
+    roles_with_revert_ability.include?(current_user.role)
   end
 
   def display_finance_details_link_for?(resource)

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -50,10 +50,10 @@ module ActionLinksHelper
     can?(:refund, resource)
   end
 
-  def display_revert_link?
-    roles_with_revert_ability = %w[agency_with_refund agency_super finance_admin finance finance_super]
+  def display_reverse_link?
+    roles_with_reverse_ability = %w[agency_with_refund agency_super finance_admin finance finance_super]
 
-    roles_with_revert_ability.include?(current_user.role)
+    roles_with_reverse_ability.include?(current_user.role)
   end
 
   def display_finance_details_link_for?(resource)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -61,7 +61,7 @@ class Ability
       finance_details.zero_difference_balance <= write_off_agency_user_cap
     end
 
-    can :revert, WasteCarriersEngine::Payment do |payment|
+    can :reverse, WasteCarriersEngine::Payment do |payment|
       payment.cash? || payment.postal_order? || payment.cheque?
     end
   end
@@ -70,7 +70,7 @@ class Ability
     can :view_certificate, WasteCarriersEngine::Registration
     can :record_bank_transfer_payment, :all
 
-    can :revert, WasteCarriersEngine::Payment, &:bank_transfer?
+    can :reverse, WasteCarriersEngine::Payment, &:bank_transfer?
   end
 
   def permissions_for_finance_admin_user
@@ -79,7 +79,7 @@ class Ability
     can :view_certificate, WasteCarriersEngine::Registration
     can :record_worldpay_missed_payment, :all
 
-    can :revert, WasteCarriersEngine::Payment do |payment|
+    can :reverse, WasteCarriersEngine::Payment do |payment|
       payment.worldpay? || payment.worldpay_missed?
     end
   end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -58,17 +58,35 @@ class Ability
     can :write_off_small, WasteCarriersEngine::FinanceDetails do |finance_details|
       finance_details.zero_difference_balance <= write_off_agency_user_cap
     end
+
+    # rubocop:disable Style/SymbolProc
+    can :revert, WasteCarriersEngine::Payment do |payment|
+      payment.cash? || payment.postal_order? || payment.cheque?
+    end
+    # rubocop:enable Style/SymbolProc
   end
 
   def permissions_for_finance_user
     can :view_certificate, WasteCarriersEngine::Registration
     can :record_bank_transfer_payment, :all
+
+    # rubocop:disable Style/SymbolProc
+    can :revert, WasteCarriersEngine::Payment do |payment|
+      payment.bank_transfer?
+    end
+    # rubocop:enable Style/SymbolProc
   end
 
   def permissions_for_finance_admin_user
     can :write_off_large, WasteCarriersEngine::FinanceDetails
     can :view_certificate, WasteCarriersEngine::Registration
     can :record_worldpay_missed_payment, :all
+
+    # rubocop:disable Style/SymbolProc
+    can :revert, WasteCarriersEngine::Payment do |payment|
+      payment.worldpay? || payment.worldpay_missed?
+    end
+    # rubocop:enable Style/SymbolProc
   end
 
   def permissions_for_agency_super_user

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/ClassLength
+
 class Ability
   include CanCan::Ability
 
@@ -59,22 +61,16 @@ class Ability
       finance_details.zero_difference_balance <= write_off_agency_user_cap
     end
 
-    # rubocop:disable Style/SymbolProc
     can :revert, WasteCarriersEngine::Payment do |payment|
       payment.cash? || payment.postal_order? || payment.cheque?
     end
-    # rubocop:enable Style/SymbolProc
   end
 
   def permissions_for_finance_user
     can :view_certificate, WasteCarriersEngine::Registration
     can :record_bank_transfer_payment, :all
 
-    # rubocop:disable Style/SymbolProc
-    can :revert, WasteCarriersEngine::Payment do |payment|
-      payment.bank_transfer?
-    end
-    # rubocop:enable Style/SymbolProc
+    can :revert, WasteCarriersEngine::Payment, &:bank_transfer?
   end
 
   def permissions_for_finance_admin_user
@@ -83,11 +79,9 @@ class Ability
     can :view_certificate, WasteCarriersEngine::Registration
     can :record_worldpay_missed_payment, :all
 
-    # rubocop:disable Style/SymbolProc
     can :revert, WasteCarriersEngine::Payment do |payment|
       payment.worldpay? || payment.worldpay_missed?
     end
-    # rubocop:enable Style/SymbolProc
   end
 
   def permissions_for_agency_super_user
@@ -154,3 +148,4 @@ class Ability
     @_write_off_agency_user_cap ||= WasteCarriersBackOffice::Application.config.write_off_agency_user_cap.to_i
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/app/presenters/payment_presenter.rb
+++ b/app/presenters/payment_presenter.rb
@@ -11,8 +11,8 @@ class PaymentPresenter < WasteCarriersEngine::BasePresenter
     refunded_payment.present?
   end
 
-  def already_reverted?
-    reverted_payment.present?
+  def already_reversed?
+    reversed_payment.present?
   end
 
   def refunded_message
@@ -24,16 +24,16 @@ class PaymentPresenter < WasteCarriersEngine::BasePresenter
   end
 
   def no_action_message
-    if already_reverted?
+    if already_reversed?
       I18n.t(".reversal_forms.index.already_reverted")
     else
       I18n.t(".reversal_forms.index.not_applicable")
     end
   end
 
-  def revertible?
-    return false unless @view.current_user.can?(:revert, __getobj__)
-    return false if already_reverted?
+  def reversible?
+    return false unless @view.current_user.can?(:reverse, __getobj__)
+    return false if already_reversed?
 
     true
   end
@@ -44,7 +44,7 @@ class PaymentPresenter < WasteCarriersEngine::BasePresenter
     @_refunded_payment ||= finance_details.payments.where(order_key: "#{order_key}_REFUNDED").first
   end
 
-  def reverted_payment
-    @_reverted_payment ||= finance_details.payments.where(order_key: "#{order_key}_REVERSAL").first
+  def reversed_payment
+    @_reversed_payment ||= finance_details.payments.where(order_key: "#{order_key}_REVERSAL").first
   end
 end

--- a/app/presenters/payment_presenter.rb
+++ b/app/presenters/payment_presenter.rb
@@ -25,9 +25,9 @@ class PaymentPresenter < WasteCarriersEngine::BasePresenter
 
   def no_action_message
     if already_reverted?
-      I18n.t(".reversal_forms.index.already_reversed")
+      I18n.t(".reversal_forms.index.already_reverted")
     else
-      I18n.t(".reversal_forms.index.not_aplicable")
+      I18n.t(".reversal_forms.index.not_applicable")
     end
   end
 

--- a/app/presenters/payment_presenter.rb
+++ b/app/presenters/payment_presenter.rb
@@ -25,7 +25,7 @@ class PaymentPresenter < WasteCarriersEngine::BasePresenter
 
   def no_action_message
     if already_reversed?
-      I18n.t(".reversal_forms.index.already_reverted")
+      I18n.t(".reversal_forms.index.already_reversed")
     else
       I18n.t(".reversal_forms.index.not_applicable")
     end

--- a/app/services/process_reversal_service.rb
+++ b/app/services/process_reversal_service.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class ProcessReversalService < WasteCarriersEngine::BaseService
+  def run(finance_details:, payment:, user:, reason:)
+    @finance_details = finance_details
+    @payment = payment
+    @user = user
+    @reason = reason
+
+    finance_details.payments << build_reversal
+
+    finance_details.update_balance
+    finance_details.save!
+  end
+
+  private
+
+  attr_reader :payment, :user, :finance_details, :reason
+
+  def build_reversal
+    reversal = WasteCarriersEngine::Payment.new(payment_type: WasteCarriersEngine::Payment::REVERSAL)
+
+    reversal.order_key = "#{payment.order_key}_REVERSAL"
+    reversal.amount = -payment.amount
+    reversal.date_entered = Date.current
+    reversal.date_received = Date.current
+    reversal.registration_reference = payment.registration_reference
+    reversal.updated_by_user = user.email
+    reversal.comment = reason
+
+    reversal
+  end
+end

--- a/app/views/reversal_forms/index.html.erb
+++ b/app/views/reversal_forms/index.html.erb
@@ -49,7 +49,7 @@
               <%= display_pence_as_pounds_and_cents(payment.amount) %>
             </td>
             <td>
-              <% if payment.revertible? %>
+              <% if payment.reversible? %>
                 <%= link_to new_resource_reversal_form_path(resource_id: @resource._id, order_key: payment.order_key) do %>
                   <%= t(".reverse_payment") %>
                   <span class="visually-hidden">

--- a/app/views/reversal_forms/index.html.erb
+++ b/app/views/reversal_forms/index.html.erb
@@ -1,0 +1,72 @@
+<div class="grid-row">
+  <div class="column-full">
+    <%= render("waste_carriers_engine/shared/back", back_path: resource_finance_details_path(@resource._id)) %>
+  </div>
+</div>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <h1 class="heading-large">
+      <%= t(".heading") %>
+    </h1>
+
+    <%= render "shared/company_details_panel", registration: @resource %>
+
+    <table>
+      <thead>
+        <tr>
+          <th>
+            <%= t(".date") %>
+          </th>
+          <th>
+            <%= t(".type") %>
+          </th>
+          <th>
+            <%= t(".reference") %>
+          </th>
+          <th class="numeric">
+            <%= t(".amount") %>
+          </th>
+          <th>
+            <%= t(".action") %>
+          </th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <% @payments.each do |payment| %>
+          <tr>
+            <td>
+              <%= payment.date_received.to_formatted_s(:day_month_year_time_slashes) %>
+            </td>
+            <td>
+              <%= t("shared.payment_type.#{payment.payment_type}") %>
+            </td>
+            <td>
+              <%= payment.order_key %>/<%= payment.registration_reference %>
+            </td>
+            <td class="numeric">
+              <%= display_pence_as_pounds_and_cents(payment.amount) %>
+            </td>
+            <td>
+              <% if payment.revertible? %>
+                <%= link_to new_resource_reversal_form_path(resource_id: @resource._id, order_key: payment.order_key) do %>
+                  <%= t(".reverse_payment") %>
+                  <span class="visually-hidden">
+                    <%= t(".reverse_payment_alt",
+                          date: payment.date_received.to_formatted_s(:day_month_year_time_slashes),
+                          method: t("shared.payment_type.#{payment.payment_type}"),
+                          amount: display_pence_as_pounds_and_cents(payment.amount)) %>
+                  </span>
+                <% end %>
+              <% else %>
+                <%= payment.no_action_message %>
+              <% end %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>
+

--- a/app/views/reversal_forms/new.html.erb
+++ b/app/views/reversal_forms/new.html.erb
@@ -1,0 +1,40 @@
+<div class="grid-row">
+  <div class="column-full">
+    <%= render("waste_carriers_engine/shared/back", back_path: resource_refunds_path(@resource._id)) %>
+  </div>
+</div>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render("waste_carriers_engine/shared/errors", object: @reversal_form) %>
+
+    <h1 class="heading-large">
+      <%= t(".heading", reg_identifier: @resource.reg_identifier) %>
+    </h1>
+
+    <div class="form-group">
+      <%= render "shared/company_details_panel", registration: @resource %>
+    </div>
+
+    <h2 class="heading-medium strong">
+      <%= t(".reverse_payment", amount: display_pence_as_pounds_and_cents(@payment.amount)) %>
+    </h2>
+
+    <%= form_for(@reversal_form, url: resource_reversal_forms_path(@resource._id, order_key: params[:order_key])) do |f| %>
+      <div class="form-group <%= "form-group-error" if @reversal_form.errors[:reason].any? %>">
+        <fieldset id="reason">
+          <% if @reversal_form.errors[:reason].any? %>
+            <span class="error-message"><%= @reversal_form.errors[:reason].join(", ") %></span>
+          <% end %>
+
+          <%= f.label :reason, t(".reason.label"), class: "form-label" %>
+          <%= f.text_area :reason, class: "form-control" %>
+        </fieldset>
+      </div>
+
+      <div class="form-group">
+        <%= f.submit t(".confirm"), class: "button" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/shared/registrations/_finance_action_links.html.erb
+++ b/app/views/shared/registrations/_finance_action_links.html.erb
@@ -4,7 +4,7 @@
       <%= link_to t(".enter_payment"), new_resource_payment_path(registration._id), class: "button wcr-finance-button" %>
     <% end %>
 
-    <% if display_revert_link? %>
+    <% if display_reverse_link? %>
       <%= link_to t(".reverse_payment"), resource_reversal_forms_path(registration._id), class: "button wcr-finance-button" %>
     <% end %>
 

--- a/app/views/shared/registrations/_finance_action_links.html.erb
+++ b/app/views/shared/registrations/_finance_action_links.html.erb
@@ -1,11 +1,12 @@
 <div class="grid-row">
   <div class="column-full">
-
     <% if display_payment_link_for?(registration) %>
       <%= link_to t(".enter_payment"), new_resource_payment_path(registration._id), class: "button wcr-finance-button" %>
     <% end %>
 
-    <%= link_to t(".reverse_payment"), "#TODO", class: "button wcr-finance-button" %>
+    <% if display_revert_link? %>
+      <%= link_to t(".reverse_payment"), resource_reversal_forms_path(registration._id), class: "button wcr-finance-button" %>
+    <% end %>
 
     <% if display_write_off_large_link_for?(registration.finance_details) %>
       <%= link_to t(".write_off_l"), new_resource_write_off_form_path(registration._id), class: "button wcr-finance-button" %>

--- a/config/locales/reversal_forms.en.yml
+++ b/config/locales/reversal_forms.en.yml
@@ -1,0 +1,31 @@
+en:
+  reversal_forms:
+    flash_messages:
+      successful: "£%{amount} reverted successfully"
+    index:
+      title: "Reverse a payment"
+      heading: "Which payment do you want to reverse?"
+      date: "Date"
+      type: "Type"
+      reference: "Reference"
+      amount: "Amount"
+      action: "Action"
+      reverse_payment: "Reverse payment"
+      reverse_payment_alt: "Reverse payment from %{date} by %{method} for %{amount}"
+      not_aplicable: "n/a"
+      already_reversed: "Already reversed"
+    new:
+      title: "Reverse a payment"
+      heading: "Reverse a payment for %{reg_identifier}"
+      reverse_payment: "Reverse payment of £%{amount}"
+      reason:
+        label: "Reason"
+      confirm: "Reverse payment"
+  activemodel:
+    errors:
+      models:
+        reversal_form:
+          attributes:
+            reason:
+              blank: "Enter a reason"
+              too_long: "Reason must be %{count} characters or fewer"

--- a/config/locales/reversal_forms.en.yml
+++ b/config/locales/reversal_forms.en.yml
@@ -12,7 +12,7 @@ en:
       action: "Action"
       reverse_payment: "Reverse payment"
       reverse_payment_alt: "Reverse payment from %{date} by %{method} for %{amount}"
-      not_aplicable: "n/a"
+      not_applicable: "n/a"
       already_reversed: "Already reversed"
     new:
       title: "Reverse a payment"

--- a/config/locales/reversal_forms.en.yml
+++ b/config/locales/reversal_forms.en.yml
@@ -1,7 +1,7 @@
 en:
   reversal_forms:
     flash_messages:
-      successful: "£%{amount} reverted successfully"
+      successful: "£%{amount} reversed successfully"
     index:
       title: "Reverse a payment"
       heading: "Which payment do you want to reverse?"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,12 @@ Rails.application.routes.draw do
                         only: %i[index new create],
                         param: :order_key
 
+              resources :reversal_forms,
+                        only: %i[index new create],
+                        path: "reversals",
+                        path_names: { new: ":order_key/new" },
+                        param: :order_key
+
               resources :payments,
                         only: %i[new create]
 

--- a/spec/factories/payment.rb
+++ b/spec/factories/payment.rb
@@ -11,27 +11,23 @@ FactoryBot.define do
     end
 
     trait :cheque do
-      payment_type { "CHEQUE" }
+      payment_type { WasteCarriersEngine::Payment::CHEQUE }
     end
 
     trait :cash do
-      payment_type { "CASH" }
+      payment_type { WasteCarriersEngine::Payment::CASH }
     end
 
     trait :postal_order do
-      payment_type { "POSTALORDER" }
-    end
-
-    trait :bank_transfer do
-      payment_type { "BANKTRANSFER" }
+      payment_type { WasteCarriersEngine::Payment::POSTALORDER }
     end
 
     trait :worldpay do
-      payment_type { "WORLDPAY" }
+      payment_type { WasteCarriersEngine::Payment::WORLDPAY }
     end
 
     trait :worldpay_missed do
-      payment_type { "WORLDPAY_MISSED" }
+      payment_type { WasteCarriersEngine::Payment::WORLDPAY_MISSED }
     end
   end
 end

--- a/spec/factories/payment.rb
+++ b/spec/factories/payment.rb
@@ -4,8 +4,34 @@ FactoryBot.define do
   factory :payment, class: WasteCarriersEngine::Payment do
     amount { 100 }
     date_received { Time.now }
+    order_key { SecureRandom.uuid.split("-").last }
+
+    trait :bank_transfer do
+      payment_type { WasteCarriersEngine::Payment::BANKTRANSFER }
+    end
+
+    trait :cheque do
+      payment_type { "CHEQUE" }
+    end
+
+    trait :cash do
+      payment_type { "CASH" }
+    end
+
+    trait :postal_order do
+      payment_type { "POSTALORDER" }
+    end
+
     trait :bank_transfer do
       payment_type { "BANKTRANSFER" }
+    end
+
+    trait :worldpay do
+      payment_type { "WORLDPAY" }
+    end
+
+    trait :worldpay_missed do
+      payment_type { "WORLDPAY_MISSED" }
     end
   end
 end

--- a/spec/forms/reversal_form_spec.rb
+++ b/spec/forms/reversal_form_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ReversalForm do
+  describe "#submit" do
+    subject { described_class.new(build(:renewing_registration)) }
+
+    context "when the params are valid" do
+      let(:params) { { reason: "A reason" } }
+
+      it "returns true" do
+        expect(subject.submit(params)).to be_truthy
+      end
+    end
+
+    context "when the params are not valid" do
+      let(:params) { { reason: nil } }
+
+      it "returns false" do
+        expect(subject.submit(params)).to be_falsey
+      end
+    end
+  end
+end

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe ActionLinksHelper, type: :helper do
     end
   end
 
-  describe "#display_revert_link?" do
+  describe "#display_reverse_link?" do
     let(:current_user) { double(:current_user, role: role) }
 
     before do
@@ -148,7 +148,7 @@ RSpec.describe ActionLinksHelper, type: :helper do
       let(:role) { "agency_with_refund" }
 
       it "returns true" do
-        expect(helper.display_revert_link?).to be_truthy
+        expect(helper.display_reverse_link?).to be_truthy
       end
     end
 
@@ -156,15 +156,7 @@ RSpec.describe ActionLinksHelper, type: :helper do
       let(:role) { "foo" }
 
       it "returns false" do
-        expect(helper.display_revert_link?).to be_falsey
-      end
-    end
-
-    context "when there is no current user" do
-      let(:current_user) { nil }
-
-      it "returns false" do
-        expect(helper.display_revert_link?).to be_falsey
+        expect(helper.display_reverse_link?).to be_falsey
       end
     end
   end

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -137,6 +137,38 @@ RSpec.describe ActionLinksHelper, type: :helper do
     end
   end
 
+  describe "#display_revert_link?" do
+    let(:current_user) { double(:current_user, role: role) }
+
+    before do
+      allow(helper).to receive(:current_user).and_return(current_user)
+    end
+
+    context "when the current user is in the allowed group of roles" do
+      let(:role) { "agency_with_refund" }
+
+      it "returns true" do
+        expect(helper.display_revert_link?).to be_truthy
+      end
+    end
+
+    context "when the current user is not in the allowed group of roles" do
+      let(:role) { "foo" }
+
+      it "returns false" do
+        expect(helper.display_revert_link?).to be_falsey
+      end
+    end
+
+    context "when there is no current user" do
+      let(:current_user) { nil }
+
+      it "returns false" do
+        expect(helper.display_revert_link?).to be_falsey
+      end
+    end
+  end
+
   describe "#display_refund_link_for?" do
     let(:resource) { build(:finance_details, balance: balance) }
 

--- a/spec/presenters/payment_presenter_spec.rb
+++ b/spec/presenters/payment_presenter_spec.rb
@@ -53,42 +53,42 @@ RSpec.describe PaymentPresenter do
     end
   end
 
-  describe "#already_reverted?" do
+  describe "#already_reversed?" do
     before do
       scope = double(:scope)
 
       expect(finance_details).to receive(:payments).and_return(scope)
-      expect(scope).to receive(:where).with(order_key: "123_REVERSAL").and_return([reverted_payment])
+      expect(scope).to receive(:where).with(order_key: "123_REVERSAL").and_return([reversed_payment])
     end
 
     context "if a reversal payment exist for that order key" do
-      let(:reverted_payment) { double(:reverted_payment) }
+      let(:reversed_payment) { double(:reversed_payment) }
 
       it "returns true" do
-        expect(subject).to be_already_reverted
+        expect(subject).to be_already_reversed
       end
     end
 
     context "if a reversal payment do not exist for that order key" do
-      let(:reverted_payment) {}
+      let(:reversed_payment) {}
 
       it "returns false" do
-        expect(subject).to_not be_already_reverted
+        expect(subject).to_not be_already_reversed
       end
     end
   end
 
   describe "#no_action_message" do
-    let(:reverted_payment) { double(:reverted_payment) }
+    let(:reversed_payment) { double(:reversed_payment) }
 
     before do
-      allow(subject).to receive(:already_reverted?).and_return(already_reverted)
+      allow(subject).to receive(:already_reversed?).and_return(already_reversed)
     end
 
-    context "when the payment was already reverted" do
-      let(:already_reverted) { true }
+    context "when the payment was already reversed" do
+      let(:already_reversed) { true }
 
-      it "returns an already reverted message" do
+      it "returns an already reversed message" do
         result = double(:result)
 
         expect(I18n).to receive(:t).with(".reversal_forms.index.already_reversed").and_return(result)
@@ -96,10 +96,10 @@ RSpec.describe PaymentPresenter do
       end
     end
 
-    context "when the payment was not reverted" do
-      let(:already_reverted) { false }
+    context "when the payment was not reversed" do
+      let(:already_reversed) { false }
 
-      it "returns an already reverted message" do
+      it "returns an already reversed message" do
         result = double(:result)
 
         expect(I18n).to receive(:t).with(".reversal_forms.index.not_applicable").and_return(result)
@@ -108,42 +108,42 @@ RSpec.describe PaymentPresenter do
     end
   end
 
-  describe "#revertible?" do
+  describe "#reversible?" do
     let(:user) { double(:user) }
     let(:view) { double(:view, current_user: user) }
 
     before do
-      allow(user).to receive(:can?).with(:revert, payment).and_return(can)
+      allow(user).to receive(:can?).with(:reverse, payment).and_return(can)
     end
 
-    context "when current user cannot revert the object" do
+    context "when current user cannot reverse the object" do
       let(:can) { false }
 
       it "returns false" do
-        expect(subject).to_not be_revertible
+        expect(subject).to_not be_reversible
       end
     end
 
-    context "when current user can revert the object" do
+    context "when current user can reverse the object" do
       let(:can) { true }
 
       before do
-        allow(subject).to receive(:already_reverted?).and_return(already_reverted)
+        allow(subject).to receive(:already_reversed?).and_return(already_reversed)
       end
 
-      context "when the payment is already reverted" do
-        let(:already_reverted) { true }
+      context "when the payment is already reversed" do
+        let(:already_reversed) { true }
 
         it "returns false" do
-          expect(subject).to_not be_revertible
+          expect(subject).to_not be_reversible
         end
       end
 
-      context "when the payment has not been reverted yet" do
-        let(:already_reverted) { false }
+      context "when the payment has not been reversed yet" do
+        let(:already_reversed) { false }
 
         it "returns true" do
-          expect(subject).to be_revertible
+          expect(subject).to be_reversible
         end
       end
     end

--- a/spec/presenters/payment_presenter_spec.rb
+++ b/spec/presenters/payment_presenter_spec.rb
@@ -5,8 +5,9 @@ require "rails_helper"
 RSpec.describe PaymentPresenter do
   let(:finance_details) { double(:finance_details) }
   let(:payment) { double(:payment, finance_details: finance_details, order_key: "123") }
+  let(:view) { nil }
 
-  subject { described_class.new(payment, nil) }
+  subject { described_class.new(payment, view) }
 
   describe ".create_from_collection" do
     it "given a list of objects, returns a list of instances of itself" do
@@ -50,6 +51,103 @@ RSpec.describe PaymentPresenter do
         expect(subject).to_not be_already_refunded
       end
     end
+  end
+
+  describe "#already_reverted?" do
+    before do
+      scope = double(:scope)
+
+      expect(finance_details).to receive(:payments).and_return(scope)
+      expect(scope).to receive(:where).with(order_key: "123_REVERSAL").and_return([reverted_payment])
+    end
+
+    context "if a rerversal payment exist for that order key" do
+      let(:reverted_payment) { double(:reverted_payment) }
+
+      it "returns true" do
+        expect(subject).to be_already_reverted
+      end
+    end
+
+    context "if a rerversal payment do not exist for that order key" do
+      let(:reverted_payment) {}
+
+      it "returns false" do
+        expect(subject).to_not be_already_reverted
+      end
+    end
+  end
+
+  describe "#no_action_message" do
+    let(:reverted_payment) { double(:reverted_payment) }
+
+    before do
+      allow(subject).to receive(:already_reverted?).and_return(already_reverted)
+    end
+
+    context "when the payment was already reverted" do
+      let(:already_reverted) { true }
+
+      it "returns an already reverted message" do
+        result = double(:result)
+
+        expect(I18n).to receive(:t).with(".reversal_forms.index.already_reversed").and_return(result)
+        expect(subject.no_action_message).to eq(result)
+      end
+    end
+
+    context "when the payment was not reverted" do
+      let(:already_reverted) { false }
+
+      it "returns an already reverted message" do
+        result = double(:result)
+
+        expect(I18n).to receive(:t).with(".reversal_forms.index.not_aplicable").and_return(result)
+        expect(subject.no_action_message).to eq(result)
+      end
+    end
+  end
+
+  describe "#revertible?" do
+    let(:user) { double(:user) }
+    let(:view) { double(:view, current_user: user) }
+
+    before do
+      allow(user).to receive(:can?).with(:revert, payment).and_return(can)
+    end
+
+    context "when current user cannot revert the object" do
+      let(:can) { false }
+
+      it "returns false" do
+        expect(subject).to_not be_revertible
+      end
+    end
+
+    context "when current user can revert the object" do
+      let(:can) { true }
+
+      before do
+        allow(subject).to receive(:already_reverted?).and_return(already_reverted)
+      end
+
+      context "when the payment is already reverted" do
+        let(:already_reverted) { true }
+
+        it "returns false" do
+          expect(subject).to_not be_revertible
+        end
+      end
+
+      context "when the payment has not been reverted yet" do
+        let(:already_reverted) { false }
+
+        it "returns true" do
+          expect(subject).to be_revertible
+        end
+      end
+    end
+
   end
 
   describe "#refunded_message" do

--- a/spec/presenters/payment_presenter_spec.rb
+++ b/spec/presenters/payment_presenter_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe PaymentPresenter do
       expect(scope).to receive(:where).with(order_key: "123_REVERSAL").and_return([reverted_payment])
     end
 
-    context "if a rerversal payment exist for that order key" do
+    context "if a reversal payment exist for that order key" do
       let(:reverted_payment) { double(:reverted_payment) }
 
       it "returns true" do
@@ -69,7 +69,7 @@ RSpec.describe PaymentPresenter do
       end
     end
 
-    context "if a rerversal payment do not exist for that order key" do
+    context "if a reversal payment do not exist for that order key" do
       let(:reverted_payment) {}
 
       it "returns false" do
@@ -102,7 +102,7 @@ RSpec.describe PaymentPresenter do
       it "returns an already reverted message" do
         result = double(:result)
 
-        expect(I18n).to receive(:t).with(".reversal_forms.index.not_aplicable").and_return(result)
+        expect(I18n).to receive(:t).with(".reversal_forms.index.not_applicable").and_return(result)
         expect(subject.no_action_message).to eq(result)
       end
     end

--- a/spec/requests/refunds_spec.rb
+++ b/spec/requests/refunds_spec.rb
@@ -63,13 +63,13 @@ RSpec.describe "Refunds", type: :request do
       let(:payment) { renewing_registration.finance_details.payments.first }
 
       before(:each) do
+        renewing_registration.finance_details.orders.first.order_code = payment.order_key
+        renewing_registration.save
+
         sign_in(user)
       end
 
       it "creates a refund payment, redirects to the finance details page and returns a 302 status" do
-        payment.payment_type = WasteCarriersEngine::Payment::CASH
-        payment.save
-
         expected_payments_count = renewing_registration.finance_details.payments.count + 1
 
         post resource_refunds_path(renewing_registration._id), order_key: payment.order_key

--- a/spec/requests/reversal_forms_spec.rb
+++ b/spec/requests/reversal_forms_spec.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "ReversalForms", type: :request do
+  describe "GET /bo/resources/:_id/reversals" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user, :agency_with_refund) }
+      let(:renewing_registration) { create(:renewing_registration, :overpaid) }
+
+      before(:each) do
+        sign_in(user)
+      end
+
+      it "renders the index template and returns a 200 status" do
+        get resource_reversal_forms_path(renewing_registration._id)
+
+        expect(response).to render_template(:index)
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context "when a user is not signed in" do
+      it "redirects to the sign-in page" do
+        get resource_reversal_forms_path("foo")
+
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  describe "GET /bo/resource/:_id/reversals/:order_key/new" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user, :agency_with_refund) }
+      let(:renewing_registration) { create(:renewing_registration, :overpaid) }
+      let(:payment) { renewing_registration.finance_details.payments.first }
+
+      before(:each) do
+        sign_in(user)
+
+        payment.payment_type = "CASH"
+        payment.save
+      end
+
+      it "renders the index template and returns a 200 status" do
+        get new_resource_reversal_form_path(renewing_registration._id, order_key: payment.order_key)
+
+        expect(response).to render_template(:new)
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context "when a user is not signed in" do
+      it "redirects to the sign-in page" do
+        get new_resource_reversal_form_path("foo", order_key: "foo")
+
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  describe "POST /bo/resource/:_id/reversals/:order_key" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user, :agency_with_refund) }
+      let(:renewing_registration) { create(:renewing_registration, :overpaid) }
+      let(:payment) { renewing_registration.finance_details.payments.first }
+
+      before(:each) do
+        sign_in(user)
+
+        payment.payment_type = WasteCarriersEngine::Payment::CASH
+        payment.save
+      end
+
+      context "when params are valid" do
+        let(:params) do
+          {
+            reversal_form: {
+              reason: "A reason."
+            }
+          }
+        end
+        it "creates a reversal payment, redirects to the finance details page and returns a 302 status" do
+          expected_payments_count = renewing_registration.finance_details.payments.count + 1
+
+          post resource_reversal_forms_path(renewing_registration._id, order_key: payment.order_key), params
+
+          renewing_registration.reload
+          expect(renewing_registration.finance_details.payments.count).to eq(expected_payments_count)
+
+          expect(response).to redirect_to(resource_finance_details_path(renewing_registration._id))
+          expect(response).to have_http_status(302)
+        end
+      end
+
+      context "when params are not valid" do
+        it "does not create a reversal payment, renders the new template and returns a 200 status code" do
+          expected_payments_count = renewing_registration.finance_details.payments.count
+
+          post resource_reversal_forms_path(renewing_registration._id, order_key: payment.order_key), {}
+
+          renewing_registration.reload
+          expect(renewing_registration.finance_details.payments.count).to eq(expected_payments_count)
+
+          expect(response).to render_template(:new)
+          expect(response).to have_http_status(200)
+        end
+      end
+    end
+
+    context "when a user is not signed in" do
+      it "redirects to the sign-in page" do
+        post resource_reversal_forms_path("foo", order_key: "bar")
+
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "when a user with the wrong permissions is signed in" do
+      let(:renewing_registration) { create(:renewing_registration, :overpaid) }
+
+      it "redirects to the permissions page" do
+        sign_in(create(:user))
+
+        post resource_reversal_forms_path(renewing_registration._id, order_key: "bar")
+
+        expect(response).to redirect_to("/bo/pages/permission")
+      end
+    end
+  end
+end

--- a/spec/services/process_reversal_service_spec.rb
+++ b/spec/services/process_reversal_service_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ProcessReversalService do
+  describe ".run" do
+    let(:finance_details) { double(:finance_details) }
+    let(:payment) { double(:payment, amount: 10, registration_reference: "Registration reference", order_key: "123") }
+    let(:user) { double(:user, email: "user@example.com") }
+    let(:reason) { "A reason" }
+
+    it "generates a new payment and assigns it to the finance details" do
+      reversal = double(:reversal)
+
+      expect(finance_details).to receive_message_chain(:payments, :<<).with(reversal)
+      expect(WasteCarriersEngine::Payment).to receive(:new).with(payment_type: WasteCarriersEngine::Payment::REVERSAL).and_return(reversal)
+
+      expect(reversal).to receive(:order_key=).with("123_REVERSAL")
+      expect(reversal).to receive(:amount=).with(-10)
+      expect(reversal).to receive(:date_entered=).with(Date.today)
+      expect(reversal).to receive(:date_received=).with(Date.today)
+      expect(reversal).to receive(:registration_reference=).with("Registration reference")
+      expect(reversal).to receive(:updated_by_user=).with("user@example.com")
+      expect(reversal).to receive(:comment=).with("A reason")
+
+      expect(finance_details).to receive(:update_balance)
+      expect(finance_details).to receive(:save!)
+
+      described_class.run({ finance_details: finance_details, payment: payment, user: user, reason: reason })
+    end
+  end
+end

--- a/spec/services/process_reversal_service_spec.rb
+++ b/spec/services/process_reversal_service_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe ProcessReversalService do
       expect(finance_details).to receive(:update_balance)
       expect(finance_details).to receive(:save!)
 
-      described_class.run({ finance_details: finance_details, payment: payment, user: user, reason: reason })
+      described_class.run(finance_details: finance_details, payment: payment, user: user, reason: reason)
     end
   end
 end

--- a/spec/support/shared_examples/abilities/agency_with_refund_examples.rb
+++ b/spec/support/shared_examples/abilities/agency_with_refund_examples.rb
@@ -25,6 +25,40 @@ RSpec.shared_examples "agency_with_refund examples" do
     should be_able_to(:record_postal_order_payment, WasteCarriersEngine::RenewingRegistration)
   end
 
+  context ":revert" do
+    context "when the payment is a cash payment" do
+      let(:payment) { build(:payment, :cash) }
+
+      it "should be able to revert the payment" do
+        should be_able_to(:revert, payment)
+      end
+    end
+
+    context "when the payment is a cheque payment" do
+      let(:payment) { build(:payment, :cheque) }
+
+      it "should be able to revert the payment" do
+        should be_able_to(:revert, payment)
+      end
+    end
+
+    context "when the payment is a postal order" do
+      let(:payment) { build(:payment, :postal_order) }
+
+      it "should be able to revert the payment" do
+        should be_able_to(:revert, payment)
+      end
+    end
+
+    context "when the payment is another type" do
+      let(:payment) { build(:payment) }
+
+      it "should not be able to revert the payment" do
+        should_not be_able_to(:revert, payment)
+      end
+    end
+  end
+
   context ":write_off_small" do
     let(:finance_details) { build(:finance_details, balance: balance) }
 

--- a/spec/support/shared_examples/abilities/agency_with_refund_examples.rb
+++ b/spec/support/shared_examples/abilities/agency_with_refund_examples.rb
@@ -25,36 +25,36 @@ RSpec.shared_examples "agency_with_refund examples" do
     should be_able_to(:record_postal_order_payment, WasteCarriersEngine::RenewingRegistration)
   end
 
-  context ":revert" do
+  context ":reverse" do
     context "when the payment is a cash payment" do
       let(:payment) { build(:payment, :cash) }
 
-      it "should be able to revert the payment" do
-        should be_able_to(:revert, payment)
+      it "should be able to reverse the payment" do
+        should be_able_to(:reverse, payment)
       end
     end
 
     context "when the payment is a cheque payment" do
       let(:payment) { build(:payment, :cheque) }
 
-      it "should be able to revert the payment" do
-        should be_able_to(:revert, payment)
+      it "should be able to reverse the payment" do
+        should be_able_to(:reverse, payment)
       end
     end
 
     context "when the payment is a postal order" do
       let(:payment) { build(:payment, :postal_order) }
 
-      it "should be able to revert the payment" do
-        should be_able_to(:revert, payment)
+      it "should be able to reverse the payment" do
+        should be_able_to(:reverse, payment)
       end
     end
 
     context "when the payment is another type" do
       let(:payment) { build(:payment) }
 
-      it "should not be able to revert the payment" do
-        should_not be_able_to(:revert, payment)
+      it "should not be able to reverse the payment" do
+        should_not be_able_to(:reverse, payment)
       end
     end
   end

--- a/spec/support/shared_examples/abilities/below_agency_with_refund_examples.rb
+++ b/spec/support/shared_examples/abilities/below_agency_with_refund_examples.rb
@@ -5,6 +5,40 @@ RSpec.shared_examples "below agency_with_refund examples" do
     should_not be_able_to(:view_revoked_reasons, WasteCarriersEngine::RenewingRegistration)
   end
 
+  context ":revert" do
+    context "when the payment is a cash payment" do
+      let(:payment) { build(:payment, :cash) }
+
+      it "should not be able to revert the payment" do
+        should_not be_able_to(:revert, payment)
+      end
+    end
+
+    context "when the payment is a cheque payment" do
+      let(:payment) { build(:payment, :cheque) }
+
+      it "should not be able to revert the payment" do
+        should_not be_able_to(:revert, payment)
+      end
+    end
+
+    context "when the payment is a postal order" do
+      let(:payment) { build(:payment, :postal_order) }
+
+      it "should not be able to revert the payment" do
+        should_not be_able_to(:revert, payment)
+      end
+    end
+
+    context "when the payment is another type" do
+      let(:payment) { build(:payment) }
+
+      it "should not be able to revert the payment" do
+        should_not be_able_to(:revert, payment)
+      end
+    end
+  end
+
   it "should not be able to refund a payment" do
     should_not be_able_to(:refund, WasteCarriersEngine::Registration)
   end

--- a/spec/support/shared_examples/abilities/below_agency_with_refund_examples.rb
+++ b/spec/support/shared_examples/abilities/below_agency_with_refund_examples.rb
@@ -5,36 +5,36 @@ RSpec.shared_examples "below agency_with_refund examples" do
     should_not be_able_to(:view_revoked_reasons, WasteCarriersEngine::RenewingRegistration)
   end
 
-  context ":revert" do
+  context ":reverse" do
     context "when the payment is a cash payment" do
       let(:payment) { build(:payment, :cash) }
 
-      it "should not be able to revert the payment" do
-        should_not be_able_to(:revert, payment)
+      it "should not be able to reverse the payment" do
+        should_not be_able_to(:reverse, payment)
       end
     end
 
     context "when the payment is a cheque payment" do
       let(:payment) { build(:payment, :cheque) }
 
-      it "should not be able to revert the payment" do
-        should_not be_able_to(:revert, payment)
+      it "should not be able to reverse the payment" do
+        should_not be_able_to(:reverse, payment)
       end
     end
 
     context "when the payment is a postal order" do
       let(:payment) { build(:payment, :postal_order) }
 
-      it "should not be able to revert the payment" do
-        should_not be_able_to(:revert, payment)
+      it "should not be able to reverse the payment" do
+        should_not be_able_to(:reverse, payment)
       end
     end
 
     context "when the payment is another type" do
       let(:payment) { build(:payment) }
 
-      it "should not be able to revert the payment" do
-        should_not be_able_to(:revert, payment)
+      it "should not be able to reverse the payment" do
+        should_not be_able_to(:reverse, payment)
       end
     end
   end

--- a/spec/support/shared_examples/abilities/finance_admin_examples.rb
+++ b/spec/support/shared_examples/abilities/finance_admin_examples.rb
@@ -11,28 +11,28 @@ RSpec.shared_examples "finance_admin examples" do
     should be_able_to(:view_certificate, WasteCarriersEngine::Registration)
   end
 
-  context ":revert" do
+  context ":reverse" do
     context "when the payment is a worldpay" do
       let(:payment) { build(:payment, :worldpay) }
 
-      it "should be able to revert the payment" do
-        should be_able_to(:revert, payment)
+      it "should be able to reverse the payment" do
+        should be_able_to(:reverse, payment)
       end
     end
 
     context "when the payment is a worldpay_missed" do
       let(:payment) { build(:payment, :worldpay_missed) }
 
-      it "should be able to revert the payment" do
-        should be_able_to(:revert, payment)
+      it "should be able to reverse the payment" do
+        should be_able_to(:reverse, payment)
       end
     end
 
     context "when the payment is another type" do
       let(:payment) { build(:payment) }
 
-      it "should not be able to revert the payment" do
-        should_not be_able_to(:revert, payment)
+      it "should not be able to reverse the payment" do
+        should_not be_able_to(:reverse, payment)
       end
     end
   end

--- a/spec/support/shared_examples/abilities/finance_admin_examples.rb
+++ b/spec/support/shared_examples/abilities/finance_admin_examples.rb
@@ -11,7 +11,31 @@ RSpec.shared_examples "finance_admin examples" do
     should be_able_to(:view_certificate, WasteCarriersEngine::Registration)
   end
 
-  # finance_admin and finance_super users should not be able to do this:
+  context ":revert" do
+    context "when the payment is a worldpay" do
+      let(:payment) { build(:payment, :worldpay) }
+
+      it "should be able to revert the payment" do
+        should be_able_to(:revert, payment)
+      end
+    end
+
+    context "when the payment is a worldpay_missed" do
+      let(:payment) { build(:payment, :worldpay_missed) }
+
+      it "should be able to revert the payment" do
+        should be_able_to(:revert, payment)
+      end
+    end
+
+    context "when the payment is another type" do
+      let(:payment) { build(:payment) }
+
+      it "should not be able to revert the payment" do
+        should_not be_able_to(:revert, payment)
+      end
+    end
+  end
 
   it "should not be able to update a transient registration" do
     should_not be_able_to(:update, WasteCarriersEngine::RenewingRegistration)

--- a/spec/support/shared_examples/abilities/finance_examples.rb
+++ b/spec/support/shared_examples/abilities/finance_examples.rb
@@ -10,6 +10,24 @@ RSpec.shared_examples "finance examples" do
     should be_able_to(:view_certificate, WasteCarriersEngine::Registration)
   end
 
+  context ":revert" do
+    context "when the payment is a bank transfer" do
+      let(:payment) { build(:payment, :bank_transfer) }
+
+      it "should be able to revert the payment" do
+        should be_able_to(:revert, payment)
+      end
+    end
+
+    context "when the payment is another type" do
+      let(:payment) { build(:payment) }
+
+      it "should not be able to revert the payment" do
+        should_not be_able_to(:revert, payment)
+      end
+    end
+  end
+
   # Everything else is off-limits.
 
   it "should not be able to update a transient registration" do

--- a/spec/support/shared_examples/abilities/finance_examples.rb
+++ b/spec/support/shared_examples/abilities/finance_examples.rb
@@ -15,20 +15,20 @@ RSpec.shared_examples "finance examples" do
     should be_able_to(:view_certificate, WasteCarriersEngine::Registration)
   end
 
-  context ":revert" do
+  context ":reverse" do
     context "when the payment is a bank transfer" do
       let(:payment) { build(:payment, :bank_transfer) }
 
-      it "should be able to revert the payment" do
-        should be_able_to(:revert, payment)
+      it "should be able to reverse the payment" do
+        should be_able_to(:reverse, payment)
       end
     end
 
     context "when the payment is another type" do
       let(:payment) { build(:payment) }
 
-      it "should not be able to revert the payment" do
-        should_not be_able_to(:revert, payment)
+      it "should not be able to reverse the payment" do
+        should_not be_able_to(:reverse, payment)
       end
     end
   end


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-822
From: https://eaflood.atlassian.net/browse/RUBY-809

This PR contains the code necessary to give a user the ability to revert a payment.
Given the presence of validations, we have created a form for the revert. 
The controller uses our latest standard for dealing with simple journeys in payments, with the exception that we have added an `index` action and route in order to select a payment to be reverted. 