### PR TITLE
Fix typo on charge adjust validation messages

### DIFF
--- a/config/locales/negative_charge_adjust_forms.en.yml
+++ b/config/locales/negative_charge_adjust_forms.en.yml
@@ -26,4 +26,4 @@ en:
               blank: "Enter a reason"
               too_long: "Description must be %{count} characters or fewer"
             reference:
-              blank: "Enter the tansaction reference"
+              blank: "Enter the transaction reference"

--- a/config/locales/positive_charge_adjust_forms.en.yml
+++ b/config/locales/positive_charge_adjust_forms.en.yml
@@ -26,4 +26,4 @@ en:
               blank: "Enter a reason"
               too_long: "Description must be %{count} characters or fewer"
             reference:
-              blank: "Enter the tansaction reference"
+              blank: "Enter the transaction reference"


### PR DESCRIPTION
Spotted a typo on the validation for the charge adjust pages, and thought I'd fix it :)