### PR TITLE
Uodate back button path to new backoffice

### DIFF
--- a/app/views/ad_privacy_policy/show.html.erb
+++ b/app/views/ad_privacy_policy/show.html.erb
@@ -1,6 +1,6 @@
 <div class="grid-row">
   <div class="column-two-thirds">
-    <%= render("waste_carriers_engine/shared/back", back_path: root_path) %>
+    <%= render("waste_carriers_engine/shared/back", back_path: "/bo") %>
 
     <h1 class="heading-large">
       <%= t(".heading") %>


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-1038

We used to redirect the user to the privacy policy page for only renewals, from the old backend.
Since now we are using this page for new registrations that can be triggered from the new backoffice as well, we want the path to redirect always to the new backoffice instead.