### PR TITLE
Add hint to all text areas

### DIFF
--- a/app/forms/base_payment_form.rb
+++ b/app/forms/base_payment_form.rb
@@ -6,7 +6,7 @@ class BasePaymentForm < WasteCarriersEngine::BaseForm
                 :finance_details, :order, :payment
 
   validates :amount, numericality: { greater_than_or_equal_to: 0.01 }
-  validates :comment, length: { maximum: 250 }
+  validates :comment, length: { maximum: 500 }
   validates :date_received, presence: true, "defra_ruby/validators/past_date": true
   validates :registration_reference, presence: true
 

--- a/app/views/conviction_approval_forms/new.html.erb
+++ b/app/views/conviction_approval_forms/new.html.erb
@@ -9,21 +9,24 @@
         <%= t(".heading", reg_identifier: @transient_registration.reg_identifier) %>
       </h1>
 
-      <% if @conviction_approval_form.errors[:revoked_reason].any? %>
-      <div class="form-group form-group-error">
-      <% else %>
-      <div class="form-group">
-      <% end %>
+      <div class="form-group <%= "form-group-error" if @conviction_approval_form.errors[:revoked_reason].any? %>">
         <fieldset id="company_name">
           <legend class="visuallyhidden">
             <%= t(".heading", reg_identifier: @transient_registration.reg_identifier) %>
           </legend>
 
           <% if @conviction_approval_form.errors[:revoked_reason].any? %>
-          <span class="error-message"><%= @conviction_approval_form.errors[:revoked_reason].join(", ") %></span>
+            <span class="error-message"><%= @conviction_approval_form.errors[:revoked_reason].join(", ") %></span>
           <% end %>
 
-          <%= f.label :revoked_reason, t(".revoked_reason_label"), class: "form-label" %>
+          <%= f.label :revoked_reason, class: "form-label" do %>
+            <%= t(".revoked_reason.label") %>
+
+            <span class="form-hint">
+              <%= t(".revoked_reason.hint") %>
+            </span>
+          <% end %>
+
           <%= f.text_area :revoked_reason, class: "form-control" %>
         </fieldset>
       </div>
@@ -33,6 +36,7 @@
           <i class="icon icon-important">
             <span class="visually-hidden">Warning</span>
           </i>
+
           <strong class="bold-small">
             <p><%= t(".renewal_message") %></p>
           </strong>

--- a/app/views/conviction_rejection_forms/new.html.erb
+++ b/app/views/conviction_rejection_forms/new.html.erb
@@ -19,7 +19,14 @@
           <span class="error-message"><%= @conviction_rejection_form.errors[:revoked_reason].join(", ") %></span>
           <% end %>
 
-          <%= f.label :revoked_reason, t(".revoked_reason_label"), class: "form-label" %>
+          <%= f.label :revoked_reason, class: "form-label" do %>
+            <%= t(".revoked_reason.label") %>
+
+            <span class="form-hint">
+              <%= t(".revoked_reason.hint") %>
+            </span>
+          <% end %>
+
           <%= f.text_area :revoked_reason, class: "form-control" %>
         </fieldset>
       </div>

--- a/app/views/negative_charge_adjust_forms/new.html.erb
+++ b/app/views/negative_charge_adjust_forms/new.html.erb
@@ -34,7 +34,8 @@
           <span class="error-message"><%= @negative_charge_adjust_form.errors[:reference].join(", ") %></span>
         <% end %>
 
-        <%= f.label :reference, t(".fields.reference.label"), class: "form-label" %>
+        <%= f.label :reference, t(".fields.reference.label"), class: "form-label"%>
+
         <%= f.text_field :reference, class: "form-control" %>
       </div>
 
@@ -43,7 +44,14 @@
           <span class="error-message"><%= @negative_charge_adjust_form.errors[:description].join(", ") %></span>
         <% end %>
 
-        <%= f.label :description, t(".fields.description.label"), class: "form-label" %>
+        <%= f.label :description, class: "form-label" do %>
+          <%= t(".fields.description.label") %>
+
+          <span class="form-hint">
+            <%= t(".fields.description.hint") %>
+          </span>
+        <% end %>
+
         <%= f.text_area :description, class: "form-control" %>
       </div>
 

