### PR TITLE
Fix validation on amounts

### DIFF
--- a/app/forms/concerns/can_have_charge_adjust_attributes.rb
+++ b/app/forms/concerns/can_have_charge_adjust_attributes.rb
@@ -6,8 +6,7 @@ module CanHaveChargeAdjustAttributes
   included do
     attr_accessor :amount, :reference, :description
 
-    # Format: 102.30 - At least a digit, can have a dot and up to two digits after it.
-    validates :amount, presence: true, format: { with: /\A\d+\.?\d?\d?\z/ }
+    validates :amount, presence: true, numericality: { greater_than: 0 }
     validates :reference, presence: true
     validates :description, presence: true, length: { maximum: 500 }
   end

--- a/app/forms/payment_form.rb
+++ b/app/forms/payment_form.rb
@@ -28,6 +28,8 @@ class PaymentForm < WasteCarriersEngine::BaseForm
     params[:date_received] = set_date_received
     params[:payment_type] = payment_type_value
 
+    return false unless valid?
+
     build_payment(params)
     update_finance_details
 

--- a/config/locales/negative_charge_adjust_forms.en.yml
+++ b/config/locales/negative_charge_adjust_forms.en.yml
@@ -21,7 +21,8 @@ en:
           attributes:
             amount:
               blank: "Enter amount"
-              invalid: "Amount is invalid"
+              not_a_number: "Amount is invalid"
+              greater_than: "You must enter a positive number"
             description:
               blank: "Enter a reason"
               too_long: "Description must be %{count} characters or fewer"

--- a/config/locales/positive_charge_adjust_forms.en.yml
+++ b/config/locales/positive_charge_adjust_forms.en.yml
@@ -21,7 +21,8 @@ en:
           attributes:
             amount:
               blank: "Enter amount"
-              invalid: "Amount is invalid"
+              not_a_number: "Amount is invalid"
+              greater_than: "You must enter a positive number"
             description:
               blank: "Enter a reason"
               too_long: "Description must be %{count} characters or fewer"


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-894

This PR fixes some insconsistency on the way we validate our amounts in the payments and charge adjust forms.
This also fixes a bug for which submitting a payment form without an amount results in a 500 error. This bug was dues
to the fact that we were not validating the form data before creating a payment on the object when submitting the form
.
Another issue related to this has to deal with an existing bug on the re-implementation of the Enumerable module from
rails, for which the `sum` method called on a `[nil]` collection returns 0 rather than throwing an error as per ruby's implementation (https://github.com/rails/rails/issues/24796). Given this,
our test suite was missing to report the error because our test always run on objects with no existing payments.