### PR TITLE
Add api endpoint for acceptance tests

### DIFF
--- a/app/controllers/api/registrations_controller.rb
+++ b/app/controllers/api/registrations_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Api
+  class RegistrationsController < ApplicationController
+    before_action :authenticate_user!
+
+    def show
+      registration = WasteCarriersEngine::Registration.find_by(reg_identifier: params[:id])
+
+      render json: { _id: registration.id.to_s }
+    end
+  end
+end

--- a/app/controllers/api/renewals_controller.rb
+++ b/app/controllers/api/renewals_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Api
+  class RenewalsController < ApplicationController
+    before_action :authenticate_user!
+
+    def show
+      renewal = WasteCarriersEngine::RenewingRegistration.find_by(reg_identifier: params[:id])
+
+      render json: { _id: renewal.id.to_s, token: renewal.token }
+    end
+  end
+end

--- a/config/feature_toggles.yml
+++ b/config/feature_toggles.yml
@@ -3,3 +3,5 @@ edit_registration:
   active: <%= ENV["FEATURE_TOGGLE_EDIT_REGISTRATION"] %>
 new_registration:
   active: <%= ENV["FEATURE_TOGGLE_NEW_REGISTRATION"] %>
+api:
+  active: <%= ENV["FEATURE_TOGGLE_API"] %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,12 @@ Rails.application.routes.draw do
 
   root to: "application#redirect_root_to_dashboard"
 
+  scope "/bo" do
+    namespace :api, defaults: { format: :json } do
+      resources :registrations, :renewals, only: :show
+    end
+  end
+
   devise_for :users,
              controllers: { invitations: "user_invitations", sessions: "sessions" },
              path: "/bo/users",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,11 @@ Rails.application.routes.draw do
   root to: "application#redirect_root_to_dashboard"
 
   scope "/bo" do
-    namespace :api, defaults: { format: :json } do
+    namespace(
+      :api,
+      defaults: { format: :json },
+      constraints: ->(_request) { WasteCarriersEngine::FeatureToggle.active?(:api) }
+    ) do
       resources :registrations, :renewals, only: :show
     end
   end

--- a/spec/requests/api/registrations_spec.rb
+++ b/spec/requests/api/registrations_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Assisted Digital Forms", type: :request do
+  let(:registration) { create(:registration) }
+
+  describe "GET /bo/api/registrations/:reg_identifier" do
+    context "when a user is signed in" do
+      let(:user) { create(:user, :finance) }
+
+      before(:each) do
+        sign_in(user)
+      end
+
+      it "returns a json containing registration info" do
+        get "/bo/api/registrations/#{registration.reg_identifier}"
+
+        expect(JSON.parse(response.body)).to eq({ "_id" => registration.id.to_s })
+      end
+    end
+
+    context "when no user is signed in" do
+      it "returns a json containing an error" do
+        get "/bo/api/registrations/#{registration.reg_identifier}"
+
+        expect(JSON.parse(response.body)).to eq({ "error" => "You need to sign in before continuing." })
+      end
+    end
+  end
+end

--- a/spec/requests/api/registrations_spec.rb
+++ b/spec/requests/api/registrations_spec.rb
@@ -5,6 +5,10 @@ require "rails_helper"
 RSpec.describe "Registrations API", type: :request do
   let(:registration) { create(:registration) }
 
+  before do
+    allow(WasteCarriersEngine::FeatureToggle).to receive(:active?).with(:api).and_return(true)
+  end
+
   describe "GET /bo/api/registrations/:reg_identifier" do
     context "when a user is signed in" do
       let(:user) { create(:user, :finance) }

--- a/spec/requests/api/registrations_spec.rb
+++ b/spec/requests/api/registrations_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Assisted Digital Forms", type: :request do
+RSpec.describe "Registrations API", type: :request do
   let(:registration) { create(:registration) }
 
   describe "GET /bo/api/registrations/:reg_identifier" do