--- a/app/views/positive_charge_adjust_forms/new.html.erb
+++ b/app/views/positive_charge_adjust_forms/new.html.erb
@@ -43,7 +43,14 @@
           <span class="error-message"><%= @positive_charge_adjust_form.errors[:description].join(", ") %></span>
         <% end %>
 
-        <%= f.label :description, t(".fields.description.label"), class: "form-label" %>
+        <%= f.label :description, class: "form-label" do %>
+          <%= t(".fields.description.label") %>
+
+          <span class="form-hint">
+            <%= t(".fields.description.hint") %>
+          </span>
+        <% end %>
+
         <%= f.text_area :description, class: "form-control" %>
       </div>
 

--- a/app/views/registration_conviction_approval_forms/new.html.erb
+++ b/app/views/registration_conviction_approval_forms/new.html.erb
@@ -19,7 +19,14 @@
             <span class="error-message"><%= @conviction_approval_form.errors[:revoked_reason].join(", ") %></span>
           <% end %>
 
-          <%= f.label :revoked_reason, t(".revoked_reason_label"), class: "form-label" %>
+          <%= f.label :revoked_reason, class: "form-label" do %>
+            <%= t(".revoked_reason.label") %>
+
+            <span class="form-hint">
+              <%= t(".revoked_reason.hint") %>
+            </span>
+          <% end %>
+
           <%= f.text_area :revoked_reason, class: "form-control" %>
         </fieldset>
       </div>

--- a/app/views/registration_conviction_rejection_forms/new.html.erb
+++ b/app/views/registration_conviction_rejection_forms/new.html.erb
@@ -23,7 +23,14 @@
             <span class="error-message"><%= @conviction_rejection_form.errors[:revoked_reason].join(", ") %></span>
           <% end %>
 
-          <%= f.label :revoked_reason, t(".revoked_reason_label"), class: "form-label" %>
+          <%= f.label :revoked_reason, class: "form-label" do %>
+            <%= t(".revoked_reason.label") %>
+
+            <span class="form-hint">
+              <%= t(".revoked_reason.hint") %>
+            </span>
+          <% end %>
+
           <%= f.text_area :revoked_reason, class: "form-control" %>
         </fieldset>
       </div>

--- a/app/views/reversal_forms/new.html.erb
+++ b/app/views/reversal_forms/new.html.erb
@@ -26,7 +26,14 @@
           <span class="error-message"><%= @reversal_form.errors[:reason].join(", ") %></span>
         <% end %>
 
-        <%= f.label :reason, t(".reason.label"), class: "form-label" %>
+        <%= f.label :reason, class: "form-label" do %>
+          <%= t(".reason.label") %>
+
+          <span class="form-hint">
+            <%= t(".reason.hint") %>
+          </span>
+        <% end %>
+
         <%= f.text_area :reason, class: "form-control" %>
       </div>
 

--- a/app/views/shared/_payment_form.html.erb
+++ b/app/views/shared/_payment_form.html.erb
@@ -58,7 +58,14 @@
       <span class="error-message"><%= form.errors[:comment].join(", ") %></span>
     <% end %>
 
-    <%= f.label :comment, t(".labels.comment"), class: "form-label" %>
+    <%= f.label :comment, class: "form-label" do %>
+      <%= t(".labels.comment") %>
+
+      <span class="form-hint">
+        <%= t(".labels.comment_hint") %>
+      </span>
+    <% end %>
+
     <%= f.text_area :comment, class: "form-control" %>
   </div>
 

--- a/app/views/write_off_forms/new.html.erb
+++ b/app/views/write_off_forms/new.html.erb
@@ -31,7 +31,14 @@
             <span class="error-message"><%= @write_off_form.errors[:comment].join(", ") %></span>
           <% end %>
 
-          <%= f.label :comment, t(".reason"), class: "form-label" %>
+          <%= f.label :comment, class: "form-label" do %>
+            <%= t(".reason.label") %>
+
+            <span class="form-hint">
+              <%= t(".reason.hint") %>
+            </span>
+          <% end %>
+
           <%= f.text_area :comment, class: "form-control" %>
         </fieldset>
       </div>

