### PR TITLE
Add cancel functionality for in-progress registrations

### DIFF
--- a/app/controllers/cancels_controller.rb
+++ b/app/controllers/cancels_controller.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class CancelsController < ApplicationController
+  include CanFetchResource
+  include FinanceDetailsHelper
+
+  prepend_before_action :authenticate_user!
+  before_action :authorize_user
+
+  def new; end
+
+  def create
+    @resource.metaData.cancel
+    @resource.save!
+
+    flash[:success] = I18n.t(
+      "cancels.messages.success",
+      reg_identifier: @resource.reg_identifier
+    )
+
+    redirect_to details_path_for(@resource)
+  end
+
+  private
+
+  def authorize_user
+    authorize! :cancel, WasteCarriersEngine::Registration
+  end
+end

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -86,8 +86,8 @@ module ActionLinksHelper
   end
 
   def display_cancel_link_for?(resource)
-    return false unless can?(:cancel, WasteCarriersEngine::Registration)
     return false unless display_registration_links?(resource)
+    return false unless can?(:cancel, WasteCarriersEngine::Registration)
 
     resource.pending?
   end

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -85,6 +85,13 @@ module ActionLinksHelper
     resource.active? && resource.upper_tier?
   end
 
+  def display_cancel_link_for?(resource)
+    return false unless can?(:cancel, WasteCarriersEngine::Registration)
+    return false unless display_registration_links?(resource)
+
+    resource.pending?
+  end
+
   def display_renew_link_for?(resource)
     return false unless display_registration_links?(resource)
     return false unless can?(:renew, WasteCarriersEngine::Registration)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -50,6 +50,7 @@ class Ability
     can :view_revoked_reasons, :all
     can :cease, WasteCarriersEngine::Registration
     can :revoke, WasteCarriersEngine::Registration
+    can :cancel, :all
 
     can :refund, :all
     can :record_cash_payment, :all

--- a/app/views/cancels/new.html.erb
+++ b/app/views/cancels/new.html.erb
@@ -1,0 +1,27 @@
+<div class="grid-row">
+  <div class="column-full">
+    <%= render("waste_carriers_engine/shared/back", back_path: details_path_for(@resource)) %>
+  </div>
+</div>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <h1 class="heading-large">
+      <%= t(".heading", reg_identifier: @resource.reg_identifier) %>
+    </h1>
+
+    <div class="form-group">
+      <%= render "shared/company_details_panel", registration: @resource %>
+    </div>
+
+    <%= form_tag(url: resource_cancels_path(@resource._id)) do |f| %>
+      <div class="form-group">
+        <%= submit_tag t(".confirm"), class: "button" %>
+
+        <div class="form-button-link">
+          <%= link_to(t(".cancel"), details_path_for(@resource)) %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/registrations/show.html.erb
+++ b/app/views/registrations/show.html.erb
@@ -2,6 +2,9 @@
   <div class="column-full">
     <%= render("waste_carriers_engine/shared/back", back_path: bo_path) %>
 
+    <%= render("shared/success", message: flash[:success]) if flash[:success].present? %>
+    <%= render("shared/message", message: flash[:message]) if flash[:message].present? %>
+
     <div class="grid-row">
       <div class="column-two-thirds">
 

--- a/app/views/shared/registrations/_action_links_panel.html.erb
+++ b/app/views/shared/registrations/_action_links_panel.html.erb
@@ -55,5 +55,13 @@
         <%= link_to t(".actions_box.links.revoke"), WasteCarriersEngine::Engine.routes.url_helpers.new_cease_or_revoke_form_path(resource.reg_identifier) %>
       </li>
     <% end %>
+
+    <li class="separated" />
+
+    <% if display_cancel_link_for?(resource) %>
+      <li>
+        <%= link_to t(".actions_box.links.cancel"), new_resource_cancel_path(resource._id) %>
+      </li>
+    <% end %>
   </ul>
 </div>

--- a/config/locales/cancels.en.yml
+++ b/config/locales/cancels.en.yml
@@ -1,0 +1,9 @@
+en:
+  cancels:
+    messages:
+      success: "%{reg_identifier} in progress registration has been cancelled"
+    new:
+      title: "Confirm cancel"
+      heading: "Confirm cancel for in progress registration %{reg_identifier}"
+      confirm: "Confirm cancel"
+      cancel: "Keep this registration"

--- a/config/locales/shared/registrations.en.yml
+++ b/config/locales/shared/registrations.en.yml
@@ -70,6 +70,7 @@ en:
             transfer: "Transfer to another account"
             edit: "Edit registration"
             certificate: "View certificate"
+            cancel: "Cancel registration"
             order_copy_cards: "Order registration cards"
             payment_details: "Payment details"
             process_payment: "Process payment"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,10 @@ Rails.application.routes.draw do
                         only: %i[index new create],
                         param: :order_key
 
+              resources :cancels,
+                        only: %i[new create],
+                        path_names: { new: "" }
+
               resources :reversal_forms,
                         only: %i[index new create],
                         path: "reversals",

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -339,6 +339,56 @@ RSpec.describe ActionLinksHelper, type: :helper do
     end
   end
 
