### PR TITLE
Complete a registration if possible at write off

### DIFF
--- a/app/controllers/write_off_forms_controller.rb
+++ b/app/controllers/write_off_forms_controller.rb
@@ -5,6 +5,7 @@ class WriteOffFormsController < ApplicationController
   include CanFetchResource
   include FinanceDetailsHelper
   include CanRenewIfPossible
+  include CanCompleteIfPossible
 
   prepend_before_action :authenticate_user!
 
@@ -26,6 +27,8 @@ class WriteOffFormsController < ApplicationController
       if renew_if_possible
         redirect_to resource_finance_details_path(@resource.registration._id)
       else
+        complete_if_possible
+
         redirect_to resource_finance_details_path(@resource._id)
       end
     else

--- a/app/controllers/write_off_forms_controller.rb
+++ b/app/controllers/write_off_forms_controller.rb
@@ -1,39 +1,25 @@
 # frozen_string_literal: true
 
-# TODO: Refactor to inherit from ResourceFormController
-class WriteOffFormsController < ApplicationController
-  include CanFetchResource
+class WriteOffFormsController < ResourceFormsController
   include FinanceDetailsHelper
-  include CanRenewIfPossible
-  include CanCompleteIfPossible
 
-  prepend_before_action :authenticate_user!
+  before_renew_or_complete :process_write_off
 
-  before_action :authorise_user!
-  before_action :fetch_finance_details
-  before_action :fetch_write_off_form
-
-  def new; end
+  def new
+    super(WriteOffForm, "write_off_form")
+  end
 
   def create
+    fetch_resource
+
     amount_to_write_off = @resource.finance_details.zero_difference_balance
 
-    if @write_off_form.submit(write_off_form_params, current_user)
-      flash[:success] = I18n.t(
+    return unless super(WriteOffForm, "write_off_form")
+
+    flash[:success] = I18n.t(
         "write_off_forms.flash_messages.successful",
         amount: display_pence_as_pounds_and_cents(amount_to_write_off)
       )
-
-      if renew_if_possible
-        redirect_to resource_finance_details_path(@resource.registration._id)
-      else
-        complete_if_possible
-
-        redirect_to resource_finance_details_path(@resource._id)
-      end
-    else
-      render :new
-    end
   end
 
   private
@@ -42,15 +28,15 @@ class WriteOffFormsController < ApplicationController
     params.fetch(:write_off_form, {}).permit(:comment)
   end
 
-  def fetch_finance_details
-    @finance_details = @resource.finance_details
+  def process_write_off
+    ProcessWriteOffService.run(
+      finance_details: @resource.finance_details,
+      user: current_user,
+      comment: @write_off_form.comment
+    )
   end
 
-  def fetch_write_off_form
-    @write_off_form = WriteOffForm.new(@resource)
-  end
-
-  def authorise_user!
+  def authorize_user
     return if can?(:write_off_small, @resource.finance_details)
     return if can?(:write_off_large, @resource.finance_details)
 

--- a/app/controllers/write_off_forms_controller.rb
+++ b/app/controllers/write_off_forms_controller.rb
@@ -17,9 +17,9 @@ class WriteOffFormsController < ResourceFormsController
     return unless super(WriteOffForm, "write_off_form")
 
     flash[:success] = I18n.t(
-        "write_off_forms.flash_messages.successful",
-        amount: display_pence_as_pounds_and_cents(amount_to_write_off)
-      )
+      "write_off_forms.flash_messages.successful",
+      amount: display_pence_as_pounds_and_cents(amount_to_write_off)
+    )
   end
 
   private

--- a/app/forms/write_off_form.rb
+++ b/app/forms/write_off_form.rb
@@ -5,18 +5,10 @@ class WriteOffForm < WasteCarriersEngine::BaseForm
 
   validates :comment, presence: true, length: { maximum: 500 }
 
-  def submit(params, user)
+  def submit(params)
     # Assign the params for validation
     self.comment = params[:comment]
 
-    return false unless valid?
-
-    ProcessWriteOffService.run(
-      finance_details: transient_registration.finance_details,
-      user: user,
-      comment: comment
-    )
-
-    true
+    valid?
   end
 end

--- a/app/views/write_off_forms/new.html.erb
+++ b/app/views/write_off_forms/new.html.erb
@@ -17,7 +17,7 @@
     </div>
 
     <h2 class="heading-medium strong">
-      <%= t(".write_off", amount: display_pence_as_pounds_and_cents(@finance_details.zero_difference_balance)) %>
+      <%= t(".write_off", amount: display_pence_as_pounds_and_cents(@resource.finance_details.zero_difference_balance)) %>
     </h2>
 
     <%= form_for(@write_off_form, url: resource_write_off_form_path(@resource._id)) do |f| %>

--- a/spec/forms/write_off_form_spec.rb
+++ b/spec/forms/write_off_form_spec.rb
@@ -15,16 +15,10 @@ RSpec.describe WriteOffForm do
     context "when the object is valid" do
       let(:valid) { true }
 
-      it "runs the write off service" do
+      it "returns true" do
         comment = double(:comment)
 
-        expect(ProcessWriteOffService).to receive(:run).with(
-          finance_details: renewing_registration.finance_details,
-          user: user,
-          comment: comment
-        )
-
-        expect(subject.submit({ comment: comment }, user)).to eq(true)
+        expect(subject.submit({ comment: comment })).to eq(true)
       end
     end
 
@@ -32,7 +26,7 @@ RSpec.describe WriteOffForm do
       let(:valid) { false }
 
       it "returns false" do
-        expect(subject.submit({}, user)).to eq(false)
+        expect(subject.submit({})).to eq(false)
       end
     end
   end

--- a/spec/forms/write_off_form_spec.rb
+++ b/spec/forms/write_off_form_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe WriteOffForm do
       it "returns true" do
         comment = double(:comment)
 
-        expect(subject.submit({ comment: comment })).to eq(true)
+        expect(subject.submit(comment: comment)).to eq(true)
       end
     end
 

--- a/spec/requests/write_off_forms_spec.rb
+++ b/spec/requests/write_off_forms_spec.rb
@@ -82,6 +82,19 @@ RSpec.describe "WriteOffForms", type: :request do
           }
         end
 
+        context "when the resource is a registration" do
+          let(:registration) { create(:registration, :has_unpaid_order, :pending) }
+
+          it "activates the registration" do
+            post resource_write_off_form_path(registration._id), params
+
+            registration.reload
+
+            expect(registration.finance_details.balance).to eq(0)
+            expect(registration).to be_active
+          end
+        end
+
         it "generates a new payment, renews the registration, updates the registration balance, returns a 302 status and redirects to the finance details page" do
           registration = renewing_registration.registration
           before_request_payments_count = registration.finance_details.payments.count


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-954

This fixes a bug for which we fail to complete a registration when a balance is written off from finance users.