### PR TITLE
Add form to charge adjust in order to handle validations

### DIFF
--- a/app/controllers/charge_adjust_forms_controller.rb
+++ b/app/controllers/charge_adjust_forms_controller.rb
@@ -5,14 +5,13 @@ class ChargeAdjustFormsController < ApplicationController
 
   prepend_before_action :authenticate_user!
   before_action :authorize_user
+  before_action :fetch_form
 
   def new; end
 
   def create
-    charge_type = params.fetch(:charge_adjust_form, {})[:charge_type]
-
-    if valid_charge_type?(charge_type)
-      redirect_to public_send("new_resource_#{charge_type}_charge_adjust_form_path")
+    if @charge_adjust_form.submit(charge_adjust_form_attributes)
+      redirect_to public_send("new_resource_#{@charge_adjust_form.charge_type}_charge_adjust_form_path")
     else
       render :new
     end
@@ -20,11 +19,15 @@ class ChargeAdjustFormsController < ApplicationController
 
   private
 
-  def valid_charge_type?(charge_type)
-    %w[positive negative].include?(charge_type)
+  def charge_adjust_form_attributes
+    params.fetch(:charge_adjust_form, {}).permit(:charge_type)
   end
 
   def authorize_user
     authorize! :charge_adjust, @resource
+  end
+
+  def fetch_form
+    @charge_adjust_form = ChargeAdjustForm.new
   end
 end

--- a/app/forms/charge_adjust_form.rb
+++ b/app/forms/charge_adjust_form.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class ChargeAdjustForm
+  include ActiveModel::Model
+
+  attr_accessor :charge_type
+
+  validates :charge_type, presence: true
+
+  def submit(params)
+    self.charge_type = params[:charge_type]
+
+    valid?
+  end
+end

--- a/app/views/charge_adjust_forms/new.html.erb
+++ b/app/views/charge_adjust_forms/new.html.erb
@@ -6,6 +6,8 @@
 
 <div class="grid-row">
   <div class="column-two-thirds">
+    <%= render("waste_carriers_engine/shared/errors", object: @charge_adjust_form) %>
+
     <h1 class="heading-large">
       <%= t(".heading", reg_identifier: @resource.reg_identifier) %>
     </h1>
@@ -14,12 +16,16 @@
       <%= render "shared/company_details_panel", registration: @resource %>
     </div>
 
-    <%= form_for(:charge_adjust_form, url: resource_charge_adjust_form_path(@resource._id)) do |f| %>
-      <div class="form-group">
+    <%= form_for(@charge_adjust_form, url: resource_charge_adjust_form_path(@resource._id)) do |f| %>
+      <div class="form-group <%= "form-group-error" if @charge_adjust_form.errors[:charge_type].any? %>" id="charge_type">
         <fieldset id="charge-adjust">
           <legend class="visuallyhidden">
             <%= t(".heading", reg_identifier: @resource.reg_identifier) %>
           </legend>
+
+          <% if @charge_adjust_form.errors[:charge_type].any? %>
+            <span class="error-message"><%= @charge_adjust_form.errors[:charge_type].join(", ") %></span>
+          <% end %>
 
           <div class="multiple-choice">
             <%= f.radio_button :charge_type, :positive %>

--- a/config/locales/charge_adjust_forms.en.yml
+++ b/config/locales/charge_adjust_forms.en.yml
@@ -11,3 +11,10 @@ en:
           label: "Negative charge adjustment"
           hint: "Charge reduction, credits the registration"
       confirm: "Continue"
+  activemodel:
+    errors:
+      models:
+        charge_adjust_form:
+          attributes:
+            charge_type:
+              blank: "Select positive or negative charge"

--- a/spec/forms/charge_adjust_form_spec.rb
+++ b/spec/forms/charge_adjust_form_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ChargeAdjustForm do
+  describe "#submit" do
+    context "when parameters are valid" do
+      let(:params) { { charge_type: "positive" } }
+
+      it "returns true" do
+        expect(subject.submit(params)).to be_truthy
+      end
+    end
+
+    context "when parameters are invalid" do
+      let(:params) { { charge_type: "foo" } }
+
+      it "returns false" do
+        expect(subject.submit(params)).to be_falsey
+      end
+    end
+
+    context "when parameters are empty" do
+      it "returns false" do
+        expect(subject.submit({})).to be_falsey
+      end
+    end
+  end
+end

--- a/spec/forms/charge_adjust_form_spec.rb
+++ b/spec/forms/charge_adjust_form_spec.rb
@@ -12,14 +12,6 @@ RSpec.describe ChargeAdjustForm do
       end
     end
 
-    context "when parameters are invalid" do
-      let(:params) { { charge_type: "foo" } }
-
-      it "returns false" do
-        expect(subject.submit(params)).to be_falsey
-      end
-    end
-
     context "when parameters are empty" do
       it "returns false" do
         expect(subject.submit({})).to be_falsey


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-870

In order to handle validations on the charge adjust page, we have decided that we are going to use a simple version of forms object to be consistent with the rest of our codebase.
For more info: https://github.com/DEFRA/waste-carriers-back-office/pull/685