### PR TITLE
Add  code to send first renewal reminder letter via rake task

### DIFF
--- a/app/mailers/renewal_reminder_mailer.rb
+++ b/app/mailers/renewal_reminder_mailer.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class RenewalReminderMailer < ActionMailer::Base
+  helper "waste_carriers_engine/mailer"
+
+  def first_reminder_email(registration)
+    @registration = registration
+
+    mail(
+      to: collect_addresses(registration),
+      from: "#{Rails.configuration.email_service_name} <#{Rails.configuration.email_service_email}>",
+      subject: I18n.t(".renewal_reminder_mailer.first_reminder_email.subject", date: @expiry_date)
+    )
+  end
+
+  private
+
+  def collect_addresses(registration)
+    [registration.contact_email, registration.account_email].compact.uniq
+  end
+end

--- a/app/services/first_renewal_reminder_service.rb
+++ b/app/services/first_renewal_reminder_service.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class FirstRenewalReminderService < RenewalReminderServiceBase
+  private
+
+  def send_email(registration)
+    RenewalReminderMailer.first_reminder_email(registration).deliver_now
+  end
+
+  def expires_in_days
+    WasteCarriersEngine.configuration.first_renewal_email_reminder_days.to_i
+  end
+end

--- a/app/views/renewal_reminder_mailer/first_reminder_email.html.erb
+++ b/app/views/renewal_reminder_mailer/first_reminder_email.html.erb
@@ -1,0 +1,118 @@
+<!doctype html>
+<!--[if lt IE 7]>  <html class="ie ie6 lte9 lte8 lte7"> <![endif]-->
+<!--[if IE 7]>     <html class="ie ie7 lte9 lte8 lte7"> <![endif]-->
+<!--[if IE 8]>     <html class="ie ie8 lte9 lte8"> <![endif]-->
+<!--[if IE 9]>     <html class="ie ie9 lte9"> <![endif]-->
+<!--[if gt IE 9]>  <html> <![endif]-->
+<!--[if !IE]><!--> <html> <!--<![endif]-->
+<head>
+    <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
+  <meta content="utf-8" http-equiv="encoding">
+    <!-- Use title if it's in the page YAML frontmatter -->
+    <title>Waste Carriers Service</title>
+</head>
+
+<body style="font-family: Helvetica, Arial, sans-serif; font-size: 16px; margin: 0; color: #0b0c0c">
+<table width="100%" cellpadding="0" cellspacing="0" border="0">
+  <tr>
+    <td width="100%" height="53px" bgcolor="#0b0c0c">
+      <table width="580" cellpadding="0" cellspacing="0" border="0" align="center">
+        <tr>
+          <td width="100%" bgcolor="#0b0c0c" valign="middle">
+            <%= email_image_tag("govuk_logotype_email.png", { alt: "GOV.UK", border: "0"}) %>
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+</table>
+
+<table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#FFFFFF">
+  <tr>
+    <td width="100%">
+      <table width="580" cellpadding="0" cellspacing="0" border="0" align="center">
+        <tr>
+          <td width="100%" class="header" style="padding-top: 10px;" colspan="2">
+            <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#FFFFFF">
+              <tr>
+              </tr>
+            </table>
+          </td>
+        </tr>
+        <tr>
+          <td width="75%" style="font-family: Helvetica, Arial, sans-serif;">
+            <p style="font-weight: 400; font-size: 16px; line-height: 1; margin: 10px 0 10px 0;">&nbsp;</p>
+          </td>
+          <td width="25%">&nbsp;</td>
+        </tr>
+        <tr>
+          <td width="75%" style="font-family: Helvetica, Arial, sans-serif;">
+            <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 15px 0;">
+              <%= t(".dear", name: @registration.first_name) %>
+            </p>
+
+            <h1>
+              <%= t(".header", date: @registration.expires_on.to_formatted_s(:day_month_year)) %>
+            </h1>
+
+            <p style="font-size: 19px; line-height: 1.315789474; margin: 15px 0 15px 0;">
+              <%= t(".paragraph_1") %>
+            </p>
+
+            <h2>
+              <%= t(".subheading_1") %>
+            </h2>
+
+            <p style="font-size: 19px; line-height: 1.315789474; margin: 15px 0 15px 0;">
+              <%= t(".list.heading") %>
+            </p>
+
+            <ul style="font-size: 19px; line-height: 1.315789474;">
+              <% t(".list.items", reg_identifier: @registration.reg_identifier, account_email: @registration.account_email).each do |item| %>
+                <li><%= item %></li>
+              <% end %>
+            </ul>
+
+            <p style="font-size: 19px; line-height: 1.315789474; margin: 15px 0 15px 0;">
+              <%= t(".paragraph_2") %>
+            </p>
+
+            <p style="font-size: 19px; line-height: 1.315789474; margin: 15px 0 15px 0; font-weight: bold">
+              <%= t(".renew_link.text") %> <a href="<%= t(".renew_link.value") %>"><%= t(".renew_link.value") %></a>
+            </p>
+
+            <h2>
+              <%= t(".subheading_2") %>
+            </h2>
+
+            <p style="font-size: 19px; line-height: 1.315789474; margin: 15px 0 15px 0;">
+              <%= t(".paragraph_3", date: @registration.expires_on.to_formatted_s(:day_month_year)) %>
+            </p>
+
+            <p style="font-size: 19px; line-height: 1.315789474; margin: 15px 0 15px 0;">
+              <%= t(".paragraph_4") %>
+            </p>
+
+            <h2>
+              <%= t(".subheading_3") %>
+            </h2>
+
+            <p style="font-size: 19px; line-height: 1.315789474; margin: 15px 0 15px 0;">
+              <%= t(".contacts.text") %> <a href="mailto:<%= t(".contacts.email") %>"><%= t(".contacts.email") %></a>.
+            </p>
+
+            <p style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 15px 0;">
+              <% t(".signed").each do |signed| %>
+                <%= signed %> <br/>
+              <% end %>
+            </p>
+          </td>
+          <td width="25%">&nbsp;</td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+</table>
+
+</body>
+</html>

