### PR TITLE
Fix back path for finance details page

### DIFF
--- a/app/helpers/finance_details_helper.rb
+++ b/app/helpers/finance_details_helper.rb
@@ -6,4 +6,12 @@ module FinanceDetailsHelper
 
     format("%<pounds>.2f", pounds: pounds)
   end
+
+  def details_path_for(resource)
+    if resource.is_a?(WasteCarriersEngine::RenewingRegistration)
+      renewing_registration_path(resource.reg_identifier)
+    else
+      registration_path(resource.reg_identifier)
+    end
+  end
 end

--- a/app/views/finance_details/show.html.erb
+++ b/app/views/finance_details/show.html.erb
@@ -1,6 +1,6 @@
 <div class="grid-row">
   <div class="column-full">
-    <%= render("waste_carriers_engine/shared/back", back_path: registration_path(@resource.reg_identifier)) %>
+    <%= render("waste_carriers_engine/shared/back", back_path: details_path_for(@resource)) %>
 
     <h1 class="heading-large">
       <%= t(".heading", reg_identifier: @resource.reg_identifier) %>

--- a/spec/helpers/finance_details_helper_spec.rb
+++ b/spec/helpers/finance_details_helper_spec.rb
@@ -9,4 +9,20 @@ RSpec.describe FinanceDetailsHelper, type: :helper do
       expect(helper.display_pence_as_pounds_and_cents(1045)).to eq("10.45")
     end
   end
+
+  describe "#details_path_for" do
+    it "returns the path to the registration's details page" do
+      allow(helper).to receive(:registration_path).and_return(:registration_path)
+
+      expect(helper.details_path_for(WasteCarriersEngine::Registration.new)).to eq(:registration_path)
+    end
+
+    context "when the resource is a RenewingRegistration" do
+      it "returns the pat to the renewing registration details page" do
+        allow(helper).to receive(:renewing_registration_path).and_return(:renewing_registration_path)
+
+        expect(helper.details_path_for(WasteCarriersEngine::RenewingRegistration.new)).to eq(:renewing_registration_path)
+      end
+    end
+  end
 end


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-907

This fixes a bug for which the finance details page was always redirecting back to the registration's details page.
With this change we are now redirecting the user back to the correct resource's page based on the object's type.