### PR TITLE
Fix impossible logic in renewal_received_form rake task

### DIFF
--- a/lib/tasks/one_off/fix_renewal_received_form.rake
+++ b/lib/tasks/one_off/fix_renewal_received_form.rake
@@ -10,7 +10,7 @@ namespace :fix do
     renewals.each do |renewal|
       updated_state = if renewal.pending_worldpay_payment?
                         "renewal_received_pending_worldpay_payment_form"
-                      elsif renewal.pending_payment?
+                      elsif renewal.unpaid_balance?
                         "renewal_received_pending_payment_form"
                       else
                         "renewal_received_pending_conviction_form"


### PR DESCRIPTION
Previously we were checking if renewals with the workflow_state `renewal_received_form` were `pending_payment?`. However this always returns false unless the renewal's workflow_state is one of the valid submitted states... which `renewal_received_form` no longer is. So it always returned false, and these renewals were then sent to the convictions state instead.

Checking if there is an unpaid balance should give us the correct result.