### PR TITLE
Rename PaymentForm to BasePaymentForm

### DIFF
--- a/app/forms/bank_transfer_payment_form.rb
+++ b/app/forms/bank_transfer_payment_form.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class BankTransferPaymentForm < PaymentForm
+class BankTransferPaymentForm < BasePaymentForm
   def submit(params)
     payment_type_value = "BANKTRANSFER"
     super(params, payment_type_value)

--- a/app/forms/base_payment_form.rb
+++ b/app/forms/base_payment_form.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class PaymentForm < WasteCarriersEngine::BaseForm
+class BasePaymentForm < WasteCarriersEngine::BaseForm
   attr_accessor :amount, :comment, :date_received, :date_received_day, :date_received_month, :date_received_year,
                 :order_key, :payment_type, :registration_reference, :updated_by_user,
                 :finance_details, :order, :payment

--- a/app/forms/cash_payment_form.rb
+++ b/app/forms/cash_payment_form.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CashPaymentForm < PaymentForm
+class CashPaymentForm < BasePaymentForm
   def submit(params)
     payment_type_value = "CASH"
     super(params, payment_type_value)

--- a/app/forms/cheque_payment_form.rb
+++ b/app/forms/cheque_payment_form.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ChequePaymentForm < PaymentForm
+class ChequePaymentForm < BasePaymentForm
   def submit(params)
     payment_type_value = "CHEQUE"
     super(params, payment_type_value)

--- a/app/forms/postal_order_payment_form.rb
+++ b/app/forms/postal_order_payment_form.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class PostalOrderPaymentForm < PaymentForm
+class PostalOrderPaymentForm < BasePaymentForm
   def submit(params)
     payment_type_value = "POSTALORDER"
     super(params, payment_type_value)

--- a/app/forms/worldpay_missed_payment_form.rb
+++ b/app/forms/worldpay_missed_payment_form.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class WorldpayMissedPaymentForm < PaymentForm
+class WorldpayMissedPaymentForm < BasePaymentForm
   def submit(params)
     payment_type_value = "WORLDPAY_MISSED"
     super(params, payment_type_value)

--- a/spec/factories/forms/base_payment_form.rb
+++ b/spec/factories/forms/base_payment_form.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :payment_form do
+  factory :base_payment_form do
     amount { 100 }
     comment { "foo" }
     updated_by_user { build(:user).email }

--- a/spec/forms/base_payment_form_spec.rb
+++ b/spec/forms/base_payment_form_spec.rb
@@ -2,8 +2,8 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentForm, type: :model do
-  let(:payment_form) { build(:payment_form) }
+RSpec.describe BasePaymentForm, type: :model do
+  let(:payment_form) { build(:base_payment_form) }
   let(:transient_registration) do
     WasteCarriersEngine::RenewingRegistration.where(reg_identifier: payment_form.reg_identifier).first
   end


### PR DESCRIPTION
This PaymentForm is actually acting as an interface for our forms of payment forms. In order to indicate it better to a code reader, and to free the PaymentForm naming to be used on the actual PaymentForm resource, this PR contains the code to rename it to BasePaymentForm