### PR TITLE
Fix missing text on registration page

### DIFF
--- a/config/locales/shared/registrations.en.yml
+++ b/config/locales/shared/registrations.en.yml
@@ -17,7 +17,9 @@ en:
             overseas: "Business owner details"
             partnership: "Partners details"
             soleTrader: "Business owner details"
-            publicBody: "Public body"
+            publicBody: "Chief executive details"
+            charity: "Main people details"
+            authority: "Chief executive details"
       contact_and_business_details_panels:
         contact_information:
           heading: "Contact details"


### PR DESCRIPTION
While checking something unrelated, I spotted that the registration details page didn't take into account some of the old business types which are still generated by the frontend. This resulted in I18n errors.

I wasn't sure what the people for a charity should be called, as technically those should always be lower tier, so just went with a generic "Main people details".