### PR TITLE
Capitalise order item descriptions properly

### DIFF
--- a/app/views/shared/registrations/_charges_and_amendments.html.erb
+++ b/app/views/shared/registrations/_charges_and_amendments.html.erb
@@ -26,7 +26,7 @@
                 <%= order.date_created.to_formatted_s(:day_month_year_time_slashes) %>
               </td>
               <td>
-                <%= order_item.description %>
+                <%= order_item.description.capitalize %>
               </td>
               <td class="numeric">
                 <%= display_pence_as_pounds_and_cents(order_item.amount) %>

--- a/app/views/shared/registrations/_finance_details.html.erb
+++ b/app/views/shared/registrations/_finance_details.html.erb
@@ -28,7 +28,7 @@
       <% resource.latest_order.order_items.each do |item| %>
         <tr>
           <th>
-            <%= item.description %>
+            <%= item.description.capitalize %>
           </th>
           <td>
             £<%= display_pence_as_pounds(item.amount) %>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-833

Since our order item descriptions are now all lowercase by default for easier joining, they are also displayed in all lowercase on the finance details views.

This just capitalises the first letter so they look nicer - `Changing carrier type` instead of `changing carrier type`.