### PR TITLE
Add API endpoint to seed data using JSON seeds

### DIFF
--- a/app/controllers/api/registrations_controller.rb
+++ b/app/controllers/api/registrations_controller.rb
@@ -2,12 +2,30 @@
 
 module Api
   class RegistrationsController < ApplicationController
-    before_action :authenticate_user!
-
     def show
       registration = WasteCarriersEngine::Registration.find_by(reg_identifier: params[:id])
 
       render json: { _id: registration.id.to_s }
+    end
+
+    def create
+      raw_data = JSON.parse(request.body.read)
+      registration = LoadSeededDataService.run(raw_data)
+
+      render json: { reg_identifier: registration.reg_identifier }
+    end
+
+    def verified_request?
+      # Given that we are sending post create data via raw JSON, we don't want Rails
+      # to complain about a missing forgery token
+      true
+    end
+
+    def skip_auth_on_this_controller?
+      # Given that this API will never be available in production servers, and adding
+      # authentication to the seed `create` requests will add complexity, we will not
+      # request authentication on these endpoints.
+      true
     end
   end
 end

--- a/app/services/api/load_seeded_data_service.rb
+++ b/app/services/api/load_seeded_data_service.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Api
+  class LoadSeededDataService < ::WasteCarriersEngine::BaseService
+    def run(seed)
+      @seed = seed
+
+      seed_registration
+    end
+
+    private
+
+    def seed_registration
+      @seed["reg_identifier"] = reg_identifier
+
+      WasteCarriersEngine::Registration.find_or_create_by(@seed.except("_id"))
+    end
+
+    def reg_identifier
+      @_reg_identifier ||= generate_reg_identifier
+    end
+
+    def generate_reg_identifier
+      tier_identifier = @seed["tier"] == "lower" ? "L" : "U"
+      unique_identifier = ::WasteCarriersEngine::GenerateRegIdentifierService.run.to_s
+
+      "CBD#{tier_identifier}#{unique_identifier}"
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,8 @@ Rails.application.routes.draw do
       defaults: { format: :json },
       constraints: ->(_request) { WasteCarriersEngine::FeatureToggle.active?(:api) }
     ) do
-      resources :registrations, :renewals, only: :show
+      resources :registrations, only: %i[show create]
+      resources :renewals, only: :show
     end
   end
 

--- a/spec/requests/api/registrations_spec.rb
+++ b/spec/requests/api/registrations_spec.rb
@@ -10,30 +10,25 @@ RSpec.describe "Registrations API", type: :request do
   end
 
   describe "GET /bo/api/registrations/:reg_identifier" do
-    context "when a user is signed in" do
-      let(:user) { create(:user, :finance) }
+    it "returns a json containing registration info" do
+      get "/bo/api/registrations/#{registration.reg_identifier}"
 
-      before(:each) do
-        sign_in(user)
-      end
+      expected_json = { "_id" => registration.id.to_s }.to_json
 
-      it "returns a json containing registration info" do
-        get "/bo/api/registrations/#{registration.reg_identifier}"
-
-        expected_json = { "_id" => registration.id.to_s }.to_json
-
-        expect(response.body).to eq(expected_json)
-      end
+      expect(response.body).to eq(expected_json)
     end
+  end
 
-    context "when no user is signed in" do
-      it "returns a json containing an error" do
-        get "/bo/api/registrations/#{registration.reg_identifier}"
+  describe "POST /bo/api/registrations" do
+    let(:data) { File.read("#{Rails.root}/spec/support/fixtures/registration_seed.json") }
 
-        expected_json = { "error" => "You need to sign in before continuing." }.to_json
+    it "generates a new registration and returns a json containing its info" do
+      expected_registrations_count = WasteCarriersEngine::Registration.count + 1
 
-        expect(response.body).to eq(expected_json)
-      end
+      post "/bo/api/registrations", data, format: :json
+
+      expect(response.code).to eq("200")
+      expect(WasteCarriersEngine::Registration.count).to eq(expected_registrations_count)
     end
   end
 end

--- a/spec/services/api/load_seeded_data_service_spec.rb
+++ b/spec/services/api/load_seeded_data_service_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Api
+  RSpec.describe LoadSeededDataService do
+    describe ".run" do
+      it "creates a new registration after assigning a new reg_identifier" do
+        seed = {}
+        registration = double(:registration)
+
+        expect(WasteCarriersEngine::Registration).to receive(:find_or_create_by).and_return(registration)
+        expect(WasteCarriersEngine::GenerateRegIdentifierService).to receive(:run).and_return(1)
+
+        expect(described_class.run(seed)).to eq(registration)
+      end
+    end
+  end
+end