--- a/spec/requests/api/registrations_spec.rb
+++ b/spec/requests/api/registrations_spec.rb
@@ -16,7 +16,9 @@ RSpec.describe "Assisted Digital Forms", type: :request do
       it "returns a json containing registration info" do
         get "/bo/api/registrations/#{registration.reg_identifier}"
 
-        expect(JSON.parse(response.body)).to eq({ "_id" => registration.id.to_s })
+        expected_json = { "_id" => registration.id.to_s }.to_json
+
+        expect(response.body).to eq(expected_json)
       end
     end
 
@@ -24,7 +26,9 @@ RSpec.describe "Assisted Digital Forms", type: :request do
       it "returns a json containing an error" do
         get "/bo/api/registrations/#{registration.reg_identifier}"
 
-        expect(JSON.parse(response.body)).to eq({ "error" => "You need to sign in before continuing." })
+        expected_json = { "error" => "You need to sign in before continuing." }.to_json
+
+        expect(response.body).to eq(expected_json)
       end
     end
   end

--- a/spec/requests/api/renewals_spec.rb
+++ b/spec/requests/api/renewals_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Assisted Digital Forms", type: :request do
+RSpec.describe "Renewals API", type: :request do
   let(:renewal) { create(:renewing_registration) }
 
   describe "GET /bo/api/renewals/:reg_identifier" do

--- a/spec/requests/api/renewals_spec.rb
+++ b/spec/requests/api/renewals_spec.rb
@@ -16,7 +16,9 @@ RSpec.describe "Assisted Digital Forms", type: :request do
       it "returns a json containing registration info" do
         get "/bo/api/renewals/#{renewal.reg_identifier}"
 
-        expect(JSON.parse(response.body)).to eq({ "_id" => renewal.id.to_s, "token" => renewal.token })
+        expected_json = { "_id" => renewal.id.to_s, "token" => renewal.token }.to_json
+
+        expect(response.body).to eq(expected_json)
       end
     end
 
@@ -24,7 +26,9 @@ RSpec.describe "Assisted Digital Forms", type: :request do
       it "returns a json containing an error" do
         get "/bo/api/renewals/#{renewal.reg_identifier}"
 
-        expect(JSON.parse(response.body)).to eq({ "error" => "You need to sign in before continuing." })
+        expected_json = { "error" => "You need to sign in before continuing." }.to_json
+
+        expect(response.body).to eq(expected_json)
       end
     end
   end

--- a/spec/requests/api/renewals_spec.rb
+++ b/spec/requests/api/renewals_spec.rb
@@ -5,6 +5,10 @@ require "rails_helper"
 RSpec.describe "Renewals API", type: :request do
   let(:renewal) { create(:renewing_registration) }
 
+  before do
+    allow(WasteCarriersEngine::FeatureToggle).to receive(:active?).with(:api).and_return(true)
+  end
+
   describe "GET /bo/api/renewals/:reg_identifier" do
     context "when a user is signed in" do
       let(:user) { create(:user, :finance) }

--- a/spec/requests/api/renewals_spec.rb
+++ b/spec/requests/api/renewals_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Assisted Digital Forms", type: :request do
+  let(:renewal) { create(:renewing_registration) }
+
+  describe "GET /bo/api/renewals/:reg_identifier" do
+    context "when a user is signed in" do
+      let(:user) { create(:user, :finance) }
+
+      before(:each) do
+        sign_in(user)
+      end
+
+      it "returns a json containing registration info" do
+        get "/bo/api/renewals/#{renewal.reg_identifier}"
+
+        expect(JSON.parse(response.body)).to eq({ "_id" => renewal.id.to_s, "token" => renewal.token })
+      end
+    end
+
+    context "when no user is signed in" do
+      it "returns a json containing an error" do
+        get "/bo/api/renewals/#{renewal.reg_identifier}"
+
+        expect(JSON.parse(response.body)).to eq({ "error" => "You need to sign in before continuing." })
+      end
+    end
+  end
+end


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-977

Add API endpoint to fetch id and token of registrations and renewals. Those will be used by the acceptance tests suite in order to visit pages directly.