### PR TITLE
Remove `renewal` from payment pages

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -18,7 +18,7 @@ en:
       searched_at: "Searched at"
       confirmed: "Confirmed"
     payment_form:
-      current_balance: "The current balance for this renewal is £%{balance}."
+      current_balance: "The current balance is £%{balance}."
       labels:
         amount: "Amount received (£)"
         amount_hint: "For example, 120.50"
@@ -29,7 +29,7 @@ en:
         date_received_year: "Year"
         registration_reference: "Reference"
         comment: "Comment"
-      renewal_message: "This renewal will automatically be completed once it is fully paid for and there are no pending conviction checks."
+      renewal_message: "This application will automatically be completed once it is fully paid for and there are no pending conviction checks."
       submit_button: "Add this payment"
     person_table_rows:
       name: "Name"


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-826

It was reported that the current text on payment pages was referring to renewals even when the payment was taken on registrations.
In order to avoid adding extra complication to the code base, I took the liberty of adjusting the text so that it will apply to either a renewal or a registration.

@andrewhick This is to address point 7 of the connected document