### PR TITLE
Remove Transfer link from dashboard page

### DIFF
--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -156,17 +156,6 @@
                       <% end %>
                     </li>
                     <% end %>
-                  <% if display_transfer_link_for?(result) %>
-                    <li>
-                      <%= link_to new_registration_registration_transfer_path(result.reg_identifier) do %>
-                        <%= t(".results.actions.transfer.link_text") %>
-                        <span class="visually-hidden">
-                          <%= t(".results.actions.transfer.visually_hidden_text",
-                                name: result.company_name) %>
-                        </span>
-                      <% end %>
-                    </li>
-                  <% end %>
                 </ul>
               </td>
             </tr>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-932

When we first shipped the back-office it included a new ‘Transfer’ function to replace the broken one in the backend. However, you accessed it from a link in the backend because the back-office had no registration details view.

Fast forward to the recent tech debt work, and the ‘Registration details’ screen was added, along with seeing registrations in the back-office dashboard results. With them in place, we also removed the ‘Transfer’ link from the backend and made it visible in the back-office.

When the dashboard link was added to the back office it followed the convention in the old code of adding a link to perform the task directly in the dashboard results.

However, we are trying to simplify things as much as possible and that includes reducing the number of things you see in the dashboard results, especially listing actions that are also available in the registrations details screen.

<details>
<summary>Screenshot before</summary>

![Screenshot 2020-03-03 at 12 20 51](https://user-images.githubusercontent.com/1789650/75776231-80059000-5d4b-11ea-907d-90f4151e3f80.png)

</details>

<details>
<summary>Screenshot after</summary>

![Screenshot 2020-03-03 at 12 34 51](https://user-images.githubusercontent.com/1789650/75776246-8ac02500-5d4b-11ea-8a81-a3860c832ab7.png)

</details>