### PR TITLE
Hide start new registration behind feature toggle

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,7 @@ gem "defra_ruby_aws", "~> 0.2.0"
 # Use the waste carriers engine for the user journey
 gem "waste_carriers_engine",
     git: "https://github.com/DEFRA/waste-carriers-engine",
-    branch: "hide-start-new-reg-behind-feature-toggle"
+    branch: "master"
 
 # Use the defra ruby mocks engine to add support for mocking external services
 # in live environment. Essentially with this gem added and enabled the app

--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,7 @@ gem "defra_ruby_aws", "~> 0.2.0"
 # Use the waste carriers engine for the user journey
 gem "waste_carriers_engine",
     git: "https://github.com/DEFRA/waste-carriers-engine",
-    branch: "master"
+    branch: "hide-start-new-reg-behind-feature-toggle"
 
 # Use the defra ruby mocks engine to add support for mocking external services
 # in live environment. Essentially with this gem added and enabled the app

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,12 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
+<<<<<<< HEAD
   revision: 49d4d99884a5260929bed95c391cfb33cecc71bb
   branch: master
+=======
+  revision: 2cc9e9c8860ffc6d45f364fee120fe72d9c32980
+  branch: hide-start-new-reg-behind-feature-toggle
+>>>>>>> Switch to branch version of engine
   specs:
     waste_carriers_engine (0.0.1)
       aasm (~> 4.12)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,7 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-<<<<<<< HEAD
-  revision: 49d4d99884a5260929bed95c391cfb33cecc71bb
+  revision: 015c31e9a57db1b1796ddfc2bd7f9a29ead6cd87
   branch: master
-=======
-  revision: 2cc9e9c8860ffc6d45f364fee120fe72d9c32980
-  branch: hide-start-new-reg-behind-feature-toggle
->>>>>>> Switch to branch version of engine
   specs:
     waste_carriers_engine (0.0.1)
       aasm (~> 4.12)

--- a/config/feature_toggles.yml
+++ b/config/feature_toggles.yml
@@ -1,3 +1,5 @@
 ---
 edit_registration:
   active: <%= ENV["FEATURE_TOGGLE_EDIT_REGISTRATION"] %>
+new_registration:
+  active: <%= ENV["FEATURE_TOGGLE_NEW_REGISTRATION"] %>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-840

We are currently not yet finished with building new registrations into the service (migrating it from the old code). But there are other features we do want to ship so for now, we will hide the ability to start a new registration behind a feature toggle.