### PR TITLE
Fix conviction approval access permissions

### DIFF
--- a/app/controllers/convictions_controller.rb
+++ b/app/controllers/convictions_controller.rb
@@ -2,6 +2,7 @@
 
 class ConvictionsController < ApplicationController
   before_action :authenticate_user!
+  before_action :authorize_action
 
   def index
     find_resource(params)
@@ -15,6 +16,10 @@ class ConvictionsController < ApplicationController
   end
 
   private
+
+  def authorize_action
+    authorize! :review_convictions, nil
+  end
 
   def find_resource(params)
     if params[:registration_reg_identifier].present?

--- a/app/controllers/convictions_dashboards_controller.rb
+++ b/app/controllers/convictions_dashboards_controller.rb
@@ -2,6 +2,7 @@
 
 class ConvictionsDashboardsController < ApplicationController
   before_action :authenticate_user!
+  before_action :authorize_action
 
   def index
     ordered_and_paged(list_of_possible_matches)
@@ -20,6 +21,10 @@ class ConvictionsDashboardsController < ApplicationController
   end
 
   private
+
+  def authorize_action
+    authorize! :review_convictions, nil
+  end
 
   def list_of_possible_matches
     WasteCarriersEngine::RenewingRegistration.submitted.convictions_possible_match +

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -39,8 +39,6 @@ class Ability
     can :order_copy_cards, WasteCarriersEngine::Registration
     can :edit, WasteCarriersEngine::Registration if WasteCarriersEngine::FeatureToggle.active?(:edit_registration)
 
-    can :review_convictions, :all
-
     can :revert_to_payment_summary, :all
 
     can :transfer_registration, WasteCarriersEngine::Registration
@@ -58,6 +56,8 @@ class Ability
     can :record_cheque_payment, :all
     can :record_postal_order_payment, :all
     can :view_payments, :all
+
+    can :review_convictions, :all
 
     can :write_off_small, WasteCarriersEngine::FinanceDetails do |finance_details|
       finance_details.zero_difference_balance <= write_off_agency_user_cap

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,10 +19,12 @@
                 <%= link_to t("layouts.application.menu.dashboard"),
                             main_app.bo_path %>
               </li>
-              <li>
-                <%= link_to t("layouts.application.menu.convictions"),
-                            main_app.convictions_path %>
-              </li>
+              <% if can?(:review_convictions, current_user) %>
+                <li>
+                  <%= link_to t("layouts.application.menu.convictions"),
+                              main_app.convictions_path %>
+                </li>
+              <% end %>
               <% if can?(:manage_back_office_users, current_user) %>
                 <li>
                   <%= link_to t("layouts.application.menu.users"),

--- a/spec/requests/conviction_approval_forms_spec.rb
+++ b/spec/requests/conviction_approval_forms_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "ConvictionApprovalForms", type: :request do
 
   describe "GET /bo/transient-registrations/:reg_identifier/convictions/approve" do
     context "when a valid user is signed in" do
-      let(:user) { create(:user, :agency) }
+      let(:user) { create(:user, :agency_with_refund) }
       before(:each) do
         sign_in(user)
       end
@@ -46,7 +46,7 @@ RSpec.describe "ConvictionApprovalForms", type: :request do
 
   describe "POST /bo/transient-registrations/:reg_identifier/convictions/approve" do
     context "when a valid user is signed in" do
-      let(:user) { create(:user, :agency) }
+      let(:user) { create(:user, :agency_with_refund) }
       before(:each) do
         sign_in(user)
       end

--- a/spec/requests/conviction_approval_forms_spec.rb
+++ b/spec/requests/conviction_approval_forms_spec.rb
@@ -15,18 +15,11 @@ RSpec.describe "ConvictionApprovalForms", type: :request do
         sign_in(user)
       end
 
-      it "renders the new template" do
+      it "renders the new template, returns a 200 response, and includes the reg identifier" do
         get "/bo/transient-registrations/#{transient_registration.reg_identifier}/convictions/approve"
+
         expect(response).to render_template(:new)
-      end
-
-      it "returns a 200 response" do
-        get "/bo/transient-registrations/#{transient_registration.reg_identifier}/convictions/approve"
         expect(response).to have_http_status(200)
-      end
-
-      it "includes the reg identifier" do
-        get "/bo/transient-registrations/#{transient_registration.reg_identifier}/convictions/approve"
         expect(response.body).to include(transient_registration.reg_identifier)
       end
     end
@@ -62,33 +55,15 @@ RSpec.describe "ConvictionApprovalForms", type: :request do
         }
       end
 
-      it "redirects to the convictions page" do
+      it "redirects to the convictions page and updates the revoked_reason, workflow_state, and 'confirmed_' attributes" do
         post "/bo/transient-registrations/#{transient_registration.reg_identifier}/convictions/approve", conviction_approval_form: params
+
         expect(response).to redirect_to(convictions_path)
-      end
 
-      it "updates the revoked_reason" do
-        post "/bo/transient-registrations/#{transient_registration.reg_identifier}/convictions/approve", conviction_approval_form: params
         expect(transient_registration.reload.metaData.revoked_reason).to eq(params[:revoked_reason])
