### PR TITLE
Add new registration action to back office

### DIFF
--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -10,11 +10,11 @@ module ActionLinksHelper
   end
 
   def resume_link_for(resource)
-    ad_privacy_policy_path(resource.reg_identifier)
+    ad_privacy_policy_path(reg_identifier: resource.reg_identifier)
   end
 
   def renew_link_for(resource)
-    ad_privacy_policy_path(resource.reg_identifier)
+    ad_privacy_policy_path(reg_identifier: resource.reg_identifier)
   end
 
   def display_details_link_for?(resource)

--- a/app/helpers/waste_carriers_engine/ad_privacy_policy_helper.rb
+++ b/app/helpers/waste_carriers_engine/ad_privacy_policy_helper.rb
@@ -2,10 +2,6 @@
 
 module WasteCarriersEngine
   module AdPrivacyPolicyHelper
-    def renewal_finished_link(reg_identifier:)
-      main_app.renewing_registration_path(reg_identifier: reg_identifier)
-    end
-
     def destination_path
       if @reg_identifier.present?
         WasteCarriersEngine::Engine.routes.url_helpers.new_renewal_start_form_path(token: @reg_identifier)

--- a/app/helpers/waste_carriers_engine/ad_privacy_policy_helper.rb
+++ b/app/helpers/waste_carriers_engine/ad_privacy_policy_helper.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module WasteCarriersEngine
+  module AdPrivacyPolicyHelper
+    def renewal_finished_link(reg_identifier:)
+      main_app.renewing_registration_path(reg_identifier: reg_identifier)
+    end
+
+    def destination_path
+      if @reg_identifier.present?
+        WasteCarriersEngine::Engine.routes.url_helpers.new_renewal_start_form_path(token: @reg_identifier)
+      else
+        WasteCarriersEngine::Engine.routes.url_helpers.new_start_form_path
+      end
+    end
+  end
+end

--- a/app/views/ad_privacy_policy/show.html.erb
+++ b/app/views/ad_privacy_policy/show.html.erb
@@ -55,7 +55,7 @@
       </div>
     </details>
 
-    <p><%= link_to "Continue", WasteCarriersEngine::Engine.routes.url_helpers.new_renewal_start_form_path(token: @reg_identifier), class: "button" %></p>
+    <p><%= link_to "Continue", destination_path, class: "button" %></p>
     <p><%= t(".last_updated") %></p>
   </div>
 </div>

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -38,18 +38,20 @@
     </div>
   </div>
 
-  <div class="column-one-third">
-    <div class="wcr-actions">
-      <h2 class="heading-small">
-        <%= t(".actions.subheading") %>
-      </h2>
-      <ul>
-        <li>
-          <%= link_to t(".actions.new_registration"), ad_privacy_policy_path %>
-        </li>
-      </ul>
+  <% if can?(:update, WasteCarriersEngine::Registration) %>
+    <div class="column-one-third">
+      <div class="wcr-actions">
+        <h2 class="heading-small">
+          <%= t(".actions.subheading") %>
+        </h2>
+        <ul>
+          <li>
+            <%= link_to t(".actions.new_registration"), ad_privacy_policy_path %>
+          </li>
+        </ul>
+      </div>
     </div>
-  </div>
+  <% end %>
 </div>
 
 <% if @results.any? %>

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -38,19 +38,18 @@
     </div>
   </div>
 
-  <!-- TODO: restore link when internal route exists https://eaflood.atlassian.net/browse/RUBY-786 -->
-  <!-- <div class="column-one-third">
+  <div class="column-one-third">
     <div class="wcr-actions">
       <h2 class="heading-small">
-        <%#= t(".actions.subheading") %>
+        <%= t(".actions.subheading") %>
       </h2>
       <ul>
         <li>
-          <%#= link_to t(".actions.new_registration"), "#" %>
+          <%= link_to t(".actions.new_registration"), ad_privacy_policy_path %>
         </li>
       </ul>
     </div>
-  </div> -->
+  </div>
 </div>
 
 <% if @results.any? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,7 @@ Rails.application.routes.draw do
   get "/bo/convictions/rejected" => "convictions_dashboards#rejected", as: :convictions_rejected
 
   # Privacy policy
-  get "/bo/ad-privacy-policy/:reg_identifier", to: "ad_privacy_policy#show", as: :ad_privacy_policy
+  get "/bo/ad-privacy-policy", to: "ad_privacy_policy#show", as: :ad_privacy_policy
 
   resources :resources,
             only: [],

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe ActionLinksHelper, type: :helper do
       let(:resource) { build(:renewing_registration) }
 
       it "returns the correct path" do
-        expect(helper.resume_link_for(resource)).to eq(ad_privacy_policy_path(resource.reg_identifier))
+        expect(helper.resume_link_for(resource)).to eq(ad_privacy_policy_path(reg_identifier: resource.reg_identifier))
       end
     end
   end
@@ -106,7 +106,7 @@ RSpec.describe ActionLinksHelper, type: :helper do
       let(:resource) { create(:registration) }
 
       it "returns the correct path" do
-        expect(helper.renew_link_for(resource)).to eq(ad_privacy_policy_path(resource.reg_identifier))
+        expect(helper.renew_link_for(resource)).to eq(ad_privacy_policy_path(reg_identifier: resource.reg_identifier))
       end
     end
   end

--- a/spec/helpers/waste_carriers_engine/ad_privacy_policy_helper_spec.rb
+++ b/spec/helpers/waste_carriers_engine/ad_privacy_policy_helper_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe WasteCarriersEngine::AdPrivacyPolicyHelper, type: :helper do
+    describe "destination_path" do
+      context "when a reg identifier as been defined in the controller" do
+        it "returns the renewal start form path" do
+          assign(:reg_identifier, "CBDUFOO")
+
+          expect(helper.destination_path).to eq("/bo/CBDUFOO/renew")
+        end
+      end
+
+      context "when there is no reg identifier available" do
+        it "returns the new start form path" do
+          expect(helper.destination_path).to eq("/bo/start")
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/renewing_registrations_spec.rb
+++ b/spec/requests/renewing_registrations_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "RenewingRegistrations", type: :request do
 
       it "includes a link to continue the renewal" do
         get "/bo/renewing-registrations/#{transient_registration.reg_identifier}"
-        expect(response.body).to include("/bo/ad-privacy-policy/#{transient_registration.reg_identifier}")
+        expect(response.body).to include("/bo/ad-privacy-policy?reg_identifier=#{transient_registration.reg_identifier}")
       end
 
       context "when no matching transient_registration exists" do


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-1038

This adds a new registration action link to the back office and fixes the ad privacy policy to work for both new registrations and renewals, using the same params strategy adopted with WEX.

<details>
<summary>Screenshots </summary>
<img width="1041" alt="Screenshot 2020-05-15 at 12 41 39" src="https://user-images.githubusercontent.com/1385397/82046988-e42cc480-96a9-11ea-9979-56f594d2c2de.png">
<img width="909" alt="Screenshot 2020-05-15 at 12 41 43" src="https://user-images.githubusercontent.com/1385397/82046994-e727b500-96a9-11ea-843a-207fa9d830a2.png">
<img width="591" alt="Screenshot 2020-05-15 at 12 41 49" src="https://user-images.githubusercontent.com/1385397/82046997-e858e200-96a9-11ea-8e75-59e063d4cedb.png">

</details>