### PR TITLE
Add view payments ability

### DIFF
--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -3,6 +3,7 @@
 class PaymentsController < ApplicationController
   include CanFetchResource
 
+  prepend_before_action :authorize_user
   prepend_before_action :authenticate_user!
   before_action :define_payment_types
 
@@ -41,5 +42,9 @@ class PaymentsController < ApplicationController
       "new_resource_#{payment_type}_payment_form_path",
       @resource._id
     )
+  end
+
+  def authorize_user
+    authorize! :view_payments, WasteCarriersEngine::Registration
   end
 end

--- a/app/controllers/reversal_forms_controller.rb
+++ b/app/controllers/reversal_forms_controller.rb
@@ -4,6 +4,8 @@ class ReversalFormsController < ResourceFormsController
   include FinanceDetailsHelper
 
   def index
+    authorize! :view_payments, @resource
+
     payments = @resource.finance_details.payments.reversible
     @payments = ::PaymentPresenter.create_from_collection(payments, view_context)
   end

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -41,19 +41,13 @@ module ActionLinksHelper
     # TODO: Temporary - for release only. See: https://eaflood.atlassian.net/browse/RUBY-846
     return false if a_registration?(resource)
 
-    resource.upper_tier?
+    resource.upper_tier? && can?(:view_payments, resource)
   end
 
   def display_refund_link_for?(resource)
     return false if resource.balance >= 0
 
     can?(:refund, resource)
-  end
-
-  def display_reverse_link?
-    roles_with_reverse_ability = %w[agency_with_refund agency_super finance_admin finance finance_super]
-
-    roles_with_reverse_ability.include?(current_user.role)
   end
 
   def display_finance_details_link_for?(resource)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -57,6 +57,8 @@ class Ability
     can :record_cash_payment, :all
     can :record_cheque_payment, :all
     can :record_postal_order_payment, :all
+    can :view_payments, :all
+
     can :write_off_small, WasteCarriersEngine::FinanceDetails do |finance_details|
       finance_details.zero_difference_balance <= write_off_agency_user_cap
     end
@@ -70,6 +72,7 @@ class Ability
     can :view_certificate, WasteCarriersEngine::Registration
     can :record_bank_transfer_payment, :all
 
+    can :view_payments, :all
     can :reverse, WasteCarriersEngine::Payment, &:bank_transfer?
   end
 
@@ -78,6 +81,7 @@ class Ability
     can :write_off_large, WasteCarriersEngine::FinanceDetails
     can :view_certificate, WasteCarriersEngine::Registration
     can :record_worldpay_missed_payment, :all
+    can :view_payments, :all
 
     can :reverse, WasteCarriersEngine::Payment do |payment|
       payment.worldpay? || payment.worldpay_missed?

--- a/app/views/shared/registrations/_finance_action_links.html.erb
+++ b/app/views/shared/registrations/_finance_action_links.html.erb
@@ -4,7 +4,7 @@
       <%= link_to t(".enter_payment"), new_resource_payment_path(registration._id), class: "button wcr-finance-button" %>
     <% end %>
 
-    <% if display_reverse_link? %>
+    <% if can?(:view_payments, registration) %>
       <%= link_to t(".reverse_payment"), resource_reversal_forms_path(registration._id), class: "button wcr-finance-button" %>
     <% end %>
 

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -137,30 +137,6 @@ RSpec.describe ActionLinksHelper, type: :helper do
     end
   end
 
-  describe "#display_reverse_link?" do
-    let(:current_user) { double(:current_user, role: role) }
-
-    before do
-      allow(helper).to receive(:current_user).and_return(current_user)
-    end
-
-    context "when the current user is in the allowed group of roles" do
-      let(:role) { "agency_with_refund" }
-
-      it "returns true" do
-        expect(helper.display_reverse_link?).to be_truthy
-      end
-    end
-
-    context "when the current user is not in the allowed group of roles" do
-      let(:role) { "foo" }
-
-      it "returns false" do
-        expect(helper.display_reverse_link?).to be_falsey
-      end
-    end
-  end
-
   describe "#display_refund_link_for?" do
     let(:resource) { build(:finance_details, balance: balance) }
 

--- a/spec/requests/payments_spec.rb
+++ b/spec/requests/payments_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Payments", type: :request do
 
   describe "GET /bo/resources/:_id/payments" do
     context "when a valid user is signed in" do
-      let(:user) { create(:user, :agency) }
+      let(:user) { create(:user, :agency_super) }
       before(:each) do
         sign_in(user)
       end
@@ -34,7 +34,7 @@ RSpec.describe "Payments", type: :request do
 
   describe "POST /bo/resources/:_id/payments" do
     context "when a valid user is signed in" do
-      let(:user) { create(:user, :agency) }
+      let(:user) { create(:user, :agency_super) }
 
       before(:each) do
         sign_in(user)

--- a/spec/support/shared_examples/abilities/agency_with_refund_examples.rb
+++ b/spec/support/shared_examples/abilities/agency_with_refund_examples.rb
@@ -25,6 +25,10 @@ RSpec.shared_examples "agency_with_refund examples" do
     should be_able_to(:record_postal_order_payment, WasteCarriersEngine::RenewingRegistration)
   end
 
+  it "should be able to view payments" do
+    should be_able_to(:view_payments, WasteCarriersEngine::RenewingRegistration)
+  end
+
   context ":reverse" do
     context "when the payment is a cash payment" do
       let(:payment) { build(:payment, :cash) }

--- a/spec/support/shared_examples/abilities/below_agency_with_refund_examples.rb
+++ b/spec/support/shared_examples/abilities/below_agency_with_refund_examples.rb
@@ -39,6 +39,10 @@ RSpec.shared_examples "below agency_with_refund examples" do
     end
   end
 
+  it "should not be able to view payments" do
+    should_not be_able_to(:view_payments, WasteCarriersEngine::RenewingRegistration)
+  end
+
   it "should not be able to refund a payment" do
     should_not be_able_to(:refund, WasteCarriersEngine::Registration)
   end

--- a/spec/support/shared_examples/abilities/finance_admin_examples.rb
+++ b/spec/support/shared_examples/abilities/finance_admin_examples.rb
@@ -11,6 +11,10 @@ RSpec.shared_examples "finance_admin examples" do
     should be_able_to(:view_certificate, WasteCarriersEngine::Registration)
   end
 
+  it "should be able to view payments" do
+    should be_able_to(:view_payments, WasteCarriersEngine::RenewingRegistration)
+  end
+
   context ":reverse" do
     context "when the payment is a worldpay" do
       let(:payment) { build(:payment, :worldpay) }

--- a/spec/support/shared_examples/abilities/finance_examples.rb
+++ b/spec/support/shared_examples/abilities/finance_examples.rb
@@ -11,6 +11,10 @@ RSpec.shared_examples "finance examples" do
     should_not be_able_to(:charge_adjust, WasteCarriersEngine::Registration)
   end
 
+  it "should be able to view payments" do
+    should be_able_to(:view_payments, WasteCarriersEngine::RenewingRegistration)
+  end
+
   it "should be able to view the certificate" do
     should be_able_to(:view_certificate, WasteCarriersEngine::Registration)
   end


### PR DESCRIPTION
Currently, abilities for managing payments and reversale are bounded to the type of payment the user can deal with. Given that, in order to being able to block a user from viewving intermediary screens and links to those functionality me and Iris have decided to add a `view_payments` ability.