### PR TITLE
Fix id of fieldset for validation link

### DIFF
--- a/app/views/write_off_forms/new.html.erb
+++ b/app/views/write_off_forms/new.html.erb
@@ -22,7 +22,7 @@
 
     <%= form_for(@write_off_form, url: resource_write_off_form_path(@resource._id)) do |f| %>
       <div class="form-group <%= "form-group-error" if @write_off_form.errors[:comment].any? %>">
-        <fieldset id="write_off">
+        <fieldset id="comment">
           <legend class="visuallyhidden">
             <%= t(".heading", reg_identifier: @resource.reg_identifier) %>
           </legend>


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-810

This fixes the id of the fieldset containing the comment so that the validation message link can find the correct anchor