--- a/config/application.rb
+++ b/config/application.rb
@@ -109,6 +109,7 @@ module WasteCarriersBackOffice
     config.email_service_name = "Waste Carriers Registration Service"
     config.email_service_email = ENV["WCRS_EMAIL_SERVICE_EMAIL"]
     config.email_test_address = ENV["WCRS_EMAIL_TEST_ADDRESS"]
+    config.first_renewal_email_reminder_days = ENV["FIRST_RENEWAL_EMAIL_REMINDER_DAYS"] || 28
 
     # Digital or assisted digital metaData.route value
     config.metadata_route = "ASSISTED_DIGITAL"

--- a/config/locales/mailers/renewal_reminder_mailer/first_reminder_email.en.yml
+++ b/config/locales/mailers/renewal_reminder_mailer/first_reminder_email.en.yml
@@ -1,0 +1,29 @@
+en:
+  renewal_reminder_mailer:
+    first_reminder_email:
+      subject: Your waste carrier registration expires soon, renew online now
+      dear: "Dear %{name}"
+      header: "You must renew your waste carrier registration by %{date}."
+      paragraph_1: "It is an offence to operate as a carrier, broker or dealer of waste without a valid registration."
+      subheading_1: "How to renew online"
+      list:
+        heading: "You’ll need to sign in using:"
+        items:
+          - "your registration number: %{reg_identifier}"
+          - "the email you registered with: %{account_email}"
+          - "your password for the waste carriers service"
+      paragraph_2: "You can reset your password if you need to."
+      renew_link:
+        text: "Renew online: "
+        value: "www.gov.uk/renew-waste-carrier"
+      subheading_2: "Cost to renew"
+      paragraph_3: "If none of your business details have changed, and you renew by %{date}, you’ll pay a lower fee of £105. Payment must clear by the renewal date."
+      paragraph_4: "If you do not renew on time, or certain details about your business have changed (for example, changing from a sole trader to a limited company) you’ll be charged the full fee of £154."
+      subheading_3: "Contact us"
+      contacts:
+        text: "Call us on 03708 506 506 (Monday to Friday, 8am to 6pm) or email"
+        email: "enquiries@environment-agency.gov.uk"
+      signed:
+        - "Yours sincerely"
+        - "Waste Carrier Team"
+