-      end
-
-      it "updates the conviction_sign_off's confirmed" do
-        post "/bo/transient-registrations/#{transient_registration.reg_identifier}/convictions/approve", conviction_approval_form: params
         expect(transient_registration.reload.conviction_sign_offs.first.confirmed).to eq("yes")
-      end
-
-      it "updates the conviction_sign_off's confirmed_at" do
-        post "/bo/transient-registrations/#{transient_registration.reg_identifier}/convictions/approve", conviction_approval_form: params
         expect(transient_registration.reload.conviction_sign_offs.first.confirmed_at).to be_a(DateTime)
-      end
-
-      it "updates the conviction_sign_off's confirmed_by" do
-        post "/bo/transient-registrations/#{transient_registration.reg_identifier}/convictions/approve", conviction_approval_form: params
         expect(transient_registration.reload.conviction_sign_offs.first.confirmed_by).to eq(user.email)
-      end
-
-      it "updates the conviction_sign_off's workflow_state" do
-        post "/bo/transient-registrations/#{transient_registration.reg_identifier}/convictions/approve", conviction_approval_form: params
         expect(transient_registration.reload.conviction_sign_offs.first.workflow_state).to eq("approved")
       end
 
@@ -141,18 +116,11 @@ RSpec.describe "ConvictionApprovalForms", type: :request do
           }
         end
 
-        it "renders the new template" do
+        it "renders the new template, does not update the revoked_reason, and does not update the conviction_sign_off" do
           post "/bo/transient-registrations/#{transient_registration.reg_identifier}/convictions/approve", conviction_approval_form: params
+
           expect(response).to render_template(:new)
-        end
-
-        it "does not update the revoked_reason" do
-          post "/bo/transient-registrations/#{transient_registration.reg_identifier}/convictions/approve", conviction_approval_form: params
           expect(transient_registration.reload.metaData.revoked_reason).to_not eq(params[:revoked_reason])
-        end
-
-        it "does not update the conviction_sign_off" do
-          post "/bo/transient-registrations/#{transient_registration.reg_identifier}/convictions/approve", conviction_approval_form: params
           expect(transient_registration.reload.conviction_sign_offs.first.confirmed).to eq("no")
         end
       end
@@ -170,18 +138,11 @@ RSpec.describe "ConvictionApprovalForms", type: :request do
         }
       end
 
-      it "redirects to the permissions error page" do
+      it "redirects to the permissions error page, does not update the revoked_reason, and does not update the conviction_sign_off" do
         post "/bo/transient-registrations/#{transient_registration.reg_identifier}/convictions/approve", conviction_approval_form: params
+
         expect(response).to redirect_to("/bo/pages/permission")
-      end
-
-      it "does not update the revoked_reason" do
-        post "/bo/transient-registrations/#{transient_registration.reg_identifier}/convictions/approve", conviction_approval_form: params
         expect(transient_registration.reload.metaData.revoked_reason).to_not eq(params[:revoked_reason])
-      end
-
-      it "does not update the conviction_sign_off" do
-        post "/bo/transient-registrations/#{transient_registration.reg_identifier}/convictions/approve", conviction_approval_form: params
         expect(transient_registration.reload.conviction_sign_offs.first.confirmed).to eq("no")
       end
     end

--- a/spec/requests/conviction_rejection_forms_spec.rb
+++ b/spec/requests/conviction_rejection_forms_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "ConvictionRejectionForms", type: :request do
 
   describe "GET /bo/transient-registrations/:reg_identifier/convictions/reject" do
     context "when a valid user is signed in" do
-      let(:user) { create(:user, :agency) }
+      let(:user) { create(:user, :agency_with_refund) }
       before(:each) do
         sign_in(user)
       end
@@ -43,7 +43,7 @@ RSpec.describe "ConvictionRejectionForms", type: :request do
 
   describe "POST /bo/transient-registrations/:reg_identifier/convictions/reject" do
     context "when a valid user is signed in" do
-      let(:user) { create(:user, :agency) }
+      let(:user) { create(:user, :agency_with_refund) }
       before(:each) do
         sign_in(user)
       end

--- a/spec/requests/conviction_rejection_forms_spec.rb
+++ b/spec/requests/conviction_rejection_forms_spec.rb
@@ -12,18 +12,11 @@ RSpec.describe "ConvictionRejectionForms", type: :request do
         sign_in(user)
       end
 
-      it "renders the new template" do
+      it "renders the new template, returns a 200 response, and includes the reg identifier" do
         get "/bo/transient-registrations/#{transient_registration.reg_identifier}/convictions/reject"
+
         expect(response).to render_template(:new)
-      end
-
-      it "returns a 200 response" do
-        get "/bo/transient-registrations/#{transient_registration.reg_identifier}/convictions/reject"
         expect(response).to have_http_status(200)
-      end
-
-      it "includes the reg identifier" do
-        get "/bo/transient-registrations/#{transient_registration.reg_identifier}/convictions/reject"
         expect(response.body).to include(transient_registration.reg_identifier)
       end
     end
@@ -54,33 +47,16 @@ RSpec.describe "ConvictionRejectionForms", type: :request do
         }
       end
 
