### PR TITLE
Add expired registrations in grace window to EPR

### DIFF
--- a/app/models/reports/epr_serializer.rb
+++ b/app/models/reports/epr_serializer.rb
@@ -27,7 +27,10 @@ module Reports
     private
 
     def scope
-      ::WasteCarriersEngine::Registration.active
+      # TODO: rollback code to use this after COVID emergency release
+      # ::WasteCarriersEngine::Registration.active
+
+      ::WasteCarriersEngine::Registration.active_and_expired.in_grace_window
     end
 
     def parse_object(registration)

--- a/app/models/reports/epr_serializer.rb
+++ b/app/models/reports/epr_serializer.rb
@@ -27,9 +27,6 @@ module Reports
     private
 
     def scope
-      # TODO: rollback code to use this after COVID emergency release
-      # ::WasteCarriersEngine::Registration.active
-
       ::WasteCarriersEngine::Registration.active_and_expired.in_grace_window
     end
 

--- a/app/presenters/reports/registration_epr_presenter.rb
+++ b/app/presenters/reports/registration_epr_presenter.rb
@@ -18,8 +18,11 @@ module Reports
 
     def expires_on
       return if lower_tier?
+      return unless super.present?
 
-      super&.to_formatted_s(:year_month_day_hyphens)
+      return (super + Rails.configuration.grace_window.days).to_formatted_s(:year_month_day_hyphens) if expired?
+
+      super.to_formatted_s(:year_month_day_hyphens)
     end
 
     def company_no

--- a/spec/factories/meta_data.rb
+++ b/spec/factories/meta_data.rb
@@ -11,6 +11,10 @@ FactoryBot.define do
       status { :ACTIVE }
     end
 
+    trait :expired do
+      status { :EXPIRED }
+    end
+
     trait :pending do
       date_activated { nil }
       status { :PENDING }

--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -39,6 +39,10 @@ FactoryBot.define do
       metaData { build(:metaData, :active) }
     end
 
+    trait :expired do
+      metaData { build(:metaData, :expired) }
+    end
+
     trait :has_orders_and_payments do
       finance_details { build(:finance_details, :has_paid_order_and_payment) }
     end

--- a/spec/models/reports/epr_serializer_spec.rb
+++ b/spec/models/reports/epr_serializer_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Reports
+  RSpec.describe EprSerializer do
+    describe "#to_csv" do
+      it "returns a csv version of the given data based on attributes" do
+        allow(Rails.configuration).to receive(:grace_window).and_return(3)
+
+        active = create(:registration, :active, expires_on: 3.days.from_now)
+        expired = create(:registration, :expired, expires_on: 2.days.ago)
+
+        result = subject.to_csv
+
+        expect(result).to include("\"Registration number\",\"Organisation name\",\"UPRN\",\"Building\",\"Address line 1\",\"Address line 2\",\"Address line 3\",\"Address line 4\",\"Town\",\"Postcode\",\"Country\",\"Easting\",\"Northing\",\"Applicant type\",\"Registration tier\",\"Registration type\",\"Registration date\",\"Expiry date\",\"Company number\"")
+        expect(result).to include(active.reg_identifier)
+        expect(result).to include(expired.reg_identifier)
+      end
+    end
+  end
+end

--- a/spec/presenters/reports/registration_epr_presenter_spec.rb
+++ b/spec/presenters/reports/registration_epr_presenter_spec.rb
@@ -52,11 +52,28 @@ module Reports
 
       context "when the registration is not a lower tier" do
         let(:lower_tier) { false }
+        let(:expired) { false }
+
+        before do
+          expect(registration).to receive(:expired?).and_return(expired)
+        end
 
         it "returns the object expires_on formatted" do
-          expect(registration).to receive(:expires_on).and_return(Time.new(2015, 1, 1))
+          allow(registration).to receive(:expires_on).and_return(Time.new(2015, 1, 1))
 
           expect(subject.expires_on).to eq("2015-01-01")
+        end
+
+        context "when the registration is expired" do
+          let(:expired) { true }
+
+          it "returns the object expires_on formatted plus grace window days" do
+            allow(Rails.configuration).to receive(:grace_window).and_return(3)
+
+            allow(registration).to receive(:expires_on).and_return(Time.new(2015, 1, 1))
+
+            expect(subject.expires_on).to eq("2015-01-04")
+          end
         end
       end
     end


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-982 and https://eaflood.atlassian.net/browse/RUBY-983

This changes the scope for fetching registration for the EPR export to include EXPIRED registrations in the grace window.
It also changes the exported data, so that the expire date is inflated with the grace window value for all expired registrations exported.