### PR TITLE
Return new registration results in dashboard search

### DIFF
--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -24,7 +24,9 @@ class SearchService < ::WasteCarriersEngine::BaseService
   end
 
   def matching_resources
-    search(WasteCarriersEngine::Registration) + search(WasteCarriersEngine::RenewingRegistration)
+    search(WasteCarriersEngine::Registration) +
+      search(WasteCarriersEngine::RenewingRegistration) +
+      search(WasteCarriersEngine::NewRegistration)
   end
 
   def search(model)

--- a/app/services/status_tag_service.rb
+++ b/app/services/status_tag_service.rb
@@ -31,6 +31,7 @@ class StatusTagService < ::WasteCarriersEngine::BaseService
   end
 
   def transient_reg_metadata_status
+    return :in_progress if transient_new?
     return :in_progress unless @resource.renewal_application_submitted?
   end
 
@@ -55,7 +56,7 @@ class StatusTagService < ::WasteCarriersEngine::BaseService
   # Stuck
 
   def stuck
-    :stuck if transient? && @resource.stuck?
+    :stuck if transient_renewal? && @resource.stuck?
   end
 
   # Helper methods
@@ -64,8 +65,16 @@ class StatusTagService < ::WasteCarriersEngine::BaseService
     @_transient ||= @resource.is_a?(WasteCarriersEngine::TransientRegistration)
   end
 
+  def transient_renewal?
+    @_transient_renewal ||= @resource.is_a?(WasteCarriersEngine::RenewingRegistration)
+  end
+
+  def transient_new?
+    @_transient_new ||= @resource.is_a?(WasteCarriersEngine::NewRegistration)
+  end
+
   def submitted_renewal?
-    @_submitted_renewal ||= transient? && @resource.renewal_application_submitted?
+    @_submitted_renewal ||= transient_renewal? && @resource.renewal_application_submitted?
   end
 
   def registration_or_submitted_renewal?

--- a/spec/factories/new_registration.rb
+++ b/spec/factories/new_registration.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :new_registration, class: WasteCarriersEngine::NewRegistration do
+  end
+end

--- a/spec/services/status_tag_service_spec.rb
+++ b/spec/services/status_tag_service_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe StatusTagService do
     end
   end
 
-  context "when the resource is a transient_registration" do
+  context "when the resource is a renewing_registration" do
     let(:resource) { create(:renewing_registration) }
 
     context "when the metadata status is revoked" do
@@ -160,6 +160,36 @@ RSpec.describe StatusTagService do
         it "does not include :stuck in the response" do
           expect(service).to_not include(:stuck)
         end
+      end
+    end
+  end
+
+  context "when the resource is a new_registration" do
+    let(:resource) { create(:new_registration) }
+
+    context "when the metadata status is revoked" do
+      before { resource.metaData.status = "REVOKED" }
+
+      it "includes :revoked in the response" do
+        expect(service).to include(:revoked)
+      end
+    end
+
+    context "when the metadata status is refused" do
+      before { resource.metaData.status = "REFUSED" }
+
+      it "includes :refused in the response" do
+        expect(service).to include(:refused)
+      end
+    end
+
+    context "when the metadata status is not revoked or refused" do
+      let(:status) { %w[ACTIVE EXPIRED PENDING].sample }
+
+      before { resource.metaData.status = status }
+
+      it "includes :in_progress in the response" do
+        expect(service).to include(:in_progress)
       end
     end
   end


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-1053

This expand the search service to work on new_registrations.

<img width="1075" alt="Screenshot 2020-05-26 at 10 49 28" src="https://user-images.githubusercontent.com/1385397/82887287-b49a7980-9f3f-11ea-94bc-f03a236417bc.png">
