### PR TITLE
Remove double validation on amounts

### DIFF
--- a/app/forms/base_payment_form.rb
+++ b/app/forms/base_payment_form.rb
@@ -5,7 +5,7 @@ class BasePaymentForm < WasteCarriersEngine::BaseForm
                 :order_key, :payment_type, :registration_reference, :updated_by_user,
                 :finance_details, :order, :payment
 
-  validates :amount, presence: true, numericality: { greater_than_or_equal_to: 0.01 }
+  validates :amount, numericality: { greater_than_or_equal_to: 0.01 }
   validates :comment, length: { maximum: 250 }
   validates :date_received, presence: true
   validates :registration_reference, presence: true

--- a/app/forms/concerns/can_have_charge_adjust_attributes.rb
+++ b/app/forms/concerns/can_have_charge_adjust_attributes.rb
@@ -6,7 +6,7 @@ module CanHaveChargeAdjustAttributes
   included do
     attr_accessor :amount, :reference, :description
 
-    validates :amount, presence: true, numericality: { greater_than_or_equal_to: 0.01 }
+    validates :amount, numericality: { greater_than_or_equal_to: 0.01 }
     validates :reference, presence: true
     validates :description, presence: true, length: { maximum: 500 }
   end

--- a/config/locales/bank_transfer_payment_forms.en.yml
+++ b/config/locales/bank_transfer_payment_forms.en.yml
@@ -9,7 +9,6 @@ en:
         bank_transfer_payment_form:
           attributes:
             amount:
-              blank: "You must enter an amount"
               not_a_number: "You must enter a valid number"
               greater_than_or_equal_to: "You must enter a number greater than or equal to 0.01"
             comment:

--- a/config/locales/cash_payment_forms.en.yml
+++ b/config/locales/cash_payment_forms.en.yml
@@ -9,7 +9,6 @@ en:
         cash_payment_form:
           attributes:
             amount:
-              blank: "You must enter an amount"
               not_a_number: "You must enter a valid number"
               greater_than_or_equal_to: "You must enter a number greater than or equal to 0.01"
             comment:

--- a/config/locales/cheque_payment_forms.en.yml
+++ b/config/locales/cheque_payment_forms.en.yml
@@ -9,7 +9,6 @@ en:
         cheque_payment_form:
           attributes:
             amount:
-              blank: "You must enter an amount"
               not_a_number: "You must enter a valid number"
               greater_than_or_equal_to: "You must enter a number greater than or equal to 0.01"
             comment:

--- a/config/locales/negative_charge_adjust_forms.en.yml
+++ b/config/locales/negative_charge_adjust_forms.en.yml
@@ -20,8 +20,7 @@ en:
         positive_charge_adjust_form:
           attributes:
             amount:
-              blank: "Enter amount"
-              not_a_number: "Amount is invalid"
+              not_a_number: "You must enter a valid number"
               greater_than_or_equal_to: "You must enter a number greater than or equal to 0.01"
             description:
               blank: "Enter a reason"

--- a/config/locales/positive_charge_adjust_forms.en.yml
+++ b/config/locales/positive_charge_adjust_forms.en.yml
@@ -20,8 +20,7 @@ en:
         positive_charge_adjust_form:
           attributes:
             amount:
-              blank: "Enter amount"
-              not_a_number: "Amount is invalid"
+              not_a_number: "You must enter a valid number"
               greater_than_or_equal_to: "You must enter a number greater than or equal to 0.01"
             description:
               blank: "Enter a reason"

--- a/config/locales/postal_order_payment_forms.en.yml
+++ b/config/locales/postal_order_payment_forms.en.yml
@@ -9,7 +9,6 @@ en:
         postal_order_payment_form:
           attributes:
             amount:
-              blank: "You must enter an amount"
               not_a_number: "You must enter a valid number"
               greater_than_or_equal_to: "You must enter a number greater than or equal to 0.01"
             comment:

--- a/config/locales/worldpay_missed_payment_forms.en.yml
+++ b/config/locales/worldpay_missed_payment_forms.en.yml
@@ -9,7 +9,6 @@ en:
         worldpay_missed_payment_form:
           attributes:
             amount:
-              blank: "You must enter an amount"
               not_a_number: "You must enter a valid number"
               greater_than_or_equal_to: "You must enter a number greater than or equal to 0.01"
             comment:


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-893

Given that `numericality` will already complain when an amount is `nil`, we don't need to check for the extra `presence`