### PR TITLE
Hide edit functionality behind a feature toggle

### DIFF
--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -62,7 +62,6 @@ module ActionLinksHelper
   end
 
   def display_edit_link_for?(resource)
-    return false unless WasteCarriersEngine::FeatureToggle.active?(:edit_registration)
     return false unless display_registration_links?(resource)
     return false unless can?(:edit, WasteCarriersEngine::Registration)
 

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -62,6 +62,7 @@ module ActionLinksHelper
   end
 
   def display_edit_link_for?(resource)
+    return false unless WasteCarriersEngine::FeatureToggle.active?(:edit_registration)
     return false unless display_registration_links?(resource)
     return false unless can?(:edit, WasteCarriersEngine::Registration)
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -37,7 +37,7 @@ class Ability
     can :renew, :all
     can :view_certificate, WasteCarriersEngine::Registration
     can :order_copy_cards, WasteCarriersEngine::Registration
-    can :edit, WasteCarriersEngine::Registration
+    can :edit, WasteCarriersEngine::Registration if WasteCarriersEngine::FeatureToggle.active?(:edit_registration)
 
     can :review_convictions, :all
 

--- a/config/feature_toggles.yml
+++ b/config/feature_toggles.yml
@@ -1,3 +1,3 @@
 ---
 edit_registration:
-  active: <%= ENV["FEATURE_TOGGLE_EDIT_REGISTRATION"] || "true" %>
+  active: <%= ENV["FEATURE_TOGGLE_EDIT_REGISTRATION"] %>

--- a/config/feature_toggles.yml
+++ b/config/feature_toggles.yml
@@ -1,0 +1,3 @@
+---
+edit_registration:
+  active: <%= ENV["FEATURE_TOGGLE_EDIT_REGISTRATION"] || "true" %>

--- a/spec/support/shared_examples/abilities/agency_examples.rb
+++ b/spec/support/shared_examples/abilities/agency_examples.rb
@@ -18,6 +18,9 @@ RSpec.shared_examples "agency examples" do
   end
 
   it "should be able to edit a registration" do
+    # TODO: Remove once edit is no longer behind a feature toggle
+    allow(WasteCarriersEngine::FeatureToggle).to receive(:active?).with(:edit_registration).and_return(true)
+
     should be_able_to(:edit, WasteCarriersEngine::Registration)
   end
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-926

We have implemented feature toggle functionality in the [waste-carriers-engine](https://github.com/DEFRA/waste-carriers-engine/pull/697) which gives us a state we can check in one place, and control through config.

This is to allow us to hide functionality that is not yet ready for release in production, but access it in our non-production environments.

One such feature that is still being developed is the edit registration feature. So this change takes advantage of the new feature toggles, and hides the edit links if the feature is disable.