### PR TITLE
Validate amounts to be greater than 1 cent

### DIFF
--- a/app/forms/base_payment_form.rb
+++ b/app/forms/base_payment_form.rb
@@ -5,7 +5,7 @@ class BasePaymentForm < WasteCarriersEngine::BaseForm
                 :order_key, :payment_type, :registration_reference, :updated_by_user,
                 :finance_details, :order, :payment
 
-  validates :amount, presence: true, numericality: { greater_than: 0 }
+  validates :amount, presence: true, numericality: { greater_than_or_equal_to: 0.01 }
   validates :comment, length: { maximum: 250 }
   validates :date_received, presence: true
   validates :registration_reference, presence: true

--- a/app/forms/concerns/can_have_charge_adjust_attributes.rb
+++ b/app/forms/concerns/can_have_charge_adjust_attributes.rb
@@ -6,7 +6,7 @@ module CanHaveChargeAdjustAttributes
   included do
     attr_accessor :amount, :reference, :description
 
-    validates :amount, presence: true, numericality: { greater_than: 0 }
+    validates :amount, presence: true, numericality: { greater_than_or_equal_to: 0.01 }
     validates :reference, presence: true
     validates :description, presence: true, length: { maximum: 500 }
   end

--- a/config/locales/bank_transfer_payment_forms.en.yml
+++ b/config/locales/bank_transfer_payment_forms.en.yml
@@ -11,7 +11,7 @@ en:
             amount:
               blank: "You must enter an amount"
               not_a_number: "You must enter a valid number"
-              greater_than_or_equal_to: "You must enter a number greater or equal to 0.01"
+              greater_than_or_equal_to: "You must enter a number greater than or equal to 0.01"
             comment:
               too_long: "Your comment must not be longer than 250 characters"
             date_received:

--- a/config/locales/bank_transfer_payment_forms.en.yml
+++ b/config/locales/bank_transfer_payment_forms.en.yml
@@ -11,7 +11,7 @@ en:
             amount:
               blank: "You must enter an amount"
               not_a_number: "You must enter a valid number"
-              greater_than_or_equal_to: "You must enter a number greather or equal to 0.01"
+              greater_than_or_equal_to: "You must enter a number greater or equal to 0.01"
             comment:
               too_long: "Your comment must not be longer than 250 characters"
             date_received:

--- a/config/locales/bank_transfer_payment_forms.en.yml
+++ b/config/locales/bank_transfer_payment_forms.en.yml
@@ -11,7 +11,7 @@ en:
             amount:
               blank: "You must enter an amount"
               not_a_number: "You must enter a valid number"
-              greater_than: "You must enter a positive number"
+              greater_than_or_equal_to: "You must enter a number greather or equal to 0.01"
             comment:
               too_long: "Your comment must not be longer than 250 characters"
             date_received:

--- a/config/locales/cash_payment_forms.en.yml
+++ b/config/locales/cash_payment_forms.en.yml
@@ -11,7 +11,7 @@ en:
             amount:
               blank: "You must enter an amount"
               not_a_number: "You must enter a valid number"
-              greater_than_or_equal_to: "You must enter a number greater or equal to 0.01"
+              greater_than_or_equal_to: "You must enter a number greater than or equal to 0.01"
             comment:
               too_long: "Your comment must not be longer than 250 characters"
             date_received:

--- a/config/locales/cash_payment_forms.en.yml
+++ b/config/locales/cash_payment_forms.en.yml
@@ -11,7 +11,7 @@ en:
             amount:
               blank: "You must enter an amount"
               not_a_number: "You must enter a valid number"
-              greater_than_or_equal_to: "You must enter a number greather or equal to 0.01"
+              greater_than_or_equal_to: "You must enter a number greater or equal to 0.01"
             comment:
               too_long: "Your comment must not be longer than 250 characters"
             date_received:

--- a/config/locales/cash_payment_forms.en.yml
+++ b/config/locales/cash_payment_forms.en.yml
@@ -11,7 +11,7 @@ en:
             amount:
               blank: "You must enter an amount"
               not_a_number: "You must enter a valid number"