--- a/spec/support/fixtures/registration_seed.json
+++ b/spec/support/fixtures/registration_seed.json
@@ -1,0 +1,156 @@
+{
+    "tier" : "UPPER",
+    "registrationType" : "carrier_dealer",
+    "businessType" : "limitedCompany",
+    "otherBusinesses" : "no",
+    "constructionWaste" : "yes",
+    "companyName" : "UT Company limited",
+    "firstName" : "Bob",
+    "lastName" : "Carolgees",
+    "phoneNumber" : "012345678",
+    "contactEmail" : "user@example.com",
+    "accountEmail" : "user@example.com",
+    "declaredConvictions" : "no",
+    "declaration" : "1",
+    "metaData" : {
+        "dateRegistered" : "2018-05-14T10:38:17.311Z",
+        "anotherString" : "userDetailAddedAtRegistration",
+        "lastModified" : "2018-05-14T10:38:22.692Z",
+        "dateActivated" : "2018-05-14T10:38:22.692Z",
+        "status" : "ACTIVE",
+        "route" : "DIGITAL",
+        "distance" : "n/a"
+    },
+    "financeDetails" : {
+        "orders" : [
+            {
+                "orderId" : "1526294297",
+                "orderItems" : [
+                    {
+                        "amount" : 15400,
+                        "currency" : "GBP",
+                        "description" : "Initial Registration",
+                        "reference" : "",
+                        "type" : "NEW"
+                    },
+                    {
+                        "amount" : 1000,
+                        "currency" : "GBP",
+                        "description" : "2x Copy cards",
+                        "reference" : "",
+                        "type" : "COPY_CARDS"
+                    }
+                ],
+                "orderCode" : "1526294297",
+                "paymentMethod" : "ONLINE",
+                "merchantId" : "EASERRSIMECOM",
+                "totalAmount" : 16400,
+                "currency" : "GBP",
+                "dateCreated" : "2018-05-14T10:38:18.000Z",
+                "worldPayStatus" : "AUTHORISED",
+                "dateLastUpdated" : "2018-05-14T10:38:22.826Z",
+                "updatedByUser" : "user@example.com",
+                "description" : "New Waste Carrier Registration: CBDU4 for UT Company limited, Plus 2 copy cards"
+            }
+        ],
+        "payments" : [
+            {
+                "orderKey" : "1526294297",
+                "amount" : 16400,
+                "currency" : "GBP",
+                "mac_code" : "fa5f24ee0cb5cb6bc739fc7834ad074b",
+                "dateReceived" : "2018-05-14T10:38:22.675Z",
+                "dateEntered" : "2018-05-14T10:38:22.679Z",
+                "registrationReference" : "Worldpay",
+                "worldPayPaymentStatus" : "AUTHORISED",
+                "updatedByUser" : "user@example.com",
+                "comment" : "Paid via Worldpay",
+                "paymentType" : "WORLDPAY"
+            }
+        ],
+        "balance" : 0
+    },
+    "reg_uuid" : "MEhGfN-GH-2tPVdeqZmbQA",
+    "company_no" : "00445790",
+    "addresses" : [
+        {
+            "uprn" : "200000567267",
+            "addressType" : "REGISTERED",
+            "addressMode" : "address-results",
+            "houseNumber" : "ENVIRONMENT AGENCY",
+            "addressLine1" : "BOW BRIDGE CLOSE",
+            "townCity" : "ROTHERHAM",
+            "postcode" : "BS1 5AH",
+            "country" : "",
+            "dependentLocality" : "",
+            "dependentThoroughfare" : "",
+            "administrativeArea" : "ROTHERHAM",
+            "localAuthorityUpdateDate" : "",
+            "royalMailUpdateDate" : "",
+            "easting" : "442265",
+            "northing" : "391948",
+            "location" : {
+                "lat" : 53.410015,
+                "lon" : -1.339531
+            }
+        },
+        {
+            "addressType" : "POSTAL",
+            "houseNumber" : "ENVIRONMENT AGENCY",
+            "addressLine1" : "BOW BRIDGE CLOSE",
+            "addressLine2" : "",
+            "addressLine3" : "",
+            "addressLine4" : "",
+            "townCity" : "ROTHERHAM",
+            "postcode" : "BS1 5AH",
+            "country" : "",
+            "firstName" : "Bob",
+            "lastName" : "Carolgees"
+        }
+    ],
+    "key_people" : [
+        {
+            "position" : "Director",
+            "first_name" : "Rigoberto",
+            "last_name" : "Mohr",
+            "dob" : "1984-05-01T00:00:00.000Z",
+            "person_type" : "KEY",
+            "conviction_search_result" : {
+                "match_result" : "NO",
+                "searched_at" : "2018-05-14T10:37:54.908Z",
+                "confirmed" : "no"
+            }
+        },
+        {
+            "position" : "Director",
+            "first_name" : "Rosalia",
+            "last_name" : "Mitchell",
+            "dob" : "1984-05-01T00:00:00.000Z",
+            "person_type" : "KEY",
+            "conviction_search_result" : {
+                "match_result" : "NO",
+                "searched_at" : "2018-05-14T10:37:56.303Z",
+                "confirmed" : "no"
+            }
+        },
+        {
+            "position" : "Director",
+            "first_name" : "Haleigh",
+            "last_name" : "Hickle",
+            "dob" : "1984-05-01T00:00:00.000Z",
+            "person_type" : "KEY",
+            "conviction_search_result" : {
+                "match_result" : "NO",
+                "searched_at" : "2018-05-14T10:37:57.529Z",
+                "confirmed" : "no"
+            }
+        }
+    ],
+    "copy_cards" : "2",
+    "expires_on" : "2021-05-14T10:38:22.692Z",
+    "conviction_search_result" : {
+        "match_result" : "NO",
+        "searched_at" : "2018-05-14T10:37:50.372Z",
+        "confirmed" : "no"
+    }
+}


### PR DESCRIPTION
This will be used to improve performances of the Acceptance test suite and will make existing seeds file easely reusable.
The main change in seeding is that this API will generate a new registration identifier and return it as a response, so that the test suite can run multiple times without having to wipe the DB data.

Check also: https://github.com/DEFRA/waste-carriers-acceptance-tests/compare/seed-data?expand=1 
