### PR TITLE
Fix parsing of amounts to flash message

### DIFF
--- a/app/controllers/bank_transfer_payment_forms_controller.rb
+++ b/app/controllers/bank_transfer_payment_forms_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class BankTransferPaymentFormsController < ResourceFormsController
-  include FinanceDetailsHelper
-
   def new
     super(BankTransferPaymentForm, "bank_transfer_payment_form")
   end
@@ -14,7 +12,7 @@ class BankTransferPaymentFormsController < ResourceFormsController
 
     flash[:success] = I18n.t(
       "payments.messages.success",
-      amount: display_pence_as_pounds_and_cents(@bank_transfer_payment_form.amount)
+      amount: @bank_transfer_payment_form.amount
     )
   end
 

--- a/app/controllers/cash_payment_forms_controller.rb
+++ b/app/controllers/cash_payment_forms_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class CashPaymentFormsController < ResourceFormsController
-  include FinanceDetailsHelper
-
   def new
     super(CashPaymentForm, "cash_payment_form")
   end
@@ -14,7 +12,7 @@ class CashPaymentFormsController < ResourceFormsController
 
     flash[:success] = I18n.t(
       "payments.messages.success",
-      amount: display_pence_as_pounds_and_cents(@cash_payment_form.amount)
+      amount: @cash_payment_form.amount
     )
   end
 

--- a/app/controllers/cheque_payment_forms_controller.rb
+++ b/app/controllers/cheque_payment_forms_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class ChequePaymentFormsController < ResourceFormsController
-  include FinanceDetailsHelper
-
   def new
     super(ChequePaymentForm, "cheque_payment_form")
   end
@@ -14,7 +12,7 @@ class ChequePaymentFormsController < ResourceFormsController
 
     flash[:success] = I18n.t(
       "payments.messages.success",
-      amount: display_pence_as_pounds_and_cents(@cheque_payment_form.amount)
+      amount: @cheque_payment_form.amount
     )
   end
 

--- a/app/controllers/postal_order_payment_forms_controller.rb
+++ b/app/controllers/postal_order_payment_forms_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class PostalOrderPaymentFormsController < ResourceFormsController
-  include FinanceDetailsHelper
-
   def new
     super(PostalOrderPaymentForm, "postal_order_payment_form")
   end
@@ -14,7 +12,7 @@ class PostalOrderPaymentFormsController < ResourceFormsController
 
     flash[:success] = I18n.t(
       "payments.messages.success",
-      amount: display_pence_as_pounds_and_cents(@postal_order_payment_form.amount)
+      amount: @postal_order_payment_form.amount
     )
   end
 

--- a/app/controllers/worldpay_missed_payment_forms_controller.rb
+++ b/app/controllers/worldpay_missed_payment_forms_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class WorldpayMissedPaymentFormsController < ResourceFormsController
-  include FinanceDetailsHelper
-
   before_renew :change_state_if_possible
 
   def new
@@ -16,7 +14,7 @@ class WorldpayMissedPaymentFormsController < ResourceFormsController
 
     flash[:success] = I18n.t(
       "payments.messages.success",
-      amount: display_pence_as_pounds_and_cents(@worldpay_missed_payment_form.amount)
+      amount: @worldpay_missed_payment_form.amount
     )
   end
 


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-899

This fixes the parsing of amounts to flash messages.
We were under the assumption that amounts are always in cents, but this is not the case for payments forms.