+  describe "#display_cancel_link_for?" do
+    context "when the resource is a registration" do
+      let(:resource) { build(:registration) }
+
+      before do
+        allow(helper).to receive(:can?).and_return(can)
+      end
+
+      context "when the user has permission for cancelling" do
+        let(:can) { true }
+
+        before do
+          expect(resource).to receive(:pending?).and_return(pending)
+        end
+
+        context "when the resource is pending" do
+          let(:pending) { true }
+
+          it "returns true" do
+            expect(helper.display_cancel_link_for?(resource)).to be_truthy
+          end
+        end
+
+        context "when the resource is not pending" do
+          let(:pending) { false }
+
+          it "returns false" do
+            expect(helper.display_cancel_link_for?(resource)).to be_falsey
+          end
+        end
+      end
+
+      context "when the user has no permission for cancelling" do
+        let(:can) { false }
+
+        it "returns false" do
+          expect(helper.display_cancel_link_for?(resource)).to be_falsey
+        end
+      end
+    end
+
+    context "when the resource is a transient registration" do
+      let(:resource) { build(:renewing_registration) }
+
+      it "returns false" do
+        expect(helper.display_cancel_link_for?(resource)).to be_falsey
+      end
+    end
+  end
+
   describe "#display_edit_link_for?" do
     context "when the resource is a registration" do
       let(:resource) { build(:registration) }

--- a/spec/requests/cancels_spec.rb
+++ b/spec/requests/cancels_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "Cancels", type: :request do
 
         expect(registration).to be_inactive
         expect(response).to have_http_status(302)
-        expect(response).to redirect_to(registration_detail_path(registration._id))
+        expect(response).to redirect_to(registration_path(registration.reg_identifier))
       end
     end
   end

--- a/spec/requests/cancels_spec.rb
+++ b/spec/requests/cancels_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Cancels", type: :request do
+  describe "GET /bo/resource/:_id/cancel" do
+    context "when an agency with refund user is signed in" do
+      let(:user) { create(:user, :agency_with_refund) }
+      let(:registration) { create(:registration) }
+
+      before(:each) do
+        sign_in(user)
+      end
+
+      it "renders the new template and returns a 200 status" do
+        get new_resource_cancel_path(registration._id)
+
+        expect(response).to render_template(:new)
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context "when a finance super user is signed in" do
+      let(:user) { create(:user, :finance_super) }
+      let(:registration) { create(:registration) }
+
+      before(:each) do
+        sign_in(user)
+      end
+
+      it "redirects to the permissions page" do
+        get new_resource_cancel_path(registration._id)
+
+        expect(response).to redirect_to("/bo/pages/permission")
+        expect(response).to have_http_status(302)
+      end
+    end
+
+    context "when a user is not signed in" do
+      it "redirects to the sign-in page" do
+        get new_resource_cancel_path("foo")
+
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  describe "POST /bo/resource/:_id/charge-adjust" do
+    context "when an agency with refund user is signed in" do
+      let(:user) { create(:user, :agency_with_refund) }
+      let(:registration) { create(:registration, :pending) }
+
+      before(:each) do
+        sign_in(user)
+      end
+
+      it "changes the status of the registration to inactive and redirects to the details page with a 302 status" do
+        post resource_cancels_path(registration._id)
+
+        registration.reload
+
+        expect(registration).to be_inactive
+        expect(response).to have_http_status(302)
+        expect(response).to redirect_to(registration_detail_path(registration._id))
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/abilities/agency_with_refund_examples.rb
+++ b/spec/support/shared_examples/abilities/agency_with_refund_examples.rb
@@ -21,6 +21,10 @@ RSpec.shared_examples "agency_with_refund examples" do
     should be_able_to(:record_cheque_payment, WasteCarriersEngine::RenewingRegistration)
   end
 
+  it "should be able to cancel a resource" do
+    should be_able_to(:cancel, WasteCarriersEngine::Registration)
+  end
+
   it "should be able to record a postal order payment" do
     should be_able_to(:record_postal_order_payment, WasteCarriersEngine::RenewingRegistration)
   end

--- a/spec/support/shared_examples/abilities/below_agency_with_refund_examples.rb
+++ b/spec/support/shared_examples/abilities/below_agency_with_refund_examples.rb
@@ -39,6 +39,10 @@ RSpec.shared_examples "below agency_with_refund examples" do
     end
   end
 
+  it "should not be able to cancel a resource" do
+    should_not be_able_to(:cancel, WasteCarriersEngine::Registration)
+  end
+
   it "should not be able to view payments" do
     should_not be_able_to(:view_payments, WasteCarriersEngine::RenewingRegistration)
   end

--- a/spec/support/shared_examples/abilities/finance_examples.rb
+++ b/spec/support/shared_examples/abilities/finance_examples.rb
@@ -39,6 +39,10 @@ RSpec.shared_examples "finance examples" do
 
   # Everything else is off-limits.
 
+  it "should not be able to cancel a resource" do
+    should_not be_able_to(:cancel, WasteCarriersEngine::Registration)
+  end
+
   it "should not be able to update a transient registration" do
     should_not be_able_to(:update, WasteCarriersEngine::RenewingRegistration)
   end


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-1017

These implements cancel functionality for in-progress registrations. It has been implemented using the `resources` pattern so that it is easier to extend to in-progress renewals later on.

<details>
<summary>
Confirm cancel
</summary>

<img width="800" alt="Screenshot 2020-05-11 at 15 01 35" src="https://user-images.githubusercontent.com/1385397/81580116-ea1e5f00-93a4-11ea-8dca-28e3408f8a45.png">

</details>

<details>
<summary>
Link to functionality</summary>

<img width="1001" alt="Screenshot 2020-05-11 at 14 57 46" src="https://user-images.githubusercontent.com/1385397/81580120-eab6f580-93a4-11ea-9963-d89ef936ef09.png">

</details>

 <details>
<summary>
Confirmation</summary>

<img width="1040" alt="Screenshot 2020-05-11 at 16 25 59" src="https://user-images.githubusercontent.com/1385397/81580105-e7bc0500-93a4-11ea-980b-8a826acab731.png">

</details>

