### PR TITLE
Generate magic link when sending email reminders

### DIFF
--- a/app/controllers/api/registrations_controller.rb
+++ b/app/controllers/api/registrations_controller.rb
@@ -5,7 +5,7 @@ module Api
     def show
       registration = WasteCarriersEngine::Registration.find_by(reg_identifier: params[:id])
 
-      render json: { _id: registration.id.to_s }
+      render json: { _id: registration.id.to_s, renew_token: registration.renew_token }
     end
 
     def create

--- a/app/mailers/renewal_reminder_mailer.rb
+++ b/app/mailers/renewal_reminder_mailer.rb
@@ -4,6 +4,8 @@ class RenewalReminderMailer < ActionMailer::Base
   helper "waste_carriers_engine/mailer"
 
   def first_reminder_email(registration)
+    generate_magic_link(registration)
+
     @registration = registration
 
     mail(
@@ -14,6 +16,8 @@ class RenewalReminderMailer < ActionMailer::Base
   end
 
   def second_reminder_email(registration)
+    generate_magic_link(registration) unless registration.renew_token.present?
+
     @registration = registration
     date = registration.expires_on.to_formatted_s(:day_month_year)
 
@@ -25,6 +29,12 @@ class RenewalReminderMailer < ActionMailer::Base
   end
 
   private
+
+  def generate_magic_link(registration)
+    return unless WasteCarriersEngine::FeatureToggle.active?(:renew_via_magic_link)
+
+    registration.generate_magic_link!
+  end
 
   def collect_addresses(registration)
     [registration.contact_email, registration.account_email].compact.uniq

--- a/app/mailers/renewal_reminder_mailer.rb
+++ b/app/mailers/renewal_reminder_mailer.rb
@@ -33,7 +33,7 @@ class RenewalReminderMailer < ActionMailer::Base
   def generate_magic_link(registration)
     return unless WasteCarriersEngine::FeatureToggle.active?(:renew_via_magic_link)
 
-    registration.generate_magic_link!
+    registration.generate_renew_token!
   end
 
   def collect_addresses(registration)

--- a/config/feature_toggles.yml
+++ b/config/feature_toggles.yml
@@ -5,3 +5,5 @@ api:
   active: <%= ENV["FEATURE_TOGGLE_API"] %>
 email_reminders:
   active: <%= ENV["FEATURE_TOGGLE_EMAIL_REMINDERS"] %>
+renew_via_magic_link:
+  active: <%= ENV["RENEW_VIA_MAGIC_LINK"] %>

--- a/spec/mailers/renewal_reminder_mailer_spec.rb
+++ b/spec/mailers/renewal_reminder_mailer_spec.rb
@@ -3,6 +3,10 @@
 require "rails_helper"
 
 RSpec.describe RenewalReminderMailer, type: :mailer do
+  before do
+    allow(WasteCarriersEngine::FeatureToggle).to receive(:active?).with(:renew_via_magic_link).and_return(true)
+  end
+
   describe ".first_reminder_email" do
     let(:registration) { create(:registration, expires_on: 3.days.from_now) }
 
@@ -13,6 +17,7 @@ RSpec.describe RenewalReminderMailer, type: :mailer do
     it "sends a first reminder email" do
       mail = described_class.first_reminder_email(registration)
 
+      expect(registration).to receive(:generate_magic_link!)
       expect(mail.subject).to include("waste carrier registration expires soon, renew online now")
       expect(mail.to).to eq([registration.contact_email])
       expect(mail.to).to eq([registration.account_email])
@@ -30,6 +35,7 @@ RSpec.describe RenewalReminderMailer, type: :mailer do
     it "sends a second reminder email" do
       mail = described_class.second_reminder_email(registration)
 
+      expect(registration).to receive(:generate_magic_link!)
       expect(mail.subject).to include("Final reminder")
       expect(mail.to).to eq([registration.contact_email])
       expect(mail.to).to eq([registration.account_email])

--- a/spec/mailers/renewal_reminder_mailer_spec.rb
+++ b/spec/mailers/renewal_reminder_mailer_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe RenewalReminderMailer, type: :mailer do
     it "sends a first reminder email" do
       mail = described_class.first_reminder_email(registration)
 
-      expect(registration).to receive(:generate_magic_link!)
+      expect(registration).to receive(:generate_renew_token!)
       expect(mail.subject).to include("waste carrier registration expires soon, renew online now")
       expect(mail.to).to eq([registration.contact_email])
       expect(mail.to).to eq([registration.account_email])
@@ -35,7 +35,7 @@ RSpec.describe RenewalReminderMailer, type: :mailer do
     it "sends a second reminder email" do
       mail = described_class.second_reminder_email(registration)
 
-      expect(registration).to receive(:generate_magic_link!)
+      expect(registration).to receive(:generate_renew_token!)
       expect(mail.subject).to include("Final reminder")
       expect(mail.to).to eq([registration.contact_email])
       expect(mail.to).to eq([registration.account_email])

--- a/spec/requests/api/registrations_spec.rb
+++ b/spec/requests/api/registrations_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "Registrations API", type: :request do
-  let(:registration) { create(:registration) }
+  let(:registration) { create(:registration, renew_token: "renew_token") }
 
   before do
     allow(WasteCarriersEngine::FeatureToggle).to receive(:active?).with(:api).and_return(true)
@@ -13,7 +13,7 @@ RSpec.describe "Registrations API", type: :request do
     it "returns a json containing registration info" do
       get "/bo/api/registrations/#{registration.reg_identifier}"
 
-      expected_json = { "_id" => registration.id.to_s }.to_json
+      expected_json = { "_id" => registration.id.to_s, renew_token: "renew_token" }.to_json
 
       expect(response.body).to eq(expected_json)
     end


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-986

Generates magic link when sending a first email reminder and when sending a second unless a token already exists.
This also updates the API to renturn the magic link as part of registration information and adds the feature toggle for magic link renewals.

blocked by: https://github.com/DEFRA/waste-carriers-engine/pull/828