### PR TITLE
Fix Transfer registration page rendering

### DIFF
--- a/app/views/registration_transfers/new.html.erb
+++ b/app/views/registration_transfers/new.html.erb
@@ -1,97 +1,81 @@
 <div class="grid-row">
+  <div class="column-full">
+    <%= render("waste_carriers_engine/shared/back", back_path: registration_path(@registration.reg_identifier)) %>
+  </div>
+</div>
+
+<div class="grid-row">
   <div class="column-two-thirds">
-    <%= render("waste_carriers_engine/shared/back", back_path: bo_path) %>
+    <%= render("waste_carriers_engine/shared/errors", object: @registration_transfer_form) %>
+
+    <h1 class="heading-large">
+      <%= t(".heading", reg_identifier: @registration.reg_identifier) %>
+    </h1>
+
+    <div class="form-group">
+      <p><%= t(".paragraph_1", email: @registration.account_email) %></p>
+      <p><%= t(".paragraph_2", reg_identifier: @registration.reg_identifier) %></p>
+      <p><%= t(".paragraph_3", email: @registration.account_email) %></p>
+      <p><%= t(".paragraph_4", email: @registration.account_email) %></p>
+
+      <table>
+        <caption class="heading-medium">
+          <%= t(".registration_info.heading") %>
+        </caption>
+        <tbody>
+          <tr>
+            <td>
+              <%= t(".registration_info.labels.account_email") %>
+            </td>
+            <td>
+              <%= @registration.account_email %>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <%= t(".registration_info.labels.reg_identifier") %>
+            </td>
+            <td>
+              <%= @registration.reg_identifier %>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <%= t(".registration_info.labels.company_name") %>
+            </td>
+            <td>
+              <%= @registration.company_name %>
+            </td>
+          </tr>
+      </table>
+    </div>
+
+    <h2 class="heading-medium">
+      <%= t(".subheading_1") %>
+    </h2>
 
     <%= form_for(@registration_transfer_form, url: registration_registration_transfers_path) do |f| %>
-      <%= render("waste_carriers_engine/shared/errors", object: @registration_transfer_form) %>
-
-      <h1 class="heading-large">
-        <%= t(".heading", reg_identifier: @registration.reg_identifier) %>
-      </h1>
-
-      <div class="form-group">
-        <p><%= t(".paragraph_1", email: @registration.account_email) %></p>
-        <p><%= t(".paragraph_2", reg_identifier: @registration.reg_identifier) %></p>
-        <p><%= t(".paragraph_3", email: @registration.account_email) %></p>
-        <p><%= t(".paragraph_4", email: @registration.account_email) %></p>
-
-        <table>
-          <caption class="heading-medium">
-            <%= t(".registration_info.heading") %>
-          </caption>
-          <tbody>
-            <tr>
-              <td>
-                <%= t(".registration_info.labels.account_email") %>
-              </td>
-              <td>
-                <%= @registration.account_email %>
-              </td>
-            </tr>
-            <tr>
-              <td>
-                <%= t(".registration_info.labels.reg_identifier") %>
-              </td>
-              <td>
-                <%= @registration.reg_identifier %>
-              </td>
-            </tr>
-            <tr>
-              <td>
-                <%= t(".registration_info.labels.company_name") %>
-              </td>
-              <td>
-                <%= @registration.company_name %>
-              </td>
-            </tr>
-        </table>
-
-        <h2 class="heading-medium">
-          <%= t(".subheading_1") %>
-        </h2>
-      </div>
-
-      <% if @registration_transfer_form.errors[:email].any? %>
-      <div class="form-group form-group-error">
-      <% else %>
-      <div class="form-group">
-      <% end %>
-        <fieldset id="email">
-          <legend class="visuallyhidden">
-            <%= t(".heading", reg_identifier: @registration.reg_identifier) %>
-          </legend>
-
-          <% if @registration_transfer_form.errors[:email].any? %>
+      <div class="form-group <%= "form-group-error" if @registration_transfer_form.errors[:email].any? %>" id="email">
+        <% if @registration_transfer_form.errors[:email].any? %>
           <span class="error-message"><%= @registration_transfer_form.errors[:email].join(", ") %></span>
-          <% end %>
+        <% end %>
 
-          <%= f.label :email, t(".email_label"), class: "form-label" %>
-          <%= f.text_field :email, class: "form-control" %>
-        </fieldset>
+        <%= f.label :email, t(".email_label"), class: "form-label" %>
+        <%= f.text_field :email, class: "form-control" %>
       </div>
 
-      <% if @registration_transfer_form.errors[:confirm_email].any? %>
-      <div class="form-group form-group-error">
-      <% else %>
-      <div class="form-group">
-      <% end %>
-        <fieldset id="confirm_email">
-          <legend class="visuallyhidden">
-            <%= t(".heading", reg_identifier: @registration.reg_identifier) %>
-          </legend>
-
-          <% if @registration_transfer_form.errors[:confirm_email].any? %>
+      <div class="form-group <%= "form-group-error" if @registration_transfer_form.errors[:confirm_email].any? %>" id="confirm_email">
+        <% if @registration_transfer_form.errors[:confirm_email].any? %>
           <span class="error-message"><%= @registration_transfer_form.errors[:confirm_email].join(", ") %></span>
-          <% end %>
+        <% end %>
 
-          <%= f.label :confirm_email, t(".confirm_email_label"), class: "form-label" %>
-          <%= f.text_field :confirm_email, class: "form-control" %>
-        </fieldset>
+        <%= f.label :confirm_email, t(".confirm_email_label"), class: "form-label" %>
+        <%= f.text_field :confirm_email, class: "form-control" %>
       </div>
 
       <div class="form-group">
         <%= f.submit t(".button"), class: "button" %>
       </div>
     <% end %>
-  </end>
-</end>
+  </div>
+</div>

--- a/app/views/registration_transfers/success.html.erb
+++ b/app/views/registration_transfers/success.html.erb
@@ -1,6 +1,11 @@
 <div class="grid-row">
-  <div class="column-two-thirds">
+  <div class="column-full">
     <%= render("waste_carriers_engine/shared/back", back_path: new_registration_registration_transfer_path(@registration.reg_identifier)) %>
+  </div>
+</div>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
 
     <h1 class="heading-large">
       <%= t(".heading", reg_identifier: @registration.reg_identifier) %>
@@ -21,5 +26,5 @@
     <div class="form-group">
       <%= link_to t(".button"), registration_path(@registration.reg_identifier), class: "button" %>
     </div>
-  </end>
-</end>
+  </div>
+</div>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-933

It was spotted whilst testing some other functionality that the transfer a registration pages were not properly rendering in IE11. A quick check found that the HTML being rendered is not valid because according to http://validator.w3.org/ they are missing some closing tags.

This change covers ensuring the pages render correctly and are valid.

<details>
<summary>Screenshot</summary>

![image-2020-03-03-16-14-49-558](https://user-images.githubusercontent.com/1789650/75796987-59a41c80-5d6c-11ea-8550-70fa3afc110d.png)

</details>