-              greater_than: "You must enter a positive number"
+              greater_than_or_equal_to: "You must enter a number greather or equal to 0.01"
             comment:
               too_long: "Your comment must not be longer than 250 characters"
             date_received:

--- a/config/locales/cheque_payment_forms.en.yml
+++ b/config/locales/cheque_payment_forms.en.yml
@@ -11,7 +11,7 @@ en:
             amount:
               blank: "You must enter an amount"
               not_a_number: "You must enter a valid number"
-              greater_than_or_equal_to: "You must enter a number greater or equal to 0.01"
+              greater_than_or_equal_to: "You must enter a number greater than or equal to 0.01"
             comment:
               too_long: "Your comment must not be longer than 250 characters"
             date_received:

--- a/config/locales/cheque_payment_forms.en.yml
+++ b/config/locales/cheque_payment_forms.en.yml
@@ -11,7 +11,7 @@ en:
             amount:
               blank: "You must enter an amount"
               not_a_number: "You must enter a valid number"
-              greater_than_or_equal_to: "You must enter a number greather or equal to 0.01"
+              greater_than_or_equal_to: "You must enter a number greater or equal to 0.01"
             comment:
               too_long: "Your comment must not be longer than 250 characters"
             date_received:

--- a/config/locales/cheque_payment_forms.en.yml
+++ b/config/locales/cheque_payment_forms.en.yml
@@ -11,7 +11,7 @@ en:
             amount:
               blank: "You must enter an amount"
               not_a_number: "You must enter a valid number"
-              greater_than: "You must enter a positive number"
+              greater_than_or_equal_to: "You must enter a number greather or equal to 0.01"
             comment:
               too_long: "Your comment must not be longer than 250 characters"
             date_received:

--- a/config/locales/negative_charge_adjust_forms.en.yml
+++ b/config/locales/negative_charge_adjust_forms.en.yml
@@ -22,10 +22,9 @@ en:
             amount:
               blank: "Enter amount"
               not_a_number: "Amount is invalid"
-              greater_than_or_equal_to: "You must enter a number greater or equal to 0.01"
+              greater_than_or_equal_to: "You must enter a number greater than or equal to 0.01"
             description:
               blank: "Enter a reason"
               too_long: "Description must be %{count} characters or fewer"
             reference:
               blank: "Enter the tansaction reference"
-

--- a/config/locales/negative_charge_adjust_forms.en.yml
+++ b/config/locales/negative_charge_adjust_forms.en.yml
@@ -22,11 +22,10 @@ en:
             amount:
               blank: "Enter amount"
               not_a_number: "Amount is invalid"
-              greater_than_or_equal_to: "You must enter a number greather or equal to 0.01"
+              greater_than_or_equal_to: "You must enter a number greater or equal to 0.01"
             description:
               blank: "Enter a reason"
               too_long: "Description must be %{count} characters or fewer"
             reference:
               blank: "Enter the tansaction reference"
-
 

--- a/config/locales/negative_charge_adjust_forms.en.yml
+++ b/config/locales/negative_charge_adjust_forms.en.yml
@@ -22,7 +22,7 @@ en:
             amount:
               blank: "Enter amount"
               not_a_number: "Amount is invalid"
-              greater_than: "You must enter a positive number"
+              greater_than_or_equal_to: "You must enter a number greather or equal to 0.01"
             description:
               blank: "Enter a reason"
               too_long: "Description must be %{count} characters or fewer"

--- a/config/locales/positive_charge_adjust_forms.en.yml
+++ b/config/locales/positive_charge_adjust_forms.en.yml
@@ -22,10 +22,9 @@ en:
             amount:
               blank: "Enter amount"
               not_a_number: "Amount is invalid"
-              greater_than_or_equal_to: "You must enter a number greater or equal to 0.01"
+              greater_than_or_equal_to: "You must enter a number greater than or equal to 0.01"
             description:
               blank: "Enter a reason"
               too_long: "Description must be %{count} characters or fewer"
             reference:
               blank: "Enter the tansaction reference"
-

--- a/config/locales/positive_charge_adjust_forms.en.yml
+++ b/config/locales/positive_charge_adjust_forms.en.yml
@@ -22,11 +22,10 @@ en:
             amount:
               blank: "Enter amount"
               not_a_number: "Amount is invalid"
