### PR TITLE
Remove ability to access finance details on unsubmitted renewals

### DIFF
--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -38,7 +38,9 @@ module ActionLinksHelper
   end
 
   def display_payment_link_for?(resource)
-    resource.upper_tier? && can?(:view_payments, resource)
+    return can_view_payments?(resource) unless a_transient_registration?(resource)
+
+    resource.renewal_application_submitted? && can_view_payments?(resource)
   end
 
   def display_refund_link_for?(resource)
@@ -116,5 +118,9 @@ module ActionLinksHelper
     return false if resource.refused?
 
     true
+  end
+
+  def can_view_payments?(resource)
+    resource.upper_tier? && can?(:view_payments, resource)
   end
 end

--- a/spec/factories/renewing_registration.rb
+++ b/spec/factories/renewing_registration.rb
@@ -16,9 +16,13 @@ FactoryBot.define do
       finance_details { build(:finance_details, :has_overpaid_order_and_payment) }
     end
 
+    trait :submitted do
+      workflow_state { "renewal_received_form" }
+    end
+
     trait :ready_to_renew do
       declared_convictions { "no" }
-      workflow_state { "renewal_received_form" }
+      submitted
 
       conviction_search_result { build(:conviction_search_result, :match_result_no) }
       finance_details { build(:finance_details, :zero_balance) }
@@ -28,44 +32,51 @@ FactoryBot.define do
     end
 
     trait :pending_payment do
-      workflow_state { "renewal_received_form" }
+      submitted
+
       finance_details { build(:finance_details, :has_unpaid_order) }
     end
 
     trait :no_pending_payment do
-      workflow_state { "renewal_received_form" }
+      submitted
+
       finance_details { build(:finance_details, :zero_balance) }
     end
 
     trait :requires_conviction_check do
-      workflow_state { "renewal_received_form" }
+      submitted
+
       key_people { [build(:key_person, :requires_conviction_check)] }
       conviction_search_result { build(:conviction_search_result, :match_result_yes) }
       conviction_sign_offs { [build(:conviction_sign_off)] }
     end
 
     trait :does_not_require_conviction_check do
-      workflow_state { "renewal_received_form" }
+      submitted
+
       key_people { [build(:key_person, :does_not_require_conviction_check)] }
       conviction_search_result { build(:conviction_search_result, :match_result_no) }
     end
 
     trait :has_flagged_conviction_check do
-      workflow_state { "renewal_received_form" }
+      submitted
+
       key_people { [build(:key_person, :requires_conviction_check)] }
       conviction_search_result { build(:conviction_search_result, :match_result_yes) }
       conviction_sign_offs { [build(:conviction_sign_off, :checks_in_progress)] }
     end
 
     trait :has_approved_conviction_check do
-      workflow_state { "renewal_received_form" }
+      submitted
+
       key_people { [build(:key_person, :requires_conviction_check)] }
       conviction_search_result { build(:conviction_search_result, :match_result_yes) }
       conviction_sign_offs { [build(:conviction_sign_off, :approved)] }
     end
 
     trait :has_rejected_conviction_check do
-      workflow_state { "renewal_received_form" }
+      submitted
+
       key_people { [build(:key_person, :requires_conviction_check)] }
       conviction_search_result { build(:conviction_search_result, :match_result_yes) }
       conviction_sign_offs { [build(:conviction_sign_off, :rejected)] }

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -237,25 +237,54 @@ RSpec.describe ActionLinksHelper, type: :helper do
 
   describe "#display_payment_link_for?" do
     let(:resource) { double(:resource) }
+    let(:upper_tier) { true }
 
     before do
       allow(resource).to receive(:upper_tier?).and_return(upper_tier)
       allow(helper).to receive(:can?).with(:view_payments, resource).and_return(true)
     end
 
-    context "when the resource is an upper tier" do
-      let(:upper_tier) { true }
+    context "when the resource is a renewing registration" do
+      context "when the resource is submitted" do
+        let(:resource) { build(:renewing_registration, :submitted) }
 
-      it "returns true" do
-        expect(helper.display_payment_link_for?(resource)).to be_truthy
+        context "when the resource is an upper tier" do
+          it "returns true" do
+            expect(helper.display_payment_link_for?(resource)).to be_truthy
+          end
+        end
+
+        context "when the resource is not an upper tier" do
+          let(:upper_tier) { false }
+
+          it "returns false" do
+            expect(helper.display_payment_link_for?(resource)).to be_falsey
+          end
+        end
+      end
+
+      context "when the resource is not yet submitted" do
+        let(:resource) { build(:renewing_registration) }
+
+        it "returns false" do
+          expect(helper.display_payment_link_for?(resource)).to be_falsey
+        end
       end
     end
 
-    context "when the resource is not an upper tier" do
-      let(:upper_tier) { false }
+    context "when the resource is not a renewing registration" do
+      context "when the resource is an upper tier" do
+        it "returns true" do
+          expect(helper.display_payment_link_for?(resource)).to be_truthy
+        end
+      end
 
-      it "returns false" do
-        expect(helper.display_payment_link_for?(resource)).to be_falsey
+      context "when the resource is not an upper tier" do
+        let(:upper_tier) { false }
+
+        it "returns false" do
+          expect(helper.display_payment_link_for?(resource)).to be_falsey
+        end
       end
     end
   end


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-908

Do not show a link to the finance details if a resource is a not yet submitted renewal.