### PR TITLE
Fix redirect path to summary-page

### DIFF
--- a/app/controllers/worldpay_escapes_controller.rb
+++ b/app/controllers/worldpay_escapes_controller.rb
@@ -45,6 +45,6 @@ class WorldpayEscapesController < ApplicationController
   end
 
   def continue_renewal_path
-    WasteCarriersEngine::Engine.routes.url_helpers.new_payment_summary_form_path(@transient_registration.reg_identifier)
+    WasteCarriersEngine::Engine.routes.url_helpers.new_payment_summary_form_path(@transient_registration.token)
   end
 end

--- a/spec/requests/worldpay_escapes_spec.rb
+++ b/spec/requests/worldpay_escapes_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe "WorldpayEscapes", type: :request do
 
         it "redirects to the payment_summary_form" do
           get "/bo/transient-registrations/#{reg_identifier}/revert-to-payment-summary"
-          expect(response).to redirect_to WasteCarriersEngine::Engine.routes.url_helpers.new_payment_summary_form_path(reg_identifier)
+
+          expect(response).to redirect_to WasteCarriersEngine::Engine.routes.url_helpers.new_payment_summary_form_path(transient_registration.token)
         end
 
         it "updates the workflow_state" do


### PR DESCRIPTION
This path should use a `token` rather than a `reg_identifier`. This is a regression bug following our refactoring to use tokens, spotted today in QA.