### PR TITLE
Add ability to complete a registration after payment

### DIFF
--- a/app/controllers/concerns/can_complete_if_possible.rb
+++ b/app/controllers/concerns/can_complete_if_possible.rb
@@ -7,7 +7,7 @@ module CanCompleteIfPossible
     private
 
     def complete_if_possible
-      return false unless @resource.is_a?(WasteCarriersEngine::Registration)
+      return false unless can_complete?
 
       WasteCarriersEngine::RegistrationCompletionService.run(registration: @resource)
 
@@ -17,6 +17,10 @@ module CanCompleteIfPossible
       Rails.logger.error e
 
       false
+    end
+
+    def can_complete?
+      @resource.is_a?(WasteCarriersEngine::Registration)
     end
   end
 end

--- a/app/controllers/concerns/can_complete_if_possible.rb
+++ b/app/controllers/concerns/can_complete_if_possible.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module CanCompleteIfPossible
+  extend ActiveSupport::Concern
+
+  included do
+    private
+
+    def complete_if_possible
+      return false unless @resource.is_a?(WasteCarriersEngine::Registration)
+
+      WasteCarriersEngine::RegistrationCompletionService.run(registration: @resource)
+
+      true
+    rescue StandardError => e
+      Airbrake.notify(e, reg_identifier: @resource.reg_identifier)
+      Rails.logger.error e
+
+      false
+    end
+  end
+end

--- a/app/controllers/resource_forms_controller.rb
+++ b/app/controllers/resource_forms_controller.rb
@@ -5,6 +5,7 @@
 class ResourceFormsController < ApplicationController
   include CanFetchResource
   include CanRenewIfPossible
+  include CanCompleteIfPossible
 
   extend ActiveModel::Callbacks
   define_model_callbacks :renew
@@ -54,6 +55,8 @@ class ResourceFormsController < ApplicationController
     if renew_if_possible
       redirect_to resource_finance_details_path(@resource.registration._id)
     else
+      complete_if_possible
+
       redirect_to resource_finance_details_path(@resource._id)
     end
   end

--- a/spec/factories/finance_details.rb
+++ b/spec/factories/finance_details.rb
@@ -17,6 +17,12 @@ FactoryBot.define do
       after(:build, :create, &:update_balance)
     end
 
+    trait :has_unpaid_order do
+      orders { [build(:order, :has_required_data)] }
+
+      after(:build, :create, &:update_balance)
+    end
+
     trait :has_overpaid_order_and_payment do
       orders { [build(:order, :has_required_data)] }
       payments do

--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -28,6 +28,10 @@ FactoryBot.define do
       metaData { build(:metaData, :pending) }
     end
 
+    trait :has_unpaid_order do
+      finance_details { build(:finance_details, :has_unpaid_order) }
+    end
+
     trait :active do
       metaData { build(:metaData, :active) }
     end

--- a/spec/requests/bank_transfer_payment_forms_spec.rb
+++ b/spec/requests/bank_transfer_payment_forms_spec.rb
@@ -6,9 +6,7 @@ RSpec.describe "BankTransferPaymentForms", type: :request do
   let(:transient_registration) do
     create(:renewing_registration, :has_finance_details, :does_not_require_conviction_check)
   end
-  let(:registration) do
-    WasteCarriersEngine::Registration.where(reg_identifier: transient_registration.reg_identifier).first
-  end
+  let(:registration) { transient_registration.registration }
 
   describe "GET /bo/resources/:_id/payments/bank-transfer" do
     context "when a valid user is signed in" do
@@ -63,49 +61,52 @@ RSpec.describe "BankTransferPaymentForms", type: :request do
       }
     end
 
-    before do
-      # Block renewal completion so we can check the values of the transient_registration after submission
-      allow_any_instance_of(WasteCarriersEngine::RenewalCompletionService).to receive(:complete_renewal).and_return(nil)
-    end
-
     context "when a valid user is signed in" do
       let(:user) { create(:user, :finance) }
+
       before(:each) do
         sign_in(user)
       end
 
-      it "redirects to the registration finance page" do
-        registration = transient_registration.registration
-
-        post "/bo/resources/#{transient_registration._id}/payments/bank-transfer", bank_transfer_payment_form: params
-
-        expect(response).to redirect_to(resource_finance_details_path(registration._id))
-      end
-
-      it "creates a new payment" do
-        old_payments_count = transient_registration.finance_details.payments.count
-        post "/bo/resources/#{transient_registration._id}/payments/bank-transfer", bank_transfer_payment_form: params
-        expect(transient_registration.reload.finance_details.payments.count).to eq(old_payments_count + 1)
-      end
-
-      it "assigns the correct updated_by_user to the payment" do
-        post "/bo/resources/#{transient_registration._id}/payments/bank-transfer", bank_transfer_payment_form: params
-        expect(transient_registration.reload.finance_details.payments.first.updated_by_user).to eq(user.email)
-      end
-
       context "when there is no pending conviction check" do
