### PR TITLE
Add base service to fetch expiring registrations

### DIFF
--- a/app/services/renewal_reminder_service_base.rb
+++ b/app/services/renewal_reminder_service_base.rb
@@ -25,7 +25,7 @@ class RenewalReminderServiceBase < ::WasteCarriersEngine::BaseService
         :$lte => expires_in_days.days.from_now.end_of_day,
         :$gte => expires_in_days.days.from_now.beginning_of_day
       })
-      .not_in(contact_email: ["nccc-carrierbroker@environment-agency.gov.uk", nil])
+      .not_in(contact_email: ["nccc-carrierbroker@environment-agency.gov.uk", nil, ""])
   end
 
   def expires_in_days

--- a/app/services/renewal_reminder_service_base.rb
+++ b/app/services/renewal_reminder_service_base.rb
@@ -21,10 +21,13 @@ class RenewalReminderServiceBase < ::WasteCarriersEngine::BaseService
   def expiring_registrations
     WasteCarriersEngine::Registration
       .active
-      .where(expires_on: {
-        :$lte => expires_in_days.days.from_now.end_of_day,
-        :$gte => expires_in_days.days.from_now.beginning_of_day
-      })
+      .where(
+        expires_on:
+        {
+          :$lte => expires_in_days.days.from_now.end_of_day,
+          :$gte => expires_in_days.days.from_now.beginning_of_day
+        }
+      )
       .not_in(contact_email: ["nccc-carrierbroker@environment-agency.gov.uk", nil, ""])
   end
 

--- a/app/services/renewal_reminder_service_base.rb
+++ b/app/services/renewal_reminder_service_base.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class RenewalReminderServiceBase < ::WasteCarriersEngine::BaseService
+  def run
+    expiring_registrations.each do |registration|
+      begin
+        send_email(registration)
+      rescue StandardError => e
+        Airbrake.notify e, registration: registration.reg_identifier
+        Rails.logger.error "Failed to send first renewal email for registration #{registration.reg_identifier}"
+      end
+    end
+  end
+
+  private
+
+  def send_email
+    raise(NotImplementedError)
+  end
+
+  def expiring_registrations
+    WasteCarriersEngine::Registration
+      .active
+      .where(expires_on: {
+        :$lte => expires_in_days.days.from_now.end_of_day,
+        :$gte => expires_in_days.days.from_now.beginning_of_day
+      })
+      .not_in(contact_email: ["nccc-carrierbroker@environment-agency.gov.uk", nil])
+  end
+
+  def expires_in_days
+    raise(NotImplementedError)
+  end
+end

--- a/spec/services/renewal_reminder_service_base_spec.rb
+++ b/spec/services/renewal_reminder_service_base_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe RenewalReminderServiceBase do
   describe ".run" do
     it "send emails to relevant registrations" do
       expiring = create(:registration, expires_on: 3.days.from_now)
-      not_exiring = create(:registration, expires_on: 5.days.from_now)
+      not_expiring = create(:registration, expires_on: 5.days.from_now)
       expiring_too_soon = create(:registration, expires_on: 2.days.from_now)
       ad_contact_email = create(
         :registration,
@@ -26,7 +26,7 @@ RSpec.describe RenewalReminderServiceBase do
 
       expect_any_instance_of(TestRegistrationTransferService).to receive(:send_email).with(expiring)
 
-      expect_any_instance_of(TestRegistrationTransferService).to_not receive(:send_email).with(not_exiring)
+      expect_any_instance_of(TestRegistrationTransferService).to_not receive(:send_email).with(not_expiring)
       expect_any_instance_of(TestRegistrationTransferService).to_not receive(:send_email).with(expiring_too_soon)
       expect_any_instance_of(TestRegistrationTransferService).to_not receive(:send_email).with(ad_contact_email)
       expect_any_instance_of(TestRegistrationTransferService).to_not receive(:send_email).with(empty_contact_email)

--- a/spec/services/renewal_reminder_service_base_spec.rb
+++ b/spec/services/renewal_reminder_service_base_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RenewalReminderServiceBase do
+  class TestRegistrationTransferService < RenewalReminderServiceBase
+    def expires_in_days
+      3
+    end
+
+    def send_email(_arg); end
+  end
+
+  describe ".run" do
+    it "send emails to relevant registrations" do
+      expiring = create(:registration, expires_on: 3.days.from_now)
+      not_exiring = create(:registration, expires_on: 5.days.from_now)
+      expiring_too_soon = create(:registration, expires_on: 2.days.from_now)
+      ad_contact_email = create(
+        :registration,
+        expires_on: 3.days.from_now,
+        contact_email: "nccc-carrierbroker@environment-agency.gov.uk"
+      )
+      empty_contact_email = create(:registration, expires_on: 3.days.from_now, contact_email: nil)
+
+      expect_any_instance_of(TestRegistrationTransferService).to receive(:send_email).with(expiring)
+
+      expect_any_instance_of(TestRegistrationTransferService).to_not receive(:send_email).with(not_exiring)
+      expect_any_instance_of(TestRegistrationTransferService).to_not receive(:send_email).with(expiring_too_soon)
+      expect_any_instance_of(TestRegistrationTransferService).to_not receive(:send_email).with(ad_contact_email)
+      expect_any_instance_of(TestRegistrationTransferService).to_not receive(:send_email).with(empty_contact_email)
+
+      TestRegistrationTransferService.run
+    end
+  end
+end

--- a/spec/services/renewal_reminder_service_base_spec.rb
+++ b/spec/services/renewal_reminder_service_base_spec.rb
@@ -21,7 +21,8 @@ RSpec.describe RenewalReminderServiceBase do
         expires_on: 3.days.from_now,
         contact_email: "nccc-carrierbroker@environment-agency.gov.uk"
       )
-      empty_contact_email = create(:registration, expires_on: 3.days.from_now, contact_email: nil)
+      empty_contact_email = create(:registration, expires_on: 3.days.from_now, contact_email: "")
+      nil_contact_email = create(:registration, expires_on: 3.days.from_now, contact_email: nil)
 
       expect_any_instance_of(TestRegistrationTransferService).to receive(:send_email).with(expiring)
 
@@ -29,6 +30,7 @@ RSpec.describe RenewalReminderServiceBase do
       expect_any_instance_of(TestRegistrationTransferService).to_not receive(:send_email).with(expiring_too_soon)
       expect_any_instance_of(TestRegistrationTransferService).to_not receive(:send_email).with(ad_contact_email)
       expect_any_instance_of(TestRegistrationTransferService).to_not receive(:send_email).with(empty_contact_email)
+      expect_any_instance_of(TestRegistrationTransferService).to_not receive(:send_email).with(nil_contact_email)
 
       TestRegistrationTransferService.run
     end

--- a/spec/services/renewal_reminder_service_base_spec.rb
+++ b/spec/services/renewal_reminder_service_base_spec.rb
@@ -34,5 +34,18 @@ RSpec.describe RenewalReminderServiceBase do
 
       TestRegistrationTransferService.run
     end
+
+    context "when an error occurs" do
+      it "logs it in rails and send it to Airbrake" do
+        create(:registration, expires_on: 3.days.from_now)
+
+        expect_any_instance_of(TestRegistrationTransferService).to receive(:send_email).and_raise("error")
+
+        expect(Airbrake).to receive(:notify)
+        expect(Rails.logger).to receive(:error)
+
+        TestRegistrationTransferService.run
+      end
+    end
   end
 end


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-470

This adds the RenewalReminderServiceBase as per WEX, which will be used by email reminders to send emails to the correct addresses.