### PR TITLE
Fix typo on conviction rejection page

### DIFF
--- a/config/locales/conviction_rejection_forms.en.yml
+++ b/config/locales/conviction_rejection_forms.en.yml
@@ -4,7 +4,7 @@ en:
       title: "Reject a renewal with possible convictions"
       heading: "Reject a renewal with possible convictions: %{reg_identifier}"
       revoked_reason:
-        label: "Reason for approval"
+        label: "Reason for rejection"
         hint: "Maximum 500 characters"
       rejection_message: "Once rejected, this renewal cannot be completed."
       reject_button: "Reject this renewal"


### PR DESCRIPTION
Spotted during review of another ticket. This says 'approval' but should be 'rejection'.