### PR TITLE
Add company info panel to payment pages

### DIFF
--- a/app/views/payment_forms/new.html.erb
+++ b/app/views/payment_forms/new.html.erb
@@ -9,6 +9,8 @@
         <%= t(".heading") %>
       </h1>
 
+      <%= render "shared/company_details_panel", registration: @resource %>
+
       <div class="form-group <%= "form-group-error" if @payment_form.errors[:payment_type].any? %>">
         <fieldset id="payment_type">
           <legend class="visuallyhidden">


### PR DESCRIPTION
Just spotted that we have missed to add the company information panel to the payments form page, as per wireframe.

Hence this adds that in so that the page matches the SPOT wireframe content.

<img width="644" alt="Screenshot 2020-02-28 at 11 12 50" src="https://user-images.githubusercontent.com/1385397/75544339-aa89dd00-5a1b-11ea-89eb-f8bf16a1aecf.png">