-        before do
-          transient_registration.conviction_sign_offs = [build(:conviction_sign_off, :confirmed)]
-          # Disable the stubbing as we want to test the full behaviour this time
-          allow_any_instance_of(WasteCarriersEngine::RenewalCompletionService).to receive(:complete_renewal).and_call_original
+        it "renews the transient registration, redirects to the registration finance page, creates a new payment and assigns the correct updated_by_user to the payment" do
+          old_payments_count = registration.finance_details.payments.count
+          expected_expiry_date = registration.expires_on.to_date + 3.years
+
+          post "/bo/resources/#{transient_registration._id}/payments/bank-transfer", bank_transfer_payment_form: params
+
+          registration.reload
+          actual_expiry_date = registration.expires_on.to_date
+
+          expect(response).to redirect_to(resource_finance_details_path(registration._id))
+          expect(registration.finance_details.payments.count).to be > old_payments_count
+          expect(registration.finance_details.payments.last.updated_by_user).to eq(user.email)
         end
 
-        it "renews the registration" do
-          expected_expiry_date = registration.expires_on.to_date + 3.years
-          post "/bo/resources/#{transient_registration._id}/payments/bank-transfer", bank_transfer_payment_form: params
-          actual_expiry_date = registration.reload.expires_on.to_date
+        context "when the resource is a registration" do
+          let(:registration) { create(:registration, :pending, :has_unpaid_order) }
+          let(:params) do
+            {
+              amount: "110.00",
+              comment: "foo",
+              registration_reference: "foo",
+              date_received_day: "1",
+              date_received_month: "1",
+              date_received_year: "2018"
+            }
+          end
 
-          expect(actual_expiry_date).to eq(expected_expiry_date)
+          it "completes the registration, redirects to the registration finance page and creates a new payment" do
+            old_payments_count = registration.finance_details.payments.count
+
+            post "/bo/resources/#{registration._id}/payments/bank-transfer", bank_transfer_payment_form: params
+
+            registration.reload
+
+            expect(response).to redirect_to(resource_finance_details_path(registration._id))
+            expect(registration.finance_details.payments.count).to be > old_payments_count
+            expect(registration).to be_active
+          end
         end
       end
 
@@ -118,8 +119,32 @@ RSpec.describe "BankTransferPaymentForms", type: :request do
 
         it "does not renews the registration" do
           old_renewal_date = registration.expires_on
+
           post "/bo/resources/#{transient_registration._id}/payments/bank-transfer", bank_transfer_payment_form: params
+
           expect(registration.reload.expires_on).to eq(old_renewal_date)
+        end
+
+        context "when the resource is a registration" do
+          let(:registration) { create(:registration, :pending, :has_unpaid_order, :requires_conviction_check) }
+          let(:params) do
+            {
+              amount: registration.finance_details.balance,
+              comment: "foo",
+              registration_reference: "foo",
+              date_received_day: "1",
+              date_received_month: "1",
+              date_received_year: "2018"
+            }
+          end
+
+          it "does not completes the registration" do
+            post "/bo/resources/#{transient_registration._id}/payments/bank-transfer", bank_transfer_payment_form: params
+
+            registration.reload
+
+            expect(registration).to_not be_active
+          end
         end
       end
 

--- a/spec/requests/bank_transfer_payment_forms_spec.rb
+++ b/spec/requests/bank_transfer_payment_forms_spec.rb
@@ -81,6 +81,7 @@ RSpec.describe "BankTransferPaymentForms", type: :request do
           expect(response).to redirect_to(resource_finance_details_path(registration._id))
           expect(registration.finance_details.payments.count).to be > old_payments_count
           expect(registration.finance_details.payments.last.updated_by_user).to eq(user.email)
+          expect(actual_expiry_date).to eq(expected_expiry_date)
         end
 
         context "when the resource is a registration" do

--- a/spec/requests/cash_payment_forms_spec.rb
+++ b/spec/requests/cash_payment_forms_spec.rb
@@ -6,9 +6,7 @@ RSpec.describe "CashPaymentForms", type: :request do
   let(:transient_registration) do
     create(:renewing_registration, :has_finance_details, :does_not_require_conviction_check)
   end
-  let(:registration) do
-    WasteCarriersEngine::Registration.where(reg_identifier: transient_registration.reg_identifier).first
-  end
+  let(:registration) do { transient_registration.registration }
 
   describe "GET /bo/resources/:_id/payments/cash" do
     context "when a valid user is signed in" do

--- a/spec/requests/cash_payment_forms_spec.rb
+++ b/spec/requests/cash_payment_forms_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "CashPaymentForms", type: :request do
   let(:transient_registration) do
     create(:renewing_registration, :has_finance_details, :does_not_require_conviction_check)
   end
-  let(:registration) do { transient_registration.registration }
+  let(:registration) { transient_registration.registration }
 
   describe "GET /bo/resources/:_id/payments/cash" do
     context "when a valid user is signed in" do


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-826

We have realised that we don't only have to renew a registration when a payment clears the balance on a renewal, but also complete a registration when the payments clears the balance of a registration and there are no pending conviction checks. This updates the code to handle the completion of a registration when a payment is taken.