-      it "redirects to the convictions page" do
+      it "redirects to the convictions page, revokes the renewal, and updates the revoked_reason, workflow_state, and 'confirmed_' attributes" do
         post "/bo/transient-registrations/#{transient_registration.reg_identifier}/convictions/reject", conviction_rejection_form: params
+
         expect(response).to redirect_to(convictions_checks_in_progress_path)
-      end
 
-      it "updates the revoked_reason" do
-        post "/bo/transient-registrations/#{transient_registration.reg_identifier}/convictions/reject", conviction_rejection_form: params
         expect(transient_registration.reload.metaData.revoked_reason).to eq(params[:revoked_reason])
-      end
-
-      it "revokes the renewal" do
-        post "/bo/transient-registrations/#{transient_registration.reg_identifier}/convictions/reject", conviction_rejection_form: params
         expect(transient_registration.reload.metaData.status).to eq("REVOKED")
-      end
 
-      it "updates the conviction_sign_off's confirmed_at" do
-        post "/bo/transient-registrations/#{transient_registration.reg_identifier}/convictions/reject", conviction_rejection_form: params
         expect(transient_registration.reload.conviction_sign_offs.first.confirmed_at).to be_a(DateTime)
-      end
-
-      it "updates the conviction_sign_off's confirmed_by" do
-        post "/bo/transient-registrations/#{transient_registration.reg_identifier}/convictions/reject", conviction_rejection_form: params
         expect(transient_registration.reload.conviction_sign_offs.first.confirmed_by).to eq(user.email)
-      end
-
-      it "updates the conviction_sign_off's workflow_state" do
-        post "/bo/transient-registrations/#{transient_registration.reg_identifier}/convictions/reject", conviction_rejection_form: params
         expect(transient_registration.reload.conviction_sign_offs.first.workflow_state).to eq("rejected")
       end
 
@@ -91,18 +67,11 @@ RSpec.describe "ConvictionRejectionForms", type: :request do
           }
         end
 
-        it "renders the new template" do
+        it "renders the new template, does not update the revoked_reason, and does not revoke the renewal" do
           post "/bo/transient-registrations/#{transient_registration.reg_identifier}/convictions/reject", conviction_rejection_form: params
+
           expect(response).to render_template(:new)
-        end
-
-        it "does not update the revoked_reason" do
-          post "/bo/transient-registrations/#{transient_registration.reg_identifier}/convictions/reject", conviction_rejection_form: params
           expect(transient_registration.reload.metaData.revoked_reason).to_not eq(params[:revoked_reason])
-        end
-
-        it "does not revoke the renewal" do
-          post "/bo/transient-registrations/#{transient_registration.reg_identifier}/convictions/reject", conviction_rejection_form: params
           expect(transient_registration.reload.metaData.status).to eq("ACTIVE")
         end
       end
@@ -120,18 +89,11 @@ RSpec.describe "ConvictionRejectionForms", type: :request do
         }
       end
 
-      it "redirects to the permissions error page" do
+      it "redirects to the permissions error page, does not update the revoked_reason, and does not update the conviction_sign_off" do
         post "/bo/transient-registrations/#{transient_registration.reg_identifier}/convictions/reject", conviction_rejection_form: params
+
         expect(response).to redirect_to("/bo/pages/permission")
-      end
-
-      it "does not update the revoked_reason" do
-        post "/bo/transient-registrations/#{transient_registration.reg_identifier}/convictions/reject", conviction_rejection_form: params
         expect(transient_registration.reload.metaData.revoked_reason).to_not eq(params[:revoked_reason])
-      end
-
-      it "does not update the conviction_sign_off" do
-        post "/bo/transient-registrations/#{transient_registration.reg_identifier}/convictions/reject", conviction_rejection_form: params
         expect(transient_registration.reload.conviction_sign_offs.first.confirmed).to eq("no")
       end
     end

--- a/spec/requests/convictions_dashboards_spec.rb
+++ b/spec/requests/convictions_dashboards_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe "ConvictionsDashboards", type: :request do
 
   describe "/bo/convictions" do
     context "when a valid user is signed in" do
-      let(:user) { create(:user) }
+      let(:user) { create(:user, :agency_with_refund) }
       before(:each) do
         sign_in(user)
       end
@@ -113,6 +113,18 @@ RSpec.describe "ConvictionsDashboards", type: :request do
       end
     end
 
