### PR TITLE
Fix charge adjustment flash messages

### DIFF
--- a/config/locales/negative_charge_adjust_forms.en.yml
+++ b/config/locales/negative_charge_adjust_forms.en.yml
@@ -1,7 +1,7 @@
 en:
   negative_charge_adjust_forms:
     messages:
-      success: "%{amount} charge adjust completed succesfully"
+      success: "£%{amount} charge adjust completed successfully"
     new:
       title: "Negative charge adjustment (credit)"
       heading: "Negative charge adjustment (credit) for %{reg_identifier}"

--- a/config/locales/positive_charge_adjust_forms.en.yml
+++ b/config/locales/positive_charge_adjust_forms.en.yml
@@ -1,7 +1,7 @@
 en:
   positive_charge_adjust_forms:
     messages:
-      success: "%{amount} charge adjust completed succesfully"
+      success: "£%{amount} charge adjust completed successfully"
     new:
       title: "Positive charge adjustment (debit)"
       heading: "Positive charge adjustment (debit) for %{reg_identifier}"


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-870

We spotted during testing that the success message that gets displayed when a charge adjustment is completed is missing the £ symbol and contains a spelling mistake.