### PR TITLE
Enable defra-ruby-email in the project

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,13 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: d28ea6714f22468583a25a2bb156d15e779d37c4
+  revision: edf5a11f018115bcb0c2859ce33840930594363e
   branch: master
   specs:
     waste_carriers_engine (0.0.1)
       aasm (~> 4.12)
       countries
       defra_ruby_alert (~> 1.0.0)
+      defra_ruby_email
       defra_ruby_validators
       high_voltage (~> 3.0)
       jbuilder (~> 2.0)
@@ -113,6 +114,8 @@ GEM
       airbrake (~> 5.8.1)
     defra_ruby_aws (0.2.0)
       aws-sdk-s3
+    defra_ruby_email (0.2.0)
+      rails (~> 4.2.11.1)
     defra_ruby_mocks (1.3.0)
       nokogiri
       rails (~> 4.2.11.1)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -57,10 +57,10 @@ class ApplicationController < ActionController::Base
   private
 
   def skip_auth_on_this_controller?
-    # Don't authorize and authenticate pages from HighVoltage or Devise
+    # Don't authorize and authenticate pages from HighVoltage, Devise, or DefraRubyEmail
     # Normally we'd use a skip_before_action, but these controllers are in gems
     controller = params[:controller]
-    controller.include?("pages") || controller.include?("devise")
+    controller.include?("pages") || controller.include?("devise") || controller.include?("last-email")
   end
 
   def current_user_cannot_use_back_office?

--- a/config/initializers/waste_carriers_engine.rb
+++ b/config/initializers/waste_carriers_engine.rb
@@ -13,6 +13,9 @@ WasteCarriersEngine.configure do |configuration|
     configuration.companies_house_host = ENV["WCRS_MOCK_FO_COMPANIES_HOUSE_URL"]
   end
 
+  # Last email cache config
+  configuration.use_last_email_cache = ENV["WCRS_USE_LAST_EMAIL_CACHE"] || "false"
+
   # Configure airbrake, which is done via the engine using defra_ruby_alert
   configuration.airbrake_enabled = ENV["WCRS_USE_AIRBRAKE"]
   configuration.airbrake_host = ENV["WCRS_AIRBRAKE_URL"]


### PR DESCRIPTION
Currently the [Waste Exemptions service](https://github.com/DEFRA/waste-exemptions-engine/pull/112) and the [Waste Carriers Frontend](https://github.com/DEFRA/waste-carriers-frontend/pull/227) have the ability to intercept and play back the details of the last email sent.

This feature is only enabled in our non-production environments and is used as part of our acceptance tests. However our QA @andrewhick has rightly pointed out that the functionality is inconsistent across our services.

Waste Exemptions has it throughout, Waste Carriers only has it in the old app, and Flood Risk Activity Exemptions doesn't have it at all. This makes writing and maintaining acceptance tests across the 3 services difficult and inconsistent so we have been asked to resolve the issue.

Rather than duplicate the existing code even more, we have created [defra-ruby-email](https://github.com/DEFRA/defra-ruby-email) a reusable engine that can be mounted into an application to provide the same functionality.

Having created the gem, we implemented it into the [waste-carriers-engine](https://github.com/DEFRA/flood-risk-engine/pull/332) to add the feature throughout this service.

This change completes the implementation for the back-office.