### PR TITLE
Rename payment to payment form

### DIFF
--- a/app/controllers/payment_forms_controller.rb
+++ b/app/controllers/payment_forms_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class PaymentsController < ApplicationController
+class PaymentFormsController < ApplicationController
   include CanFetchResource
 
   prepend_before_action :authorize_user

--- a/app/views/cash_payment_forms/new.html.erb
+++ b/app/views/cash_payment_forms/new.html.erb
@@ -1,6 +1,6 @@
 <div class="grid-row">
   <div class="column-two-thirds">
-    <%= render("waste_carriers_engine/shared/back", back_path: new_resource_payment_path(@resource._id)) %>
+    <%= render("waste_carriers_engine/shared/back", back_path: new_resource_payment_form_path(@resource._id)) %>
 
     <%= render("waste_carriers_engine/shared/errors", object: @cash_payment_form) %>
 

--- a/app/views/cheque_payment_forms/new.html.erb
+++ b/app/views/cheque_payment_forms/new.html.erb
@@ -1,6 +1,6 @@
 <div class="grid-row">
   <div class="column-two-thirds">
-    <%= render("waste_carriers_engine/shared/back", back_path: new_resource_payment_path(@resource._id)) %>
+    <%= render("waste_carriers_engine/shared/back", back_path: new_resource_payment_form_path(@resource._id)) %>
 
     <%= render("waste_carriers_engine/shared/errors", object: @cheque_payment_form) %>
 

--- a/app/views/payment_forms/new.html.erb
+++ b/app/views/payment_forms/new.html.erb
@@ -2,7 +2,7 @@
   <div class="column-two-thirds">
     <%= render("waste_carriers_engine/shared/back", back_path: resource_finance_details_path(@resource._id)) %>
 
-    <%= form_for(:payment_form, url: resource_payments_path(@resource._id)) do |f| %>
+    <%= form_for(:payment_form, url: resource_payment_forms_path(@resource._id)) do |f| %>
       <h1 class="heading-large">
         <%= t(".heading") %>
       </h1>

--- a/app/views/postal_order_payment_forms/new.html.erb
+++ b/app/views/postal_order_payment_forms/new.html.erb
@@ -1,6 +1,6 @@
 <div class="grid-row">
   <div class="column-two-thirds">
-    <%= render("waste_carriers_engine/shared/back", back_path: new_resource_payment_path(@resource._id)) %>
+    <%= render("waste_carriers_engine/shared/back", back_path: new_resource_payment_form_path(@resource._id)) %>
 
     <%= render("waste_carriers_engine/shared/errors", object: @postal_order_payment_form) %>
 

--- a/app/views/shared/registrations/_action_links_panel.html.erb
+++ b/app/views/shared/registrations/_action_links_panel.html.erb
@@ -52,7 +52,7 @@
 
     <% if display_payment_link_for?(resource) %>
       <li>
-        <%= link_to t(".actions_box.links.process_payment"), new_resource_payment_path(resource._id) %>
+        <%= link_to t(".actions_box.links.process_payment"), new_resource_payment_form_path(resource._id) %>
       </li>
     <% end %>
 

--- a/app/views/shared/registrations/_finance_action_links.html.erb
+++ b/app/views/shared/registrations/_finance_action_links.html.erb
@@ -1,7 +1,7 @@
 <div class="grid-row">
   <div class="column-full">
     <% if display_payment_link_for?(registration) %>
-      <%= link_to t(".enter_payment"), new_resource_payment_path(registration._id), class: "button wcr-finance-button" %>
+      <%= link_to t(".enter_payment"), new_resource_payment_form_path(registration._id), class: "button wcr-finance-button" %>
     <% end %>
 
     <% if can?(:view_payments, registration) %>

--- a/app/views/shared/registrations/_pending_payment_panel.html.erb
+++ b/app/views/shared/registrations/_pending_payment_panel.html.erb
@@ -6,6 +6,6 @@
     <%= t(".status.messages.pending_payment", total: display_pence_as_pounds(resource.finance_details.balance)) %>
   </p>
   <% if display_payment_link_for?(resource) %>
-    <%= link_to t(".status.actions.payment_button"), new_resource_payment_path(resource._id), class: 'button' %>
+    <%= link_to t(".status.actions.payment_button"), new_resource_payment_form_path(resource._id), class: 'button' %>
   <% end %>
 </div>

--- a/app/views/worldpay_missed_payment_forms/new.html.erb
+++ b/app/views/worldpay_missed_payment_forms/new.html.erb
@@ -1,6 +1,6 @@
 <div class="grid-row">
   <div class="column-two-thirds">
-    <%= render("waste_carriers_engine/shared/back", back_path: new_resource_payment_path(@resource._id)) %>
+    <%= render("waste_carriers_engine/shared/back", back_path: new_resource_payment_form_path(@resource._id)) %>
 
     <%= render("waste_carriers_engine/shared/errors", object: @worldpay_missed_payment_form) %>
 

--- a/config/locales/payment_forms.en.yml
+++ b/config/locales/payment_forms.en.yml
@@ -1,5 +1,5 @@
 en:
-  payments:
+  payment_forms:
     new:
       title: "Add a payment"
       heading: "How was this payment made?"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,8 +33,9 @@ Rails.application.routes.draw do
                         path_names: { new: ":order_key/new" },
                         param: :order_key
 
-              resources :payments,
+              resources :payment_forms,
                         only: %i[new create],
+                        path: "payments",
                         path_names: { new: "" }
 
               resources :cash_payment_forms,

--- a/spec/requests/payment_forms_spec.rb
+++ b/spec/requests/payment_forms_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Payments", type: :request do
+RSpec.describe "PaymentForms", type: :request do
   let(:transient_registration) { create(:renewing_registration) }
 
   describe "GET /bo/resources/:_id/payments" do


### PR DESCRIPTION
In order to add validations to the payments page, we want to take advantage of forms.
For this reason, we are renaming the resources to include form to keep it consistent with the rest of our resources dealing with forms.