### PR TITLE
Fix url to worldpay missed payment form

### DIFF
--- a/app/views/renewing_registrations/show.html.erb
+++ b/app/views/renewing_registrations/show.html.erb
@@ -38,7 +38,7 @@
                 <p>
                   <%= t(".status.messages.worldpay.paragraph_2.missed_payment") %>
                 </p>
-                <%= link_to t(".status.actions.missed_worldpay_payment_button"), new_transient_registration_worldpay_missed_payment_form_path(@transient_registration.reg_identifier), class: 'button' %>
+                <%= link_to t(".status.actions.missed_worldpay_payment_button"), new_resource_worldpay_missed_payment_form_path(@transient_registration.reg_identifier), class: 'button' %>
               <% end %>
             <% else %>
               <p>

--- a/app/views/renewing_registrations/show.html.erb
+++ b/app/views/renewing_registrations/show.html.erb
@@ -38,7 +38,7 @@
                 <p>
                   <%= t(".status.messages.worldpay.paragraph_2.missed_payment") %>
                 </p>
-                <%= link_to t(".status.actions.missed_worldpay_payment_button"), new_resource_worldpay_missed_payment_form_path(@transient_registration.reg_identifier), class: 'button' %>
+                <%= link_to t(".status.actions.missed_worldpay_payment_button"), new_resource_worldpay_missed_payment_form_path(@transient_registration._id), class: 'button' %>
               <% end %>
             <% else %>
               <p>


### PR DESCRIPTION
We recently changed those url to be scoped under the `resource` namespace and we missed to update this specific url. It was spotted during QA