### PR TITLE
Remove Cease & revoke link from dashboard

### DIFF
--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -112,17 +112,6 @@
                       <% end %>
                     </li>
                   <% end %>
-                  <% if display_cease_or_revoke_link_for?(result) %>
-                    <li>
-                      <%= link_to WasteCarriersEngine::Engine.routes.url_helpers.new_cease_or_revoke_form_path(result.reg_identifier) do %>
-                        <%= t(".results.actions.cease_or_revoke.link_text") %>
-                        <span class="visually-hidden">
-                          <%= t(".results.actions.cease_or_revoke.visually_hidden_text",
-                                name: result.company_name) %>
-                        </span>
-                      <% end %>
-                    </li>
-                  <% end %>
                   <% if display_resume_link_for?(result) %>
                     <li>
                       <%= link_to resume_link_for(result) do %>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-931

It seems a while ago now but we have implemented a new Cease & Revoke function in the back office to replace the existing de-register and revoke functions in the old backend.

This has yet to be shipped, so before we do we'd like to amend a feature of the new implementation. When it was added to the back office it followed the convention in the old code of adding a link to perform the task directly in the dashboard results.

However, we are trying to simplify things as much as possible and that includes reducing the number of things you see in the dashboard results, especially listing actions that are also available in the registrations details screen.

This change covers removing it from the back-office dashboard page.

<details>
<summary>Screenshot before</summary>

![Screenshot 2020-03-03 at 10 08 29](https://user-images.githubusercontent.com/1789650/75765417-64908a00-5d37-11ea-92e6-45c87b6f8362.png)

</details>

<details>
<summary>Screenshot after</summary>

![Screenshot 2020-03-03 at 10 35 46](https://user-images.githubusercontent.com/1789650/75767480-ce5e6300-5d3a-11ea-82ed-960a5de50b04.png)

</details>