--- a/config/locales/bank_transfer_payment_forms.en.yml
+++ b/config/locales/bank_transfer_payment_forms.en.yml
@@ -12,7 +12,7 @@ en:
               not_a_number: "You must enter a valid number"
               greater_than_or_equal_to: "You must enter a number greater than or equal to 0.01"
             comment:
-              too_long: "Your comment must not be longer than 250 characters"
+              too_long: "Your comment must not be longer than 500 characters"
             date_received:
               blank: "You must enter a valid date"
             registration_reference:

--- a/config/locales/cash_payment_forms.en.yml
+++ b/config/locales/cash_payment_forms.en.yml
@@ -12,7 +12,7 @@ en:
               not_a_number: "You must enter a valid number"
               greater_than_or_equal_to: "You must enter a number greater than or equal to 0.01"
             comment:
-              too_long: "Your comment must not be longer than 250 characters"
+              too_long: "Your comment must not be longer than 500 characters"
             date_received:
               blank: "You must enter a valid date"
             registration_reference:

--- a/config/locales/cheque_payment_forms.en.yml
+++ b/config/locales/cheque_payment_forms.en.yml
@@ -12,7 +12,7 @@ en:
               not_a_number: "You must enter a valid number"
               greater_than_or_equal_to: "You must enter a number greater than or equal to 0.01"
             comment:
-              too_long: "Your comment must not be longer than 250 characters"
+              too_long: "Your comment must not be longer than 500 characters"
             date_received:
               blank: "You must enter a valid date"
             registration_reference:

--- a/config/locales/conviction_approval_forms.en.yml
+++ b/config/locales/conviction_approval_forms.en.yml
@@ -3,7 +3,9 @@ en:
     new:
       title: "Approve a renewal with possible convictions"
       heading: "Approve a renewal with possible convictions: %{reg_identifier}"
-      revoked_reason_label: "Reason for approval"
+      revoked_reason:
+        label: "Reason for approval"
+        hint: "Maximum 500 characters"
       renewal_message: "If there is no unpaid balance, approving this conviction check will automatically complete the renewal."
       approve_button: "Approve this renewal"
   activemodel:

--- a/config/locales/conviction_rejection_forms.en.yml
+++ b/config/locales/conviction_rejection_forms.en.yml
@@ -3,7 +3,9 @@ en:
     new:
       title: "Reject a renewal with possible convictions"
       heading: "Reject a renewal with possible convictions: %{reg_identifier}"
-      revoked_reason_label: "Reason for rejection"
+      revoked_reason:
+        label: "Reason for approval"
+        hint: "Maximum 500 characters"
       rejection_message: "Once rejected, this renewal cannot be completed."
       reject_button: "Reject this renewal"
   activemodel:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -27,8 +27,9 @@ en:
         date_received_day: "Day"
         date_received_month: "Month"
         date_received_year: "Year"
-        registration_reference: "Reference"
-        comment: "Comment"
+        registration_reference: "Transaction reference"
+        comment: "Reason"
+        comment_hint: "Maximum 500 characters"
       renewal_message: "This application will automatically be completed once it is fully paid for and there are no pending conviction checks."
       submit_button: "Add this payment"
     person_table_rows:

--- a/config/locales/negative_charge_adjust_forms.en.yml
+++ b/config/locales/negative_charge_adjust_forms.en.yml
@@ -13,6 +13,7 @@ en:
           label: "Transaction reference"
         description:
           label: "Reason"
+          hint: "Maximum 500 characters"
       confirm: "Continue"
   activemodel:
     errors:

--- a/config/locales/positive_charge_adjust_forms.en.yml
+++ b/config/locales/positive_charge_adjust_forms.en.yml
@@ -13,6 +13,7 @@ en:
           label: "Transaction reference"
         description:
           label: "Reason"
+          hint: "Maximum 500 characters"
       confirm: "Continue"
   activemodel:
     errors:

--- a/config/locales/postal_order_payment_forms.en.yml
+++ b/config/locales/postal_order_payment_forms.en.yml
@@ -12,7 +12,7 @@ en:
               not_a_number: "You must enter a valid number"
               greater_than_or_equal_to: "You must enter a number greater than or equal to 0.01"
             comment:
