### PR TITLE
Add one-off rake task to update defunct renewal workflow_state

### DIFF
--- a/lib/tasks/one_off/fix_renewal_received_form.rake
+++ b/lib/tasks/one_off/fix_renewal_received_form.rake
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+namespace :fix do
+  desc "Update renewals in defunct `renewal_received_form` workflow_state"
+  task update_renewal_received_form_status: :environment do
+    renewals = WasteCarriersEngine::RenewingRegistration.where(workflow_state: "renewal_received_form")
+
+    puts "#{renewals.count} renewals to update"
+
+    renewals.each do |renewal|
+      updated_state = if renewal.pending_worldpay_payment?
+                        "renewal_received_pending_worldpay_payment_form"
+                      elsif renewal.pending_payment?
+                        "renewal_received_pending_payment_form"
+                      else
+                        "renewal_received_pending_conviction_form"
+                      end
+
+      puts "Changing workflow_state of #{renewal.reg_identifier} to #{updated_state}"
+      renewal.update_attribute(:workflow_state, updated_state)
+    end
+  end
+end

--- a/lib/tasks/stuck.rake
+++ b/lib/tasks/stuck.rake
@@ -4,7 +4,7 @@ namespace :fix do
   desc "Fix expired renewals stuck at 'renewal-received' stage"
   task unstick_received: :environment do
     stuck_renewals = WasteCarriersEngine::RenewingRegistration.in(
-      workflow_state: %w[renewal_received_form renewal_complete_form]
+      workflow_state: WasteCarriersEngine::RenewingRegistration::SUBMITTED_STATES
     )
     stuck_renewals.each do |renewal|
       completion_service = WasteCarriersEngine::RenewalCompletionService.new(renewal)


### PR DESCRIPTION
This task exists to find any renewals with the workflow_state `renewal_received_form` and change them to one of the new workflow_states we've split that into.

We should only need to run this once on production, when we release the updated workflow.

Also updated another rake task that was still using the old workflow_state.