### PR TITLE
Align data in the table correctly

### DIFF
--- a/app/views/convictions/index.html.erb
+++ b/app/views/convictions/index.html.erb
@@ -54,13 +54,13 @@
       <p>
         <%= t(".unmatched_people.paragraph") %>
       </p>
-      <% @resource.relevant_people_without_matches.each do |person| %>
-        <table>
-          <tbody>
+      <table>
+        <tbody>
+          <% @resource.relevant_people_without_matches.each do |person| %>
             <%= render("shared/person_table_rows", person: person) %>
-          </tbody>
-        </table>
-      <% end %>
+          <% end %>
+        </tbody>
+      </table>
     <% end %>
 
     <% if @resource.approved_or_revoked? %>


### PR DESCRIPTION
We spotted today that when multiple people without convictions appear for a registration, their data is not aligned correctly. This fixes the issue by making sure the people data are kept on the same table rather than on separate tables