### PR TITLE
Enable Edit registration feature

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -37,7 +37,7 @@ class Ability
     can :renew, :all
     can :view_certificate, WasteCarriersEngine::Registration
     can :order_copy_cards, WasteCarriersEngine::Registration
-    can :edit, WasteCarriersEngine::Registration if WasteCarriersEngine::FeatureToggle.active?(:edit_registration)
+    can :edit, WasteCarriersEngine::Registration
 
     can :revert_to_payment_summary, :all
 

--- a/config/feature_toggles.yml
+++ b/config/feature_toggles.yml
@@ -1,6 +1,4 @@
 ---
-edit_registration:
-  active: <%= ENV["FEATURE_TOGGLE_EDIT_REGISTRATION"] %>
 new_registration:
   active: <%= ENV["FEATURE_TOGGLE_NEW_REGISTRATION"] %>
 api:

--- a/spec/support/shared_examples/abilities/agency_examples.rb
+++ b/spec/support/shared_examples/abilities/agency_examples.rb
@@ -18,9 +18,6 @@ RSpec.shared_examples "agency examples" do
   end
 
   it "should be able to edit a registration" do
-    # TODO: Remove once edit is no longer behind a feature toggle
-    allow(WasteCarriersEngine::FeatureToggle).to receive(:active?).with(:edit_registration).and_return(true)
-
     should be_able_to(:edit, WasteCarriersEngine::Registration)
   end
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-980

Currently the functionality for editing a registration is hidden behind a feature flag. As we're now ready to make this available to users there is no need to hide it behind the flag anymore.

This change enables Edit registration by removing the feature flag checks.