### PR TITLE
Don't try to display account email if none exists

### DIFF
--- a/app/views/shared/registrations/_company_details_panel.html.erb
+++ b/app/views/shared/registrations/_company_details_panel.html.erb
@@ -13,6 +13,8 @@
       <%= resource.display_expiry_text %>
       <br>
     <% end %>
-    <%= t(".labels.account", email: resource.account_email) %>
+    <% if resource.account_email.present? %>
+      <%= t(".labels.account", email: resource.account_email) %>
+    <% end %>
   </p>
 </div>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-965

The registration info panel used across multiple screens includes the account email by default. However, since new registrations will no longer have accounts, this resulted in us just displaying `Account:` on its own.

This is just a small tweak to only display `Account:` if there is actually an account to mention.

![image](https://user-images.githubusercontent.com/13369917/79568140-3c71a600-80ad-11ea-8e15-07ec3deb9241.png)

![image](https://user-images.githubusercontent.com/13369917/79568171-4abfc200-80ad-11ea-8f41-9c4f36782154.png)