-              too_long: "Your comment must not be longer than 250 characters"
+              too_long: "Your comment must not be longer than 500 characters"
             date_received:
               blank: "You must enter a valid date"
             registration_reference:

--- a/config/locales/registration_conviction_approval_forms.en.yml
+++ b/config/locales/registration_conviction_approval_forms.en.yml
@@ -3,7 +3,9 @@ en:
     new:
       title: "Approve a registration with possible convictions"
       heading: "Approve a registration with possible convictions: %{reg_identifier}"
-      revoked_reason_label: "Reason for approval"
+      revoked_reason:
+        label: "Reason for approval"
+        hint: "Maximum 500 characters"
       warning: "If there is no unpaid balance, approving this conviction check will automatically complete the registration."
       approve_button: "Approve this renewal"
   activemodel:

--- a/config/locales/registration_conviction_rejection_forms.en.yml
+++ b/config/locales/registration_conviction_rejection_forms.en.yml
@@ -3,7 +3,9 @@ en:
     new:
       title: "Reject a registration with possible convictions"
       heading: "Reject a registration with possible convictions: %{reg_identifier}"
-      revoked_reason_label: "Reason for rejection"
+      revoked_reason:
+        label: "Reason for rejection"
+        hint: "Maximum 500 characters"
       warning: "Once rejected, this registration cannot be completed."
       reject_button: "Reject this renewal"
   activemodel:

--- a/config/locales/reversal_forms.en.yml
+++ b/config/locales/reversal_forms.en.yml
@@ -20,6 +20,7 @@ en:
       reverse_payment: "Reverse payment of £%{amount}"
       reason:
         label: "Reason"
+        hint: "Maximum 500 characters"
       confirm: "Reverse payment"
   activemodel:
     errors:

--- a/config/locales/worldpay_missed_payment_forms.en.yml
+++ b/config/locales/worldpay_missed_payment_forms.en.yml
@@ -12,7 +12,7 @@ en:
               not_a_number: "You must enter a valid number"
               greater_than_or_equal_to: "You must enter a number greater than or equal to 0.01"
             comment:
-              too_long: "Your comment must not be longer than 250 characters"
+              too_long: "Your comment must not be longer than 500 characters"
             date_received:
               blank: "You must enter a valid date"
             registration_reference:

--- a/config/locales/write_off_forms.en.yml
+++ b/config/locales/write_off_forms.en.yml
@@ -6,7 +6,9 @@ en:
       title: "Write off a difference"
       heading: "Write off a difference for %{reg_identifier}"
       write_off: "Write off £%{amount}"
-      reason: "Reason"
+      reason:
+        label: "Reason"
+        hint: "Maximum 500 characters"
       confirm: "Write off"
   activemodel:
     errors:

--- a/spec/forms/base_payment_form_spec.rb
+++ b/spec/forms/base_payment_form_spec.rb
@@ -154,9 +154,9 @@ RSpec.describe BasePaymentForm, type: :model do
   end
 
   describe "#comment" do
-    context "when it is more than 250 characters" do
+    context "when it is more than 500 characters" do
       before do
-        payment_form.comment = "Q2HK0PM50AZ8QWEQL6ZVR7A2SLL5QBQ9T6ZQQ7SU793YOSLABX4SAWMM3OE1LGH8Z6MJK92GEP3F9WR89IY7OUQN1PTU9NHFHSUHA1L6ELJI749QH9UXAKVD9CCGX344692OISGGLMAT4VLDAHOEST6N3KD5093AE9C2RHZD12TUPW0FHRR7JJSQRZM3XJ1FCQQJX9UXG7HW258Y71RDUQQ2UNOX4G1IO5J0JE3GQHH46ENQDT4JX89TSJGT"
+        payment_form.comment = "Test " * 101
       end
 
       it "is not valid" do


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-890

This adds an hint to all of our text areas missing one to let the user know about the maximum number of characters that can be inserted into the text area.

We have also agreed to fix all validations for text area to have a maximum of 500 characters all across the project, hence this PR also fixes the validation of payment forms which was set to 250.