### PR TITLE
Clarify payment details access

### DIFF
--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -50,7 +50,10 @@ module ActionLinksHelper
   end
 
   def display_finance_details_link_for?(resource)
-    resource.upper_tier? && resource.finance_details.present?
+    return false unless resource.upper_tier? && resource.finance_details.present?
+    return true unless a_transient_registration?(resource)
+
+    resource.renewal_application_submitted?
   end
 
   def display_cease_or_revoke_link_for?(resource)

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -498,30 +498,66 @@ RSpec.describe ActionLinksHelper, type: :helper do
   end
 
   describe "#display_finance_details_link_for?" do
+    let(:resource) { double(:resource) }
     let(:upper_tier) { true }
     let(:finance_details) { double(:finance_details) }
-    let(:resource) { double(:registration, finance_details: finance_details, upper_tier?: upper_tier) }
 
-    context "when the resource is an upper tier" do
-      context "when the resource has finance details" do
-        it "returns true" do
-          expect(helper.display_finance_details_link_for?(resource)).to be_truthy
+    before do
+      allow(resource).to receive(:upper_tier?).and_return(upper_tier)
+      allow(resource).to receive(:finance_details).and_return(finance_details)
+    end
+
+    context "when the resource is a renewing registration" do
+      context "when the resource is submitted" do
+        let(:resource) { build(:renewing_registration, :submitted) }
+
+        context "when the resource is an upper tier" do
+          it "returns true" do
+            expect(helper.display_finance_details_link_for?(resource)).to be_truthy
+          end
+        end
+
+        context "when the resource is not an upper tier" do
+          let(:upper_tier) { false }
+
+          it "returns false" do
+            expect(helper.display_finance_details_link_for?(resource)).to be_falsey
+          end
         end
       end
 
-      context "when the resource has no finance details" do
-        let(:finance_details) { nil }
+      context "when the resource is not yet submitted" do
+        let(:resource) { build(:renewing_registration) }
+
         it "returns false" do
           expect(helper.display_finance_details_link_for?(resource)).to be_falsey
         end
       end
     end
 
-    context "when the resource is not an upper tier" do
-      let(:upper_tier) { false }
+    context "when the resource is not a renewing registration" do
+      context "when the resource is an upper tier" do
+        context "when the resource has finance details" do
+          it "returns true" do
+            expect(helper.display_finance_details_link_for?(resource)).to be_truthy
+          end
+        end
 
-      it "returns false" do
-        expect(helper.display_finance_details_link_for?(resource)).to be_falsey
+        context "when the resource has no finance details" do
+          let(:finance_details) { nil }
+
+          it "returns false" do
+            expect(helper.display_finance_details_link_for?(resource)).to be_falsey
+          end
+        end
+      end
+
+      context "when the resource is not an upper tier" do
+        let(:upper_tier) { false }
+
+        it "returns false" do
+          expect(helper.display_finance_details_link_for?(resource)).to be_falsey
+        end
       end
     end
   end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-908

A recent PR (#717) was an initial attempt to resolve an issue found with renewals and finance actions. If any finance action, such as a charge adjust, is made before the renewal application is complete (`submitted`) it will be wiped at the the end of the application process.

It was agreed in the team that rather than try to handle in-complete renewals in these transactions (as we are not aware of a need to do so) we'd instead only allow them to be performed on registrations that have a status of `submitted`.

PR #717 focused on payments, where as what we really want to hide is the link to the payment details screen altogether, until such time as the renewal application is complete.

This PR is about updating the code to match this expected behaviour.

<details>
  <summary>Screenshots of expected behaviour</summary>

<img width="981" alt="Screenshot 2020-03-02 at 16 54 29" src="https://user-images.githubusercontent.com/1789650/75698543-d371d280-5ca6-11ea-9db8-1eded4ba9de1.png">

<img width="982" alt="Screenshot 2020-03-02 at 16 59 22" src="https://user-images.githubusercontent.com/1789650/75698776-36636980-5ca7-11ea-8a2d-2e461ddbaff1.png">

</details>
