### PR TITLE
Update permissions to view link to new registrations

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -34,6 +34,7 @@ class Ability
   def permissions_for_agency_user
     # This covers everything mounted in the engine and used for the assisted digital journey, including WorldPay
     can :update, WasteCarriersEngine::RenewingRegistration
+    can :create, WasteCarriersEngine::Registration
     can :renew, :all
     can :view_certificate, WasteCarriersEngine::Registration
     can :order_copy_cards, WasteCarriersEngine::Registration

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -38,7 +38,7 @@
     </div>
   </div>
 
-  <% if can?(:update, WasteCarriersEngine::Registration) %>
+  <% if can?(:create, WasteCarriersEngine::Registration) %>
     <div class="column-one-third">
       <div class="wcr-actions">
         <h2 class="heading-small">

--- a/spec/support/shared_examples/abilities/agency_examples.rb
+++ b/spec/support/shared_examples/abilities/agency_examples.rb
@@ -7,6 +7,10 @@ RSpec.shared_examples "agency examples" do
     should be_able_to(:update, WasteCarriersEngine::RenewingRegistration)
   end
 
+  it "should be able to create a registration" do
+    should be_able_to(:create, WasteCarriersEngine::Registration)
+  end
+
   it "should not be able to charge adjust a resource" do
     should_not be_able_to(:charge_adjust, WasteCarriersEngine::RenewingRegistration)
     should_not be_able_to(:charge_adjust, WasteCarriersEngine::Registration)

--- a/spec/support/shared_examples/abilities/finance_admin_examples.rb
+++ b/spec/support/shared_examples/abilities/finance_admin_examples.rb
@@ -52,6 +52,10 @@ RSpec.shared_examples "finance_admin examples" do
     should_not be_able_to(:update, WasteCarriersEngine::RenewingRegistration)
   end
 
+  it "should not be able to create a registration" do
+    should_not be_able_to(:create, WasteCarriersEngine::Registration)
+  end
+
   it "should be able to write off large finance details" do
     should be_able_to(:write_off_large, WasteCarriersEngine::FinanceDetails)
   end

--- a/spec/support/shared_examples/abilities/finance_examples.rb
+++ b/spec/support/shared_examples/abilities/finance_examples.rb
@@ -47,6 +47,10 @@ RSpec.shared_examples "finance examples" do
     should_not be_able_to(:update, WasteCarriersEngine::RenewingRegistration)
   end
 
+  it "should not be able to create a registration" do
+    should_not be_able_to(:create, WasteCarriersEngine::Registration)
+  end
+
   it "should not be able to write off large finance details" do
     should_not be_able_to(:write_off_large, WasteCarriersEngine::FinanceDetails)
   end


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-1038

I have used an existing permission on `:update` on the first iteration on this code, without realising that was specific to RenewingRegistration.
This introduce a new ability to `:create` Registration that we can use to decide if a user should be able to see the link to a new registration or not in the back office.