+    context "when a non-agency user is signed in" do
+      let(:user) { create(:user, :finance) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      it "redirects to the permissions error page" do
+        get "/bo/convictions"
+        expect(response).to redirect_to("/bo/pages/permission")
+      end
+    end
+
     context "when a user is not signed in" do
       it "redirects to the sign-in page" do
         get "/bo/convictions"
@@ -123,7 +135,7 @@ RSpec.describe "ConvictionsDashboards", type: :request do
 
   describe "/bo/convictions/in-progress" do
     context "when a valid user is signed in" do
-      let(:user) { create(:user) }
+      let(:user) { create(:user, :agency_with_refund) }
       before(:each) do
         sign_in(user)
       end
@@ -150,6 +162,18 @@ RSpec.describe "ConvictionsDashboards", type: :request do
       end
     end
 
+    context "when a non-agency user is signed in" do
+      let(:user) { create(:user, :finance) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      it "redirects to the permissions error page" do
+        get "/bo/convictions/in-progress"
+        expect(response).to redirect_to("/bo/pages/permission")
+      end
+    end
+
     context "when a user is not signed in" do
       it "redirects to the sign-in page" do
         get "/bo/convictions/in-progress"
@@ -160,7 +184,7 @@ RSpec.describe "ConvictionsDashboards", type: :request do
 
   describe "/bo/convictions/approved" do
     context "when a valid user is signed in" do
-      let(:user) { create(:user) }
+      let(:user) { create(:user, :agency_with_refund) }
       before(:each) do
         sign_in(user)
       end
@@ -188,6 +212,18 @@ RSpec.describe "ConvictionsDashboards", type: :request do
       end
     end
 
+    context "when a non-agency user is signed in" do
+      let(:user) { create(:user, :finance) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      it "redirects to the permissions error page" do
+        get "/bo/convictions/approved"
+        expect(response).to redirect_to("/bo/pages/permission")
+      end
+    end
+
     context "when a user is not signed in" do
       it "redirects to the sign-in page" do
         get "/bo/convictions/approved"
@@ -198,7 +234,7 @@ RSpec.describe "ConvictionsDashboards", type: :request do
 
   describe "/bo/convictions/rejected" do
     context "when a valid user is signed in" do
-      let(:user) { create(:user) }
+      let(:user) { create(:user, :agency_with_refund) }
       before(:each) do
         sign_in(user)
       end
@@ -222,6 +258,18 @@ RSpec.describe "ConvictionsDashboards", type: :request do
         expect(response.body).to_not include(link_to_possible_matches_registration)
         expect(response.body).to_not include(link_to_new_from_frontend_registration)
         expect(response.body).to_not include(link_to_possible_matches_renewal)
+      end
+    end
+
+    context "when a non-agency user is signed in" do
+      let(:user) { create(:user, :finance) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      it "redirects to the permissions error page" do
+        get "/bo/convictions/rejected"
+        expect(response).to redirect_to("/bo/pages/permission")
       end
     end
 

--- a/spec/requests/convictions_dashboards_spec.rb
+++ b/spec/requests/convictions_dashboards_spec.rb
@@ -91,18 +91,11 @@ RSpec.describe "ConvictionsDashboards", type: :request do
         sign_in(user)
       end
 
-      it "renders the index template" do
+      it "renders the index template, returns a 200 response, and links to the correct registrations and renewals" do
         get "/bo/convictions"
+
         expect(response).to render_template(:index)
-      end
-
-      it "returns a 200 response" do
-        get "/bo/convictions"
         expect(response).to have_http_status(200)
-      end
-
-      it "links to the correct registrations and renewals" do
-        get "/bo/convictions"
 
         expect(response.body).to include(link_to_possible_matches_registration)
         expect(response.body).to include(link_to_new_from_frontend_registration)
@@ -140,18 +133,11 @@ RSpec.describe "ConvictionsDashboards", type: :request do
         sign_in(user)
       end
 
-      it "renders the possible_matches template" do
+      it "renders the possible_matches template, returns a 200 response, and links to the correct registrations and renewals" do
         get "/bo/convictions/in-progress"
+
         expect(response).to render_template(:checks_in_progress)
-      end
-
-      it "returns a 200 response" do
-        get "/bo/convictions/in-progress"
         expect(response).to have_http_status(200)
-      end
-
-      it "links to the correct registrations and renewals" do
-        get "/bo/convictions/in-progress"
 
         expect(response.body).to include(link_to_checks_in_progress_registration)
         expect(response.body).to include(link_to_checks_in_progress_renewal)
@@ -189,18 +175,11 @@ RSpec.describe "ConvictionsDashboards", type: :request do
         sign_in(user)
       end
 
-      it "renders the possible_matches template" do
+      it "renders the possible_matches template, returns a 200 response, and links to the correct registrations and renewals" do
         get "/bo/convictions/approved"
+
         expect(response).to render_template(:approved)
-      end
-
-      it "returns a 200 response" do
-        get "/bo/convictions/approved"
         expect(response).to have_http_status(200)
-      end
-
-      it "links to the correct registrations and renewals" do
-        get "/bo/convictions/approved"
 
         expect(response.body).to include(link_to_pending_approved_registration)
         expect(response.body).to include(link_to_approved_renewal)
@@ -239,18 +218,11 @@ RSpec.describe "ConvictionsDashboards", type: :request do
         sign_in(user)
       end
 
-      it "renders the possible_matches template" do
+      it "renders the possible_matches template, returns a 200 response, and links to the correct registrations and renewals" do
         get "/bo/convictions/rejected"
+
         expect(response).to render_template(:rejected)
-      end
-
-      it "returns a 200 response" do
-        get "/bo/convictions/rejected"
         expect(response).to have_http_status(200)
-      end
-
-      it "links to the correct registrations and renewals" do
-        get "/bo/convictions/rejected"
 
         expect(response.body).to include(link_to_rejected_renewal)
 

--- a/spec/requests/convictions_spec.rb
+++ b/spec/requests/convictions_spec.rb
@@ -13,18 +13,11 @@ RSpec.describe "Convictions", type: :request do
         sign_in(user)
       end
 
-      it "renders the index template" do
+      it "renders the index template, returns a 200 response, and includes the reg identifier" do
         get "/bo/registrations/#{registration.reg_identifier}/convictions"
+
         expect(response).to render_template(:index)
-      end
-
-      it "returns a 200 response" do
-        get "/bo/registrations/#{registration.reg_identifier}/convictions"
         expect(response).to have_http_status(200)
-      end
-
-      it "includes the reg identifier" do
-        get "/bo/registrations/#{registration.reg_identifier}/convictions"
         expect(response.body).to include(registration.reg_identifier)
       end
     end
@@ -56,18 +49,11 @@ RSpec.describe "Convictions", type: :request do
         sign_in(user)
       end
 
-      it "renders the index template" do
+      it "renders the index template, returns a 200 response, and includes the reg identifier" do
         get "/bo/transient-registrations/#{transient_registration.reg_identifier}/convictions"
+
         expect(response).to render_template(:index)
-      end
-
-      it "returns a 200 response" do
-        get "/bo/transient-registrations/#{transient_registration.reg_identifier}/convictions"
         expect(response).to have_http_status(200)
-      end
-
-      it "includes the reg identifier" do
-        get "/bo/transient-registrations/#{transient_registration.reg_identifier}/convictions"
         expect(response.body).to include(transient_registration.reg_identifier)
       end
     end
@@ -99,13 +85,10 @@ RSpec.describe "Convictions", type: :request do
         sign_in(user)
       end
 
-      it "updates the status of the conviction_sign_off" do
+      it "updates the status of the conviction_sign_off and redirects to the convictions page" do
         get "/bo/registrations/#{registration.reg_identifier}/convictions/begin-checks"
-        expect(registration.reload.conviction_sign_offs.first.workflow_state).to eq("checks_in_progress")
-      end
 
-      it "redirects to the convictions page" do
-        get "/bo/registrations/#{registration.reg_identifier}/convictions/begin-checks"
+        expect(registration.reload.conviction_sign_offs.first.workflow_state).to eq("checks_in_progress")
         expect(response).to redirect_to(convictions_path)
       end
     end
@@ -137,13 +120,10 @@ RSpec.describe "Convictions", type: :request do
         sign_in(user)
       end
 
-      it "updates the status of the conviction_sign_off" do
+      it "updates the status of the conviction_sign_off and redirects to the convictions page" do
         get "/bo/transient-registrations/#{transient_registration.reg_identifier}/convictions/begin-checks"
-        expect(transient_registration.reload.conviction_sign_offs.first.workflow_state).to eq("checks_in_progress")
-      end
 
-      it "redirects to the convictions page" do
-        get "/bo/transient-registrations/#{transient_registration.reg_identifier}/convictions/begin-checks"
+        expect(transient_registration.reload.conviction_sign_offs.first.workflow_state).to eq("checks_in_progress")
         expect(response).to redirect_to(convictions_path)
       end
     end

--- a/spec/requests/convictions_spec.rb
+++ b/spec/requests/convictions_spec.rb
@@ -40,6 +40,13 @@ RSpec.describe "Convictions", type: :request do
         expect(response).to redirect_to("/bo/pages/permission")
       end
     end
+
+    context "when a user is not signed in" do
+      it "redirects to the sign-in page" do
+        get "/bo/registrations/#{registration.reg_identifier}/convictions"
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
   end
 
   describe "/bo/transient-registrations/:reg_identifier/convictions" do
@@ -76,6 +83,13 @@ RSpec.describe "Convictions", type: :request do
         expect(response).to redirect_to("/bo/pages/permission")
       end
     end
+
+    context "when a user is not signed in" do
+      it "redirects to the sign-in page" do
+        get "/bo/transient-registrations/#{transient_registration.reg_identifier}/convictions"
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
   end
 
   describe "/bo/registrations/:registration_reg_identifier/convictions/begin-checks" do
@@ -105,6 +119,13 @@ RSpec.describe "Convictions", type: :request do
       it "redirects to the permissions error page" do
         get "/bo/registrations/#{registration.reg_identifier}/convictions/begin-checks"
         expect(response).to redirect_to("/bo/pages/permission")
+      end
+    end
+
+    context "when a user is not signed in" do
+      it "redirects to the sign-in page" do
+        get "/bo/registrations/#{registration.reg_identifier}/convictions/begin-checks"
+        expect(response).to redirect_to(new_user_session_path)
       end
     end
   end
@@ -137,6 +158,13 @@ RSpec.describe "Convictions", type: :request do
     it "redirects to the permissions error page" do
       get "/bo/transient-registrations/#{transient_registration.reg_identifier}/convictions/begin-checks"
       expect(response).to redirect_to("/bo/pages/permission")
+    end
+  end
+
+  context "when a user is not signed in" do
+    it "redirects to the sign-in page" do
+      get "/bo/transient-registrations/#{transient_registration.reg_identifier}/convictions/begin-checks"
+      expect(response).to redirect_to(new_user_session_path)
     end
   end
 end

--- a/spec/requests/convictions_spec.rb
+++ b/spec/requests/convictions_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Convictions", type: :request do
 
   describe "/bo/registrations/:reg_identifier/convictions" do
     context "when a valid user is signed in" do
-      let(:user) { create(:user) }
+      let(:user) { create(:user, :agency_with_refund) }
       before(:each) do
         sign_in(user)
       end
@@ -28,11 +28,23 @@ RSpec.describe "Convictions", type: :request do
         expect(response.body).to include(registration.reg_identifier)
       end
     end
+
+    context "when a non-agency user is signed in" do
+      let(:user) { create(:user, :finance) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      it "redirects to the permissions error page" do
+        get "/bo/registrations/#{registration.reg_identifier}/convictions"
+        expect(response).to redirect_to("/bo/pages/permission")
+      end
+    end
   end
 
   describe "/bo/transient-registrations/:reg_identifier/convictions" do
     context "when a valid user is signed in" do
-      let(:user) { create(:user) }
+      let(:user) { create(:user, :agency_with_refund) }
       before(:each) do
         sign_in(user)
       end
@@ -52,11 +64,23 @@ RSpec.describe "Convictions", type: :request do
         expect(response.body).to include(transient_registration.reg_identifier)
       end
     end
+
+    context "when a non-agency user is signed in" do
+      let(:user) { create(:user, :finance) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      it "redirects to the permissions error page" do
+        get "/bo/transient-registrations/#{transient_registration.reg_identifier}/convictions"
+        expect(response).to redirect_to("/bo/pages/permission")
+      end
+    end
   end
 
   describe "/bo/registrations/:registration_reg_identifier/convictions/begin-checks" do
     context "when a valid user is signed in" do
-      let(:user) { create(:user) }
+      let(:user) { create(:user, :agency_with_refund) }
       before(:each) do
         sign_in(user)
       end
@@ -71,11 +95,23 @@ RSpec.describe "Convictions", type: :request do
         expect(response).to redirect_to(convictions_path)
       end
     end
+
+    context "when a non-agency user is signed in" do
+      let(:user) { create(:user, :finance) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      it "redirects to the permissions error page" do
+        get "/bo/registrations/#{registration.reg_identifier}/convictions/begin-checks"
+        expect(response).to redirect_to("/bo/pages/permission")
+      end
+    end
   end
 
   describe "/bo/transient-registrations/:transient_registration_reg_identifier/convictions/begin-checks" do
     context "when a valid user is signed in" do
-      let(:user) { create(:user) }
+      let(:user) { create(:user, :agency_with_refund) }
       before(:each) do
         sign_in(user)
       end
@@ -89,6 +125,18 @@ RSpec.describe "Convictions", type: :request do
         get "/bo/transient-registrations/#{transient_registration.reg_identifier}/convictions/begin-checks"
         expect(response).to redirect_to(convictions_path)
       end
+    end
+  end
+
+  context "when a non-agency user is signed in" do
+    let(:user) { create(:user, :finance) }
+    before(:each) do
+      sign_in(user)
+    end
+
+    it "redirects to the permissions error page" do
+      get "/bo/transient-registrations/#{transient_registration.reg_identifier}/convictions/begin-checks"
+      expect(response).to redirect_to("/bo/pages/permission")
     end
   end
 end

--- a/spec/requests/registration_conviction_approval_forms_spec.rb
+++ b/spec/requests/registration_conviction_approval_forms_spec.rb
@@ -12,18 +12,11 @@ RSpec.describe "RegistrationConvictionApprovalForms", type: :request do
         sign_in(user)
       end
 
-      it "renders the new template" do
+      it "renders the new template, returns a 200 response, and includes the reg identifier" do
         get "/bo/registrations/#{registration.reg_identifier}/convictions/approve"
+
         expect(response).to render_template(:new)
-      end
-
-      it "returns a 200 response" do
-        get "/bo/registrations/#{registration.reg_identifier}/convictions/approve"
         expect(response).to have_http_status(200)
-      end
-
-      it "includes the reg identifier" do
-        get "/bo/registrations/#{registration.reg_identifier}/convictions/approve"
         expect(response.body).to include(registration.reg_identifier)
       end
     end
@@ -54,33 +47,15 @@ RSpec.describe "RegistrationConvictionApprovalForms", type: :request do
         }
       end
 
-      it "redirects to the convictions page" do
+      it "redirects to the convictions page and updates the revoked_reason, workflow_state, and 'confirmed_' attributes" do
         post "/bo/registrations/#{registration.reg_identifier}/convictions/approve", conviction_approval_form: params
+
         expect(response).to redirect_to(convictions_path)
-      end
 
-      it "updates the revoked_reason" do
-        post "/bo/registrations/#{registration.reg_identifier}/convictions/approve", conviction_approval_form: params
         expect(registration.reload.metaData.revoked_reason).to eq(params[:revoked_reason])
-      end
-
-      it "updates the conviction_sign_off's confirmed" do
-        post "/bo/registrations/#{registration.reg_identifier}/convictions/approve", conviction_approval_form: params
         expect(registration.reload.conviction_sign_offs.first.confirmed).to eq("yes")
-      end
-
-      it "updates the conviction_sign_off's confirmed_at" do
-        post "/bo/registrations/#{registration.reg_identifier}/convictions/approve", conviction_approval_form: params
         expect(registration.reload.conviction_sign_offs.first.confirmed_at).to be_a(DateTime)
-      end
-
-      it "updates the conviction_sign_off's confirmed_by" do
-        post "/bo/registrations/#{registration.reg_identifier}/convictions/approve", conviction_approval_form: params
         expect(registration.reload.conviction_sign_offs.first.confirmed_by).to eq(user.email)
-      end
-
-      it "updates the conviction_sign_off's workflow_state" do
-        post "/bo/registrations/#{registration.reg_identifier}/convictions/approve", conviction_approval_form: params
         expect(registration.reload.conviction_sign_offs.first.workflow_state).to eq("approved")
       end
 
@@ -108,18 +83,11 @@ RSpec.describe "RegistrationConvictionApprovalForms", type: :request do
           }
         end
 
-        it "renders the new template" do
+        it "renders the new template, does not update the revoked_reason, and does not update the conviction_sign_off" do
           post "/bo/registrations/#{registration.reg_identifier}/convictions/approve", conviction_approval_form: params
+
           expect(response).to render_template(:new)
-        end
-
-        it "does not update the revoked_reason" do
-          post "/bo/registrations/#{registration.reg_identifier}/convictions/approve", conviction_approval_form: params
           expect(registration.reload.metaData.revoked_reason).to_not eq(params[:revoked_reason])
-        end
-
-        it "does not update the conviction_sign_off" do
-          post "/bo/registrations/#{registration.reg_identifier}/convictions/approve", conviction_approval_form: params
           expect(registration.reload.conviction_sign_offs.first.confirmed).to eq("no")
         end
       end
@@ -137,18 +105,11 @@ RSpec.describe "RegistrationConvictionApprovalForms", type: :request do
         }
       end
 
-      it "redirects to the permissions error page" do
+      it "redirects to the permissions error page, does not update the revoked_reason, does not update the conviction_sign_off" do
         post "/bo/registrations/#{registration.reg_identifier}/convictions/approve", conviction_approval_form: params
+
         expect(response).to redirect_to("/bo/pages/permission")
-      end
-
-      it "does not update the revoked_reason" do
-        post "/bo/registrations/#{registration.reg_identifier}/convictions/approve", conviction_approval_form: params
         expect(registration.reload.metaData.revoked_reason).to_not eq(params[:revoked_reason])
-      end
-
-      it "does not update the conviction_sign_off" do
-        post "/bo/registrations/#{registration.reg_identifier}/convictions/approve", conviction_approval_form: params
         expect(registration.reload.conviction_sign_offs.first.confirmed).to eq("no")
       end
     end

--- a/spec/requests/registration_conviction_approval_forms_spec.rb
+++ b/spec/requests/registration_conviction_approval_forms_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "RegistrationConvictionApprovalForms", type: :request do
 
   describe "GET /bo/registrations/:reg_identifier/convictions/approve" do
     context "when a valid user is signed in" do
-      let(:user) { create(:user, :agency) }
+      let(:user) { create(:user, :agency_with_refund) }
       before(:each) do
         sign_in(user)
       end
@@ -43,7 +43,7 @@ RSpec.describe "RegistrationConvictionApprovalForms", type: :request do
 
   describe "POST /bo/registrations/:reg_identifier/convictions/approve" do
     context "when a valid user is signed in" do
-      let(:user) { create(:user, :agency) }
+      let(:user) { create(:user, :agency_with_refund) }
       before(:each) do
         sign_in(user)
       end

--- a/spec/requests/registration_conviction_rejection_forms_spec.rb
+++ b/spec/requests/registration_conviction_rejection_forms_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "RegistrationConvictionRejectionForms", type: :request do
 
   describe "GET /bo/registrations/:reg_identifier/convictions/reject" do
     context "when a valid user is signed in" do
-      let(:user) { create(:user, :agency) }
+      let(:user) { create(:user, :agency_with_refund) }
       before(:each) do
         sign_in(user)
       end
@@ -43,7 +43,7 @@ RSpec.describe "RegistrationConvictionRejectionForms", type: :request do
 
   describe "POST /bo/registrations/:reg_identifier/convictions/reject" do
     context "when a valid user is signed in" do
-      let(:user) { create(:user, :agency) }
+      let(:user) { create(:user, :agency_with_refund) }
       before(:each) do
         sign_in(user)
       end

--- a/spec/requests/registration_conviction_rejection_forms_spec.rb
+++ b/spec/requests/registration_conviction_rejection_forms_spec.rb
@@ -12,18 +12,11 @@ RSpec.describe "RegistrationConvictionRejectionForms", type: :request do
         sign_in(user)
       end
 
-      it "renders the new template" do
+      it "renders the new template, returns a 200 response, and includes the reg identifier" do
         get "/bo/registrations/#{registration.reg_identifier}/convictions/reject"
+
         expect(response).to render_template(:new)
-      end
-
-      it "returns a 200 response" do
-        get "/bo/registrations/#{registration.reg_identifier}/convictions/reject"
         expect(response).to have_http_status(200)
-      end
-
-      it "includes the reg identifier" do
-        get "/bo/registrations/#{registration.reg_identifier}/convictions/reject"
         expect(response.body).to include(registration.reg_identifier)
       end
     end
@@ -54,34 +47,17 @@ RSpec.describe "RegistrationConvictionRejectionForms", type: :request do
         }
       end
 
-      it "redirects to the convictions page" do
+      it "redirects to the convictions page, refuses the registration, and updates the revoked_reason, workflow_state, and 'confirmed_' attributes" do
         post "/bo/registrations/#{registration.reg_identifier}/convictions/reject", conviction_rejection_form: params
+
         expect(response).to redirect_to(convictions_path)
-      end
 
-      it "updates the revoked_reason" do
-        post "/bo/registrations/#{registration.reg_identifier}/convictions/reject", conviction_rejection_form: params
         expect(registration.reload.metaData.revoked_reason).to eq(params[:revoked_reason])
-      end
-
-      it "updates the conviction_sign_off's confirmed_at" do
-        post "/bo/registrations/#{registration.reg_identifier}/convictions/reject", conviction_rejection_form: params
-        expect(registration.reload.conviction_sign_offs.first.confirmed_at).to be_a(DateTime)
-      end
-
-      it "updates the conviction_sign_off's confirmed_by" do
-        post "/bo/registrations/#{registration.reg_identifier}/convictions/reject", conviction_rejection_form: params
-        expect(registration.reload.conviction_sign_offs.first.confirmed_by).to eq(user.email)
-      end
-
-      it "updates the conviction_sign_off's workflow_state" do
-        post "/bo/registrations/#{registration.reg_identifier}/convictions/reject", conviction_rejection_form: params
-        expect(registration.reload.conviction_sign_offs.first.workflow_state).to eq("rejected")
-      end
-
-      it "refuses the registration" do
-        post "/bo/registrations/#{registration.reg_identifier}/convictions/reject", conviction_rejection_form: params
         expect(registration.reload.metaData.status).to eq("REFUSED")
+
+        expect(registration.reload.conviction_sign_offs.first.confirmed_at).to be_a(DateTime)
+        expect(registration.reload.conviction_sign_offs.first.confirmed_by).to eq(user.email)
+        expect(registration.reload.conviction_sign_offs.first.workflow_state).to eq("rejected")
       end
 
       context "when the params are invalid" do
@@ -91,13 +67,10 @@ RSpec.describe "RegistrationConvictionRejectionForms", type: :request do
           }
         end
 
-        it "renders the new template" do
+        it "renders the new template, and does not update the revoked_reason" do
           post "/bo/registrations/#{registration.reg_identifier}/convictions/reject", conviction_rejection_form: params
-          expect(response).to render_template(:new)
-        end
 
-        it "does not update the revoked_reason" do
-          post "/bo/registrations/#{registration.reg_identifier}/convictions/reject", conviction_rejection_form: params
+          expect(response).to render_template(:new)
           expect(registration.reload.metaData.revoked_reason).to_not eq(params[:revoked_reason])
         end
       end
@@ -115,13 +88,10 @@ RSpec.describe "RegistrationConvictionRejectionForms", type: :request do
         }
       end
 
-      it "redirects to the permissions error page" do
+      it "redirects to the permissions error page, and does not update the revoked_reason" do
         post "/bo/registrations/#{registration.reg_identifier}/convictions/reject", conviction_rejection_form: params
-        expect(response).to redirect_to("/bo/pages/permission")
-      end
 
-      it "does not update the revoked_reason" do
-        post "/bo/registrations/#{registration.reg_identifier}/convictions/reject", conviction_rejection_form: params
+        expect(response).to redirect_to("/bo/pages/permission")
         expect(registration.reload.metaData.revoked_reason).to_not eq(params[:revoked_reason])
       end
     end

--- a/spec/support/shared_examples/abilities/agency_examples.rb
+++ b/spec/support/shared_examples/abilities/agency_examples.rb
@@ -24,10 +24,6 @@ RSpec.shared_examples "agency examples" do
     should be_able_to(:edit, WasteCarriersEngine::Registration)
   end
 
-  it "should be able to review convictions" do
-    should be_able_to(:review_convictions, WasteCarriersEngine::RenewingRegistration)
-  end
-
   it "should not be able to write off large" do
     should_not be_able_to(:write_off_large, WasteCarriersEngine::FinanceDetails)
   end

--- a/spec/support/shared_examples/abilities/below_agency_with_refund_examples.rb
+++ b/spec/support/shared_examples/abilities/below_agency_with_refund_examples.rb
@@ -70,4 +70,8 @@ RSpec.shared_examples "below agency_with_refund examples" do
   it "should not be able to write off small" do
     should_not be_able_to(:write_off_small, WasteCarriersEngine::FinanceDetails)
   end
+
+  it "should not be able to review convictions" do
+    should_not be_able_to(:review_convictions, WasteCarriersEngine::RenewingRegistration)
+  end
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-945

It has been spotted in recent testing that the permissions around convictions do not match with expectations. In the old service agency & agency with refund users could approve conviction checks. After working with NCCC it has been agreed that this should be restricted to just agency with refund, and agency super users.

However, currently it seems all users can see the details, and all agency users (so not finance) can approve conviction checks.

This change is about ensuring the system behaves as expected.