--- a/config/locales/mailers/renewal_reminder_mailer/first_reminder_email.en.yml
+++ b/config/locales/mailers/renewal_reminder_mailer/first_reminder_email.en.yml
@@ -22,8 +22,7 @@ en:
       subheading_3: "Contact us"
       contacts:
         text: "Call us on 03708 506 506 (Monday to Friday, 8am to 6pm) or email"
-        email: "enquiries@environment-agency.gov.uk"
+        email: "nccc-carrierbroker@environment-agency.gov.uk"
       signed:
         - "Yours sincerely"
         - "Waste Carrier Team"
-

--- a/lib/tasks/email.rake
+++ b/lib/tasks/email.rake
@@ -5,4 +5,20 @@ namespace :email do
   task test: :environment do
     puts TestMailer.test_email.deliver_now
   end
+
+  namespace :renew_reminder do
+    namespace :first do
+      desc "Send first email reminder to all registrations expiring in X days (default is 28)"
+      task send: :environment do
+        FirstRenewalReminderService.run
+      end
+    end
+
+    namespace :second do
+      desc "Send second email reminder to all registrations expiring in X days (default is 14)"
+      task send: :environment do
+        # TODO
+      end
+    end
+  end
 end

--- a/spec/mailers/renewal_reminder_mailer_spec.rb
+++ b/spec/mailers/renewal_reminder_mailer_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RenewalReminderMailer, type: :mailer do
+  describe ".first_reminder_email" do
+    let(:registration) { create(:registration) }
+
+    before do
+      allow(Rails.configuration).to receive(:email_service_email).and_return("test@example.com")
+    end
+
+    it "sends a first reminder email" do
+      described_class.first_reminder_email(registration)
+
+      expect(mail.to).to eq([registration.contact_email, registration.account_email])
+      expect(mail.to).to eq([registration.account_email])
+      expect(mail.body.encoded).to include(registration.reg_identifier)
+    end
+  end
+end

--- a/spec/mailers/renewal_reminder_mailer_spec.rb
+++ b/spec/mailers/renewal_reminder_mailer_spec.rb
@@ -4,16 +4,16 @@ require "rails_helper"
 
 RSpec.describe RenewalReminderMailer, type: :mailer do
   describe ".first_reminder_email" do
-    let(:registration) { create(:registration) }
+    let(:registration) { create(:registration, expires_on: 3.days.from_now) }
 
     before do
       allow(Rails.configuration).to receive(:email_service_email).and_return("test@example.com")
     end
 
     it "sends a first reminder email" do
-      described_class.first_reminder_email(registration)
+      mail = described_class.first_reminder_email(registration)
 
-      expect(mail.to).to eq([registration.contact_email, registration.account_email])
+      expect(mail.to).to eq([registration.contact_email])
       expect(mail.to).to eq([registration.account_email])
       expect(mail.body.encoded).to include(registration.reg_identifier)
     end


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-471

Add code necessary to send first renewal email to users using a rake task. This uses the same strategy and name conventions as per WEX

<img width="662" alt="Screenshot 2020-04-17 at 12 45 52" src="https://user-images.githubusercontent.com/1385397/79567654-8443fd80-80ac-11ea-90e6-4f27dd3ac30b.png">
<img width="583" alt="Screenshot 2020-04-17 at 12 45 57" src="https://user-images.githubusercontent.com/1385397/79567659-86a65780-80ac-11ea-8b1a-017bfb8ec3a0.png">
