### PR TITLE
Restore links to finance functionality

### DIFF
--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -38,9 +38,6 @@ module ActionLinksHelper
   end
 
   def display_payment_link_for?(resource)
-    # TODO: Temporary - for release only. See: https://eaflood.atlassian.net/browse/RUBY-846
-    return false if a_registration?(resource)
-
     resource.upper_tier? && can?(:view_payments, resource)
   end
 
@@ -51,12 +48,7 @@ module ActionLinksHelper
   end
 
   def display_finance_details_link_for?(resource)
-    # TODO: Temporary - for release only. See: https://eaflood.atlassian.net/browse/RUBY-846
-    return false
-
-    # rubocop:disable Lint/UnreachableCode
     resource.upper_tier? && resource.finance_details.present?
-    # rubocop:enable Lint/UnreachableCode
   end
 
   def display_cease_or_revoke_link_for?(resource)

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -236,28 +236,28 @@ RSpec.describe ActionLinksHelper, type: :helper do
   end
 
   describe "#display_payment_link_for?" do
-    # TODO: Temporary - for release only. See: https://eaflood.atlassian.net/browse/RUBY-846
-    # let(:resource) { double(:resource) }
+    let(:resource) { double(:resource) }
 
-    # before do
-    #   expect(resource).to receive(:upper_tier?).and_return(upper_tier)
-    # end
+    before do
+      allow(resource).to receive(:upper_tier?).and_return(upper_tier)
+      allow(helper).to receive(:can?).with(:view_payments, resource).and_return(true)
+    end
 
-    # context "when the resource is an upper tier" do
-    #   let(:upper_tier) { true }
+    context "when the resource is an upper tier" do
+      let(:upper_tier) { true }
 
-    #   it "returns true" do
-    #     expect(helper.display_payment_link_for?(resource)).to be_truthy
-    #   end
-    # end
+      it "returns true" do
+        expect(helper.display_payment_link_for?(resource)).to be_truthy
+      end
+    end
 
-    # context "when the resource is not an upper tier" do
-    #   let(:upper_tier) { false }
+    context "when the resource is not an upper tier" do
+      let(:upper_tier) { false }
 
-    #   it "returns false" do
-    #     expect(helper.display_payment_link_for?(resource)).to be_falsey
-    #   end
-    # end
+      it "returns false" do
+        expect(helper.display_payment_link_for?(resource)).to be_falsey
+      end
+    end
   end
 
   describe "#display_cease_or_revoke_link_for?" do
@@ -473,33 +473,28 @@ RSpec.describe ActionLinksHelper, type: :helper do
     let(:finance_details) { double(:finance_details) }
     let(:resource) { double(:registration, finance_details: finance_details, upper_tier?: upper_tier) }
 
-    # TODO: Temporary - for release only. See: https://eaflood.atlassian.net/browse/RUBY-846
-    it "returns false" do
-      expect(helper.display_finance_details_link_for?(resource)).to be_falsey
+    context "when the resource is an upper tier" do
+      context "when the resource has finance details" do
+        it "returns true" do
+          expect(helper.display_finance_details_link_for?(resource)).to be_truthy
+        end
+      end
+
+      context "when the resource has no finance details" do
+        let(:finance_details) { nil }
+        it "returns false" do
+          expect(helper.display_finance_details_link_for?(resource)).to be_falsey
+        end
+      end
     end
 
-    # context "when the resource is an upper tier" do
-    #   context "when the resource has finance details" do
-    #     it "returns true" do
-    #       expect(helper.display_finance_details_link_for?(resource)).to be_truthy
-    #     end
-    #   end
+    context "when the resource is not an upper tier" do
+      let(:upper_tier) { false }
 
-    #   context "when the resource has no finance details" do
-    #     let(:finance_details) { nil }
-    #     it "returns false" do
-    #       expect(helper.display_finance_details_link_for?(resource)).to be_falsey
-    #     end
-    #   end
-    # end
-
-    # context "when the resource is not an upper tier" do
-    #   let(:upper_tier) { false }
-
-    #   it "returns false" do
-    #     expect(helper.display_finance_details_link_for?(resource)).to be_falsey
-    #   end
-    # end
+      it "returns false" do
+        expect(helper.display_finance_details_link_for?(resource)).to be_falsey
+      end
+    end
   end
 
   describe "#display_renew_link_for?" do


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-904

Restore links to the finance functionality