-              greater_than_or_equal_to: "You must enter a number greather or equal to 0.01"
+              greater_than_or_equal_to: "You must enter a number greater or equal to 0.01"
             description:
               blank: "Enter a reason"
               too_long: "Description must be %{count} characters or fewer"
             reference:
               blank: "Enter the tansaction reference"
-
 

--- a/config/locales/positive_charge_adjust_forms.en.yml
+++ b/config/locales/positive_charge_adjust_forms.en.yml
@@ -22,7 +22,7 @@ en:
             amount:
               blank: "Enter amount"
               not_a_number: "Amount is invalid"
-              greater_than: "You must enter a positive number"
+              greater_than_or_equal_to: "You must enter a number greather or equal to 0.01"
             description:
               blank: "Enter a reason"
               too_long: "Description must be %{count} characters or fewer"

--- a/config/locales/postal_order_payment_forms.en.yml
+++ b/config/locales/postal_order_payment_forms.en.yml
@@ -11,7 +11,7 @@ en:
             amount:
               blank: "You must enter an amount"
               not_a_number: "You must enter a valid number"
-              greater_than_or_equal_to: "You must enter a number greater or equal to 0.01"
+              greater_than_or_equal_to: "You must enter a number greater than or equal to 0.01"
             comment:
               too_long: "Your comment must not be longer than 250 characters"
             date_received:

--- a/config/locales/postal_order_payment_forms.en.yml
+++ b/config/locales/postal_order_payment_forms.en.yml
@@ -11,7 +11,7 @@ en:
             amount:
               blank: "You must enter an amount"
               not_a_number: "You must enter a valid number"
-              greater_than_or_equal_to: "You must enter a number greather or equal to 0.01"
+              greater_than_or_equal_to: "You must enter a number greater or equal to 0.01"
             comment:
               too_long: "Your comment must not be longer than 250 characters"
             date_received:

--- a/config/locales/postal_order_payment_forms.en.yml
+++ b/config/locales/postal_order_payment_forms.en.yml
@@ -11,7 +11,7 @@ en:
             amount:
               blank: "You must enter an amount"
               not_a_number: "You must enter a valid number"
-              greater_than: "You must enter a positive number"
+              greater_than_or_equal_to: "You must enter a number greather or equal to 0.01"
             comment:
               too_long: "Your comment must not be longer than 250 characters"
             date_received:

--- a/config/locales/worldpay_missed_payment_forms.en.yml
+++ b/config/locales/worldpay_missed_payment_forms.en.yml
@@ -11,7 +11,7 @@ en:
             amount:
               blank: "You must enter an amount"
               not_a_number: "You must enter a valid number"
-              greater_than_or_equal_to: "You must enter a number greater or equal to 0.01"
+              greater_than_or_equal_to: "You must enter a number greater than or equal to 0.01"
             comment:
               too_long: "Your comment must not be longer than 250 characters"
             date_received:

--- a/config/locales/worldpay_missed_payment_forms.en.yml
+++ b/config/locales/worldpay_missed_payment_forms.en.yml
@@ -11,7 +11,7 @@ en:
             amount:
               blank: "You must enter an amount"
               not_a_number: "You must enter a valid number"
-              greater_than_or_equal_to: "You must enter a number greather or equal to 0.01"
+              greater_than_or_equal_to: "You must enter a number greater or equal to 0.01"
             comment:
               too_long: "Your comment must not be longer than 250 characters"
             date_received:

--- a/config/locales/worldpay_missed_payment_forms.en.yml
+++ b/config/locales/worldpay_missed_payment_forms.en.yml
@@ -11,7 +11,7 @@ en:
             amount:
               blank: "You must enter an amount"
               not_a_number: "You must enter a valid number"
-              greater_than: "You must enter a positive number"
+              greater_than_or_equal_to: "You must enter a number greather or equal to 0.01"
             comment:
               too_long: "Your comment must not be longer than 250 characters"
             date_received:


### PR DESCRIPTION
This fixes our amounts validation to make sure we don't create payments for amounts less than 0.01