### PR TITLE
Use sequence to generate reg_identifier

### DIFF
--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -2,7 +2,9 @@
 
 FactoryBot.define do
   factory :registration, class: WasteCarriersEngine::Registration do
-    reg_identifier { "CBDU#{rand(10_000)}" }
+    sequence :reg_identifier do |n|
+      "CBDU#{n}"
+    end
     account_email { "whatever@example.com" }
     business_type { "limitedCompany" }
     company_name { "WasteCo" }


### PR DESCRIPTION
This fixes random failure due to the `rand` command. 