### PR TITLE
Make link to enter a payment consistent and clean

### DIFF
--- a/app/views/finance_details/show.html.erb
+++ b/app/views/finance_details/show.html.erb
@@ -17,7 +17,7 @@
     <%= render "shared/company_details_panel", registration: @resource %>
 
     <% if @resource.pending_payment? %>
-      <%= render "shared/registrations/pending_payment_panel", resource: @resource %>
+      <%= render "shared/registrations/pending_payment_panel", resource: @resource, hide_payment_link: true %>
     <% end %>
   </div>
 </div>

--- a/app/views/shared/registrations/_action_links_panel.html.erb
+++ b/app/views/shared/registrations/_action_links_panel.html.erb
@@ -50,12 +50,6 @@
       </li>
     <% end %>
 
-    <% if display_payment_link_for?(resource) %>
-      <li>
-        <%= link_to t(".actions_box.links.process_payment"), new_resource_payment_form_path(resource._id) %>
-      </li>
-    <% end %>
-
     <% if display_cease_or_revoke_link_for?(resource) %>
       <li>
         <%= link_to t(".actions_box.links.revoke"), WasteCarriersEngine::Engine.routes.url_helpers.new_cease_or_revoke_form_path(resource.reg_identifier) %>

--- a/app/views/shared/registrations/_pending_payment_panel.html.erb
+++ b/app/views/shared/registrations/_pending_payment_panel.html.erb
@@ -5,7 +5,8 @@
   <p>
     <%= t(".status.messages.pending_payment", total: display_pence_as_pounds(resource.finance_details.balance)) %>
   </p>
-  <% if display_payment_link_for?(resource) %>
+
+  <% if display_payment_link_for?(resource) && !local_assigns[:hide_payment_link] %>
     <%= link_to t(".status.actions.payment_button"), new_resource_payment_form_path(resource._id), class: 'button' %>
   <% end %>
 </div>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-906

Currently (assuming you have the right permissions) users are presented with the ability to enter a payment against a registration in 3 different ways

- through a 'Process payment' context section in the view. This appears when payment is required and is shown in both registration and payment details screen
- through a `Process payment` link in the actions section. This is only shown in the payment details screen
- using the 'Enter payment' button. This is only shown in the payment details screen

When double checking these links we noticed a few inconsistencies

- in registrations details the button and link are seen as the same when it comes to accessibility (which isn't great)
- once the balance is <=0 the 'Payment required' section with the process payment button disappears, but `process payment` link remains
- in payment details when the balance is > 0 the 'Payment required' section appears with a 'Process payment' button right above the 'Enter payment' button
- in registrations details we use 'Process payment'. In payment details we use 'Enter payment'

To makes things consistent and clean this up we have decided

- Remove the 'Process payment' link in the actions section of the registration details view
- Keep the 'Payment required' section in payment details when the balance is > 0. But remove the 'Process payment' button from it