### PR TITLE
Change seeds api to set expires_on

### DIFF
--- a/app/services/api/load_seeded_data_service.rb
+++ b/app/services/api/load_seeded_data_service.rb
@@ -12,6 +12,7 @@ module Api
 
     def seed_registration
       @seed["reg_identifier"] = reg_identifier
+      @seed["expires_on"] = Rails.configuration.expires_after.years.from_now
 
       WasteCarriersEngine::Registration.find_or_create_by(@seed.except("_id"))
     end

--- a/spec/services/api/load_seeded_data_service_spec.rb
+++ b/spec/services/api/load_seeded_data_service_spec.rb
@@ -11,6 +11,7 @@ module Api
 
         expect(WasteCarriersEngine::Registration).to receive(:find_or_create_by).and_return(registration)
         expect(WasteCarriersEngine::GenerateRegIdentifierService).to receive(:run).and_return(1)
+        expect(Rails.configuration).to receive(:expires_after).and_return(3)
 
         expect(described_class.run(seed)).to eq(registration)
       end


### PR DESCRIPTION
This updates the seeds api to set the `expires_on` date on newly seeded data from the acceptance tests suite