### PR TITLE
Add view details page for new registrations

### DIFF
--- a/app/controllers/new_registrations_controller.rb
+++ b/app/controllers/new_registrations_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class NewRegistrationsController < ApplicationController
+  before_action :authenticate_user!
+
+  def show
+    begin
+      transient_registration = fetch_new_registration
+    rescue Mongoid::Errors::DocumentNotFound
+      return redirect_to bo_path
+    end
+
+    @transient_registration = NewRegistrationPresenter.new(transient_registration, view_context)
+  end
+
+  private
+
+  def fetch_new_registration
+    WasteCarriersEngine::NewRegistration.find_by(token: params[:token])
+  end
+end

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -20,10 +20,6 @@ module ActionLinksHelper
     ad_privacy_policy_path(reg_identifier: resource.reg_identifier)
   end
 
-  def display_details_link_for?(resource)
-    a_new_registration?(resource) || a_renewing_registration?(resource) || a_registration?(resource)
-  end
-
   def display_write_off_small_link_for?(resource)
     can?(:write_off_small, resource) && resource.balance != 0
   end

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/ModuleLength
 module ActionLinksHelper
   def details_link_for(resource)
     if a_new_registration?(resource)
@@ -137,4 +136,3 @@ module ActionLinksHelper
     resource.upper_tier? && can?(:view_payments, resource)
   end
 end
-# rubocop:enable Metrics/ModuleLength

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/ModuleLength
 module ActionLinksHelper
   def details_link_for(resource)
-    if a_transient_registration?(resource)
+    if a_new_registration?(resource)
+      new_registration_path(resource.token)
+    elsif a_renewing_registration?(resource)
       renewing_registration_path(resource.reg_identifier)
     elsif a_registration?(resource)
       registration_path(resource.reg_identifier)
@@ -18,7 +21,7 @@ module ActionLinksHelper
   end
 
   def display_details_link_for?(resource)
-    a_transient_registration?(resource) || a_registration?(resource)
+    a_new_registration?(resource) || a_renewing_registration?(resource) || a_registration?(resource)
   end
 
   def display_write_off_small_link_for?(resource)
@@ -30,7 +33,7 @@ module ActionLinksHelper
   end
 
   def display_resume_link_for?(resource)
-    return false unless display_transient_registration_links?(resource)
+    return false unless display_renewing_registration_links?(resource)
     return false if resource.renewal_application_submitted?
     return false if resource.workflow_state == "worldpay_form"
 
@@ -38,7 +41,7 @@ module ActionLinksHelper
   end
 
   def display_payment_link_for?(resource)
-    return can_view_payments?(resource) unless a_transient_registration?(resource)
+    return can_view_payments?(resource) unless a_renewing_registration?(resource)
 
     resource.renewal_application_submitted? && can_view_payments?(resource)
   end
@@ -51,7 +54,7 @@ module ActionLinksHelper
 
   def display_finance_details_link_for?(resource)
     return false unless resource.upper_tier? && resource.finance_details.present?
-    return true unless a_transient_registration?(resource)
+    return true unless a_renewing_registration?(resource)
 
     resource.renewal_application_submitted?
   end
@@ -107,8 +110,8 @@ module ActionLinksHelper
 
   private
 
-  def display_transient_registration_links?(resource)
-    a_transient_registration?(resource) && not_revoked_or_refused?(resource)
+  def display_renewing_registration_links?(resource)
+    a_renewing_registration?(resource) && not_revoked_or_refused?(resource)
   end
 
   def display_registration_links?(resource)
@@ -119,7 +122,11 @@ module ActionLinksHelper
     resource.is_a?(WasteCarriersEngine::Registration) || resource.is_a?(RegistrationPresenter)
   end
 
-  def a_transient_registration?(resource)
+  def a_new_registration?(resource)
+    resource.is_a?(NewRegistrationPresenter) || resource.is_a?(WasteCarriersEngine::NewRegistration)
+  end
+
+  def a_renewing_registration?(resource)
     resource.is_a?(RenewingRegistrationPresenter) || resource.is_a?(WasteCarriersEngine::RenewingRegistration)
   end
 
@@ -134,3 +141,4 @@ module ActionLinksHelper
     resource.upper_tier? && can?(:view_payments, resource)
   end
 end
+# rubocop:enable Metrics/ModuleLength

--- a/app/presenters/base_registration_presenter.rb
+++ b/app/presenters/base_registration_presenter.rb
@@ -95,6 +95,17 @@ class BaseRegistrationPresenter < WasteCarriersEngine::BasePresenter
     end
   end
 
+  def display_action_links_heading
+    text_path = ".shared.registrations.action_links_panel.actions_box.heading"
+    if reg_identifier.present?
+      I18n.t("#{text_path}.with_reg_identifier", reg_identifier: reg_identifier)
+    elsif company_name.present?
+      I18n.t("#{text_path}.with_company_name", company_name: company_name)
+    else
+      I18n.t("#{text_path}.without_company_name_or_reg_identifier")
+    end
+  end
+
   private
 
   def displayable_tier

--- a/app/presenters/base_registration_presenter.rb
+++ b/app/presenters/base_registration_presenter.rb
@@ -86,6 +86,7 @@ class BaseRegistrationPresenter < WasteCarriersEngine::BasePresenter
   end
 
   def display_expiry_text
+    return unless expires_on.present?
     return unless upper_tier?
 
     if expired?

--- a/app/presenters/base_registration_presenter.rb
+++ b/app/presenters/base_registration_presenter.rb
@@ -1,6 +1,19 @@
 # frozen_string_literal: true
 
 class BaseRegistrationPresenter < WasteCarriersEngine::BasePresenter
+  def display_company_details_panel?
+    return true if company_name.present?
+    return true if display_tier_and_registration_type.present?
+    return true if display_expiry_text.present?
+    return true if account_email.present?
+
+    false
+  end
+
+  def display_tier_and_registration_type
+    [displayable_tier, displayable_business_type].compact.join(" - ")
+  end
+
   def displayable_location
     location = show_translation_or_filler(:location)
 
@@ -65,6 +78,18 @@ class BaseRegistrationPresenter < WasteCarriersEngine::BasePresenter
   end
 
   private
+
+  def displayable_tier
+    return unless tier.present?
+
+    I18n.t(".shared.registrations.attributes.tier.#{tier.downcase}")
+  end
+
+  def displayable_business_type
+    return unless business_type.present?
+
+    I18n.t(".shared.registrations.attributes.business_type.#{business_type}")
+  end
 
   def show_translation_or_filler(attribute)
     if send(attribute).present?

--- a/app/presenters/base_registration_presenter.rb
+++ b/app/presenters/base_registration_presenter.rb
@@ -10,6 +10,24 @@ class BaseRegistrationPresenter < WasteCarriersEngine::BasePresenter
     false
   end
 
+  def display_contact_information_panel?
+    return true if first_name.present?
+    return true if phone_number.present?
+    return true if contact_email.present?
+    return true if contact_address.present?
+
+    false
+  end
+
+  def display_business_information_panel?
+    return true if company_name.present?
+    return true if company_no.present?
+    return true if registered_address.present?
+    return true if location.present?
+
+    false
+  end
+
   def display_tier_and_registration_type
     [displayable_tier, displayable_business_type].compact.join(" - ")
   end

--- a/app/presenters/base_registration_presenter.rb
+++ b/app/presenters/base_registration_presenter.rb
@@ -2,30 +2,24 @@
 
 class BaseRegistrationPresenter < WasteCarriersEngine::BasePresenter
   def display_company_details_panel?
-    return true if company_name.present?
-    return true if display_tier_and_registration_type.present?
-    return true if display_expiry_text.present?
-    return true if account_email.present?
-
-    false
+    company_name.present? ||
+      display_tier_and_registration_type.present? ||
+      display_expiry_text.present? ||
+      account_email.present?
   end
 
   def display_contact_information_panel?
-    return true if first_name.present?
-    return true if phone_number.present?
-    return true if contact_email.present?
-    return true if contact_address.present?
-
-    false
+    first_name.present? ||
+      phone_number.present? ||
+      contact_email.present? ||
+      contact_address.present?
   end
 
   def display_business_information_panel?
-    return true if company_name.present?
-    return true if company_no.present?
-    return true if registered_address.present?
-    return true if location.present?
-
-    false
+    company_name.present? ||
+      company_no.present? ||
+      registered_address.present? ||
+      location.present?
   end
 
   def display_tier_and_registration_type

--- a/app/presenters/new_registration_presenter.rb
+++ b/app/presenters/new_registration_presenter.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class NewRegistrationPresenter < BaseRegistrationPresenter
+  def display_current_workflow_state
+    "#{I18n.t('.new_registrations.show.status.messages.in_progress')} \"#{current_workflow_state}\""
+  end
+
+  private
+
+  def current_workflow_state
+    I18n.t("waste_carriers_engine.#{workflow_state}s.new.title", default: nil) ||
+      I18n.t("waste_carriers_engine.#{workflow_state}s.new.heading", default: nil) ||
+      workflow_state
+  end
+end

--- a/app/presenters/new_registration_presenter.rb
+++ b/app/presenters/new_registration_presenter.rb
@@ -1,6 +1,14 @@
 # frozen_string_literal: true
 
 class NewRegistrationPresenter < BaseRegistrationPresenter
+  def display_heading
+    if company_name.present?
+      I18n.t(".new_registrations.show.heading.with_company_name", company_name: company_name)
+    else
+      I18n.t(".new_registrations.show.heading.without_company_name")
+    end
+  end
+
   def display_current_workflow_state
     "#{I18n.t('.new_registrations.show.status.messages.in_progress')} \"#{current_workflow_state}\""
   end

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -102,17 +102,15 @@
               </td>
               <td>
                 <ul>
-                  <% if display_details_link_for?(result) %>
-                    <li>
-                      <%= link_to details_link_for(result) do %>
-                        <%= t(".results.actions.details.link_text") %>
-                        <span class="visually-hidden">
-                          <%= t(".results.actions.details.visually_hidden_text",
-                                name: result.company_name) %>
-                        </span>
-                      <% end %>
-                    </li>
-                  <% end %>
+                  <li>
+                    <%= link_to details_link_for(result) do %>
+                      <%= t(".results.actions.details.link_text") %>
+                      <span class="visually-hidden">
+                        <%= t(".results.actions.details.visually_hidden_text",
+                              name: result.company_name) %>
+                      </span>
+                    <% end %>
+                  </li>
                   <% if display_resume_link_for?(result) %>
                     <li>
                       <%= link_to resume_link_for(result) do %>

--- a/app/views/new_registrations/show.html.erb
+++ b/app/views/new_registrations/show.html.erb
@@ -8,6 +8,22 @@
           <%= t(".heading") %>
         </h1>
 
+        <div class="panel">
+          <h2 class="heading-medium">
+            <%= t(".status.headings.in_progress") %>
+          </h2>
+
+          <% if @transient_registration.workflow_state == "worldpay_form" %>
+            <p>
+              <%= t(".status.messages.worldpay.paragraph_1") %>
+            </p>
+          <% else %>
+            <p>
+              <%= @transient_registration.display_current_workflow_state %>
+            </p>
+          <% end %>
+        </div>
+
         <%= render "shared/registrations/company_details_panel", resource: @transient_registration %>
 
         <%= render "shared/registrations/contact_and_business_details_panels", resource: @transient_registration %>

--- a/app/views/new_registrations/show.html.erb
+++ b/app/views/new_registrations/show.html.erb
@@ -10,6 +10,15 @@
 
         <hr>
 
+        <h2 class="heading-medium"><%= t(".conviction_heading") %></h2>
+        <div>
+          <p>
+            <%= @transient_registration.display_convictions_check_message %>
+          </p>
+        </div>
+
+        <hr>
+
         <% if @transient_registration.main_people.any? %>
           <%= render "shared/registrations/main_people_details", resource: @transient_registration %>
         <% end %>

--- a/app/views/new_registrations/show.html.erb
+++ b/app/views/new_registrations/show.html.erb
@@ -1,0 +1,16 @@
+<div class="grid-row">
+  <div class="column-full">
+    <%= render("waste_carriers_engine/shared/back", back_path: bo_path) %>
+
+    <div class="grid-row">
+      <div class="column-two-thirds">
+        <h1 class="heading-large">
+          <%= t(".heading") %>
+        </h1>
+      </div>
+      <div class="column-one-third">
+        <%= render "shared/registrations/action_links_panel", resource: @transient_registration %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/new_registrations/show.html.erb
+++ b/app/views/new_registrations/show.html.erb
@@ -8,6 +8,8 @@
           <%= t(".heading") %>
         </h1>
 
+        <%= render "shared/registrations/contact_and_business_details_panels", resource: @transient_registration %>
+
         <hr>
 
         <h2 class="heading-medium"><%= t(".conviction_heading") %></h2>

--- a/app/views/new_registrations/show.html.erb
+++ b/app/views/new_registrations/show.html.erb
@@ -8,6 +8,8 @@
           <%= t(".heading") %>
         </h1>
 
+        <%= render "shared/registrations/company_details_panel", resource: @transient_registration %>
+
         <%= render "shared/registrations/contact_and_business_details_panels", resource: @transient_registration %>
 
         <hr>

--- a/app/views/new_registrations/show.html.erb
+++ b/app/views/new_registrations/show.html.erb
@@ -5,7 +5,7 @@
     <div class="grid-row">
       <div class="column-two-thirds">
         <h1 class="heading-large">
-          <%= t(".heading") %>
+          <%= @transient_registration.display_heading %>
         </h1>
 
         <div class="panel">

--- a/app/views/new_registrations/show.html.erb
+++ b/app/views/new_registrations/show.html.erb
@@ -7,6 +7,12 @@
         <h1 class="heading-large">
           <%= t(".heading") %>
         </h1>
+
+        <hr>
+
+        <% if @transient_registration.main_people.any? %>
+          <%= render "shared/registrations/main_people_details", resource: @transient_registration %>
+        <% end %>
       </div>
       <div class="column-one-third">
         <%= render "shared/registrations/action_links_panel", resource: @transient_registration %>

--- a/app/views/shared/registrations/_action_links_panel.html.erb
+++ b/app/views/shared/registrations/_action_links_panel.html.erb
@@ -1,6 +1,6 @@
 <div class="wcr-actions wcr-actions--push-down">
   <h2 class="heading-medium">
-    <%= t(".actions_box.heading", reg_identifier: resource.reg_identifier) %>
+    <%= resource.display_action_links_heading %>
   </h2>
   <ul>
     <!-- TODO: This `display_resume_link_for?` will need to be updated when we build NewRegistration -->

--- a/app/views/shared/registrations/_company_details_panel.html.erb
+++ b/app/views/shared/registrations/_company_details_panel.html.erb
@@ -1,20 +1,27 @@
 <div class="panel wcr-panel wcr-panel-border-all">
-  <h2 class="heading-medium">
-    <%= resource.company_name %>
-  </h2>
-  <p class="lede">
-    <%= t(".tier.#{resource.tier.downcase}") %>
-    <% if resource.registration_type.present? %>
-      - <%= t(".attributes.registration_type.#{resource.registration_type}") %>
+  <% if resource.display_company_details_panel? %>
+    <% if resource.company_name.present? %>
+      <h2 class="heading-medium">
+        <%= resource.company_name %>
+      </h2>
     <% end %>
-  </p>
-  <p>
-    <% if resource.display_expiry_text.present? %>
-      <%= resource.display_expiry_text %>
-      <br>
+    <% if resource.display_tier_and_registration_type.present? %>
+      <p class="lede">
+        <%= resource.display_tier_and_registration_type %>
+      </p>
     <% end %>
-    <% if resource.account_email.present? %>
-      <%= t(".labels.account", email: resource.account_email) %>
+    <% if resource.display_expiry_text.present? || resource.account_email.present? %>
+      <p>
+        <% if resource.display_expiry_text.present? %>
+          <%= resource.display_expiry_text %>
+          <br>
+        <% end %>
+        <% if resource.account_email.present? %>
+          <%= t(".labels.account", email: resource.account_email) %>
+        <% end %>
+      </p>
     <% end %>
-  </p>
+  <% else %>
+    <%= t(".no_company_details_available") %>
+  <% end %>
 </div>

--- a/app/views/shared/registrations/_contact_and_business_details_panels.html.erb
+++ b/app/views/shared/registrations/_contact_and_business_details_panels.html.erb
@@ -3,48 +3,56 @@
     <h2 class="heading-medium">
       <%= t(".contact_information.heading") %>
     </h2>
-    <p>
-      <%= resource.first_name %> <%= resource.last_name %>
-    </p>
-    <p>
-      <%= resource.phone_number %>
-    </p>
-    <p class="wcr-truncate-ellipsis">
-      <a href="mailto:<%= resource.contact_email %>" target="_top">
-        <%= resource.contact_email %>
-      </a>
-    </p>
-    <p>
-      <% if resource.contact_address.present? %>
-        <% displayable_address(resource.contact_address).each do |line| %>
-          <%= line %><br>
+    <% if resource.display_contact_information_panel? %>
+      <p>
+        <%= resource.first_name %> <%= resource.last_name %>
+      </p>
+      <p>
+        <%= resource.phone_number %>
+      </p>
+      <p class="wcr-truncate-ellipsis">
+        <a href="mailto:<%= resource.contact_email %>" target="_top">
+          <%= resource.contact_email %>
+        </a>
+      </p>
+      <p>
+        <% if resource.contact_address.present? %>
+          <% displayable_address(resource.contact_address).each do |line| %>
+            <%= line %><br>
+          <% end %>
         <% end %>
-      <% end %>
-    </p>
+      </p>
+    <% else %>
+      <p><%= t(".contact_information.no_contact_information_available") %></p>
+    <% end %>
   </div>
   <div class="column-one-half wcr-side-info-box">
     <h2 class="heading-medium">
       <%= t(".business_information.heading") %>
     </h2>
-    <p>
-      <%= resource.company_name %>
-    </p>
-    <% if resource.company_no.present? %>
+    <% if resource.display_business_information_panel? %>
       <p>
-        <%= t(".business_information.labels.company_no", number: resource.company_no) %>
+        <%= resource.company_name %>
       </p>
-    <% end %>
+      <% if resource.company_no.present? %>
+        <p>
+          <%= t(".business_information.labels.company_no", number: resource.company_no) %>
+        </p>
+      <% end %>
 
-    <% if resource.registered_address.present? %>
+      <% if resource.registered_address.present? %>
+        <p>
+          <%= t(".business_information.labels.registered_address") %> <br>
+          <% displayable_address(resource.registered_address).each do |line| %>
+            <%= line %><br>
+          <% end %>
+        </p>
+      <% end %>
       <p>
-        <%= t(".business_information.labels.registered_address") %> <br>
-        <% displayable_address(resource.registered_address).each do |line| %>
-          <%= line %><br>
-        <% end %>
+        <%= resource.displayable_location %>
       </p>
+    <% else %>
+      <p><%= t(".business_information.no_business_information_available") %></p>
     <% end %>
-    <p>
-      <%= resource.displayable_location %>
-    </p>
   </div>
 </div>

--- a/config/locales/new_registrations.en.yml
+++ b/config/locales/new_registrations.en.yml
@@ -2,7 +2,9 @@ en:
   new_registrations:
     show:
       title: "New registration details"
-      heading: "New registration [TODO]"
+      heading:
+        without_company_name: "New registration"
+        with_company_name: "New registration for %{company_name}"
       filler: "–"
       status:
         headings:

--- a/config/locales/new_registrations.en.yml
+++ b/config/locales/new_registrations.en.yml
@@ -18,17 +18,6 @@ en:
           business_conviction_search_result: "Matching convictions found for company?"
           people_conviction_search_result: "Matching convictions found for people?"
       attributes:
-        business_type:
-          soleTrader: "Individual or sole trader"
-          limitedCompany: "Limited company"
-          partnership: "Partnership"
-          limitedLiabilityPartnership: "Limited liability partnership"
-          localAuthority: "Local authority or public body"
-          charity: "Charity or trust"
-          authority: "Local authority"
-          publicBody: "Public body"
-          other: "Other"
-          overseas: "Overseas"
         declaration:
           "1": "Yes"
         key_people:

--- a/config/locales/new_registrations.en.yml
+++ b/config/locales/new_registrations.en.yml
@@ -9,6 +9,8 @@ en:
           in_progress: "Application in progress"
         messages:
           in_progress: "The current form is"
+          worldpay:
+            paragraph_1: "The user is currently attempting to pay by WorldPay."
       conviction_heading: "Convictions"
       conviction_link: "Conviction details"
       conviction_information:

--- a/config/locales/new_registrations.en.yml
+++ b/config/locales/new_registrations.en.yml
@@ -1,0 +1,41 @@
+en:
+  new_registrations:
+    show:
+      title: "New registration details"
+      heading: "New registration [TODO]"
+      filler: "–"
+      status:
+        headings:
+          in_progress: "Application in progress"
+        messages:
+          in_progress: "The current form is"
+      conviction_heading: "Convictions"
+      conviction_link: "Conviction details"
+      conviction_information:
+        heading: "Conviction overview"
+        labels:
+          declared_convictions: "Declared convictions?"
+          business_conviction_search_result: "Matching convictions found for company?"
+          people_conviction_search_result: "Matching convictions found for people?"
+      attributes:
+        business_type:
+          soleTrader: "Individual or sole trader"
+          limitedCompany: "Limited company"
+          partnership: "Partnership"
+          limitedLiabilityPartnership: "Limited liability partnership"
+          localAuthority: "Local authority or public body"
+          charity: "Charity or trust"
+          authority: "Local authority"
+          publicBody: "Public body"
+          other: "Other"
+          overseas: "Overseas"
+        declaration:
+          "1": "Yes"
+        key_people:
+          number_of_people_with_matching_convictions:
+            zero: "No"
+            one: "1 match found"
+            other: "%{count} matches found"
+        key_person:
+          conviction_search_result:
+            pending: "No data yet"

--- a/config/locales/registrations.en.yml
+++ b/config/locales/registrations.en.yml
@@ -35,17 +35,6 @@ en:
         labels:
           temp_cards: "Number of cards ordered"
       attributes:
-        business_type:
-          soleTrader: "Individual or sole trader"
-          limitedCompany: "Limited company"
-          partnership: "Partnership"
-          limitedLiabilityPartnership: "Limited liability partnership"
-          localAuthority: "Local authority or public body"
-          charity: "Charity or trust"
-          authority: "Local authority"
-          publicBody: "Public body"
-          other: "Other"
-          overseas: "Overseas"
         declaration:
           "1": "Yes"
         finance_details:

--- a/config/locales/renewing_registrations.en.yml
+++ b/config/locales/renewing_registrations.en.yml
@@ -31,17 +31,6 @@ en:
           business_conviction_search_result: "Matching convictions found for company?"
           people_conviction_search_result: "Matching convictions found for people?"
       attributes:
-        business_type:
-          soleTrader: "Individual or sole trader"
-          limitedCompany: "Limited company"
-          partnership: "Partnership"
-          limitedLiabilityPartnership: "Limited liability partnership"
-          localAuthority: "Local authority or public body"
-          charity: "Charity or trust"
-          authority: "Local authority"
-          publicBody: "Public body"
-          other: "Other"
-          overseas: "Overseas"
         declaration:
           "1": "Yes"
         finance_details:

--- a/config/locales/shared/registrations.en.yml
+++ b/config/locales/shared/registrations.en.yml
@@ -63,7 +63,10 @@ en:
         no_company_details_available: "This registration application is still in progress, so there are no company details yet."
       action_links_panel:
         actions_box:
-          heading: "Actions for %{reg_identifier}"
+          heading:
+            without_company_name_or_reg_identifier: "Actions"
+            with_reg_identifier: "Actions for %{reg_identifier}"
+            with_company_name: "Actions for %{company_name}"
           links:
             continue_button: "Continue as assisted digital"
             renew: "Renew"

--- a/config/locales/shared/registrations.en.yml
+++ b/config/locales/shared/registrations.en.yml
@@ -28,6 +28,7 @@ en:
             phone_number: "Contact phone"
             contact_email: "Contact email"
             contact_address: "Contact address"
+          no_contact_information_available: "This registration application is still in progress, so there are no contact details yet."
         business_information:
           heading: "Business information"
           labels:
@@ -36,6 +37,7 @@ en:
             company_no: "Company number: %{number}"
             location: "Place of business: %{location}"
             registered_address: "Registered address:"
+          no_business_information_available: "This registration application is still in progress, so there are no business details yet."
       pending_payment_panel:
         status:
           headings:

--- a/config/locales/shared/registrations.en.yml
+++ b/config/locales/shared/registrations.en.yml
@@ -51,9 +51,6 @@ en:
           messages:
             pending_convictions_check: "A convictions check is required before this registration can be approved."
       company_details_panel:
-        tier:
-          upper: Upper tier
-          lower: Lower tier
         labels:
           account: "Account: %{email}"
         attributes:
@@ -61,6 +58,7 @@ en:
             carrier_dealer: "Carrier and dealer"
             broker_dealer: "Broker and dealer"
             carrier_broker_dealer: "Carrier, broker and dealer"
+        no_company_details_available: "This registration application is still in progress, so there are no company details yet."
       action_links_panel:
         actions_box:
           heading: "Actions for %{reg_identifier}"
@@ -104,12 +102,26 @@ en:
       show:
         filler: "–"
       attributes:
+        business_type:
+          soleTrader: "Individual or sole trader"
+          limitedCompany: "Limited company"
+          partnership: "Partnership"
+          limitedLiabilityPartnership: "Limited liability partnership"
+          localAuthority: "Local authority or public body"
+          charity: "Charity or trust"
+          authority: "Local authority"
+          publicBody: "Public body"
+          other: "Other"
+          overseas: "Overseas"
         location:
           england: "England"
           wales: "Wales"
           scotland: "Scotland"
           northern_ireland: "Northern Ireland"
           overseas: "Not in the United Kingdom"
+        tier:
+          upper: Upper tier
+          lower: Lower tier
       business_information:
         labels:
           location: "Place of business: %{location}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -102,6 +102,11 @@ Rails.application.routes.draw do
                        path_names: { new: "" }
             end
 
+  resources :new_registrations,
+            only: :show,
+            param: :token,
+            path: "/bo/new-registrations"
+
   resources :renewing_registrations,
             only: :show,
             param: :reg_identifier,

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -119,40 +119,6 @@ RSpec.describe ActionLinksHelper, type: :helper do
     end
   end
 
-  describe "#display_details_link_for?" do
-    context "when the resource is a Registration" do
-      let(:resource) { build(:registration) }
-
-      it "returns true" do
-        expect(helper.display_details_link_for?(resource)).to eq(true)
-      end
-    end
-
-    context "when the resource is a RenewingRegistration" do
-      let(:resource) { build(:renewing_registration) }
-
-      it "returns true" do
-        expect(helper.display_details_link_for?(resource)).to eq(true)
-      end
-    end
-
-    context "when the resource is a NewRegistration" do
-      let(:resource) { build(:new_registration) }
-
-      it "returns true" do
-        expect(helper.display_details_link_for?(resource)).to eq(true)
-      end
-    end
-
-    context "when the resource is not a Registration, a RenewingRegistration or a NewRegistration" do
-      let(:resource) { double(:resource) }
-
-      it "returns false" do
-        expect(helper.display_details_link_for?(resource)).to eq(false)
-      end
-    end
-  end
-
   describe "#display_refund_link_for?" do
     let(:resource) { build(:finance_details, balance: balance) }
 

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -4,6 +4,14 @@ require "rails_helper"
 
 RSpec.describe ActionLinksHelper, type: :helper do
   describe "details_link_for" do
+    context "when the resource is a new registration" do
+      let(:resource) { build(:new_registration, token: "foo") }
+
+      it "returns the new registration path" do
+        expect(helper.details_link_for(resource)).to eq(new_registration_path(resource.token))
+      end
+    end
+
     context "when the resource is a renewing registration" do
       let(:resource) { build(:renewing_registration) }
 
@@ -120,19 +128,27 @@ RSpec.describe ActionLinksHelper, type: :helper do
       end
     end
 
-    context "when the resource is not a Registration or a RenewingRegistration" do
-      let(:resource) { double(:resource) }
-
-      it "returns false" do
-        expect(helper.display_details_link_for?(resource)).to eq(false)
-      end
-    end
-
     context "when the resource is a RenewingRegistration" do
       let(:resource) { build(:renewing_registration) }
 
       it "returns true" do
         expect(helper.display_details_link_for?(resource)).to eq(true)
+      end
+    end
+
+    context "when the resource is a NewRegistration" do
+      let(:resource) { build(:new_registration) }
+
+      it "returns true" do
+        expect(helper.display_details_link_for?(resource)).to eq(true)
+      end
+    end
+
+    context "when the resource is not a Registration, a RenewingRegistration or a NewRegistration" do
+      let(:resource) { double(:resource) }
+
+      it "returns false" do
+        expect(helper.display_details_link_for?(resource)).to eq(false)
       end
     end
   end

--- a/spec/presenters/base_registration_presenter_spec.rb
+++ b/spec/presenters/base_registration_presenter_spec.rb
@@ -304,13 +304,21 @@ RSpec.describe BaseRegistrationPresenter do
   describe "#display_expiry_text" do
     let(:upper_tier) { false }
     let(:expired) { false }
+    let(:expires_on) { nil }
     let(:registration) do
       double(
         :registration,
         expired?: expired,
         upper_tier?: upper_tier,
+        expires_on: expires_on,
         display_expiry_date: "1 January 2020"
       )
+    end
+
+    context "when the registration has no expiry date" do
+      it "returns nil" do
+        expect(subject.display_expiry_text).to eq(nil)
+      end
     end
 
     context "when the registration is not upper tier" do
@@ -319,7 +327,8 @@ RSpec.describe BaseRegistrationPresenter do
       end
     end
 
-    context "when the registration is upper tier" do
+    context "when the registration has an expiry date and is upper tier" do
+      let(:expires_on) { Date.new(2020, 1, 1) }
       let(:upper_tier) { true }
 
       context "when it is not expired" do

--- a/spec/presenters/base_registration_presenter_spec.rb
+++ b/spec/presenters/base_registration_presenter_spec.rb
@@ -350,4 +350,42 @@ RSpec.describe BaseRegistrationPresenter do
       end
     end
   end
+
+  describe "#display_action_links_heading" do
+    let(:reg_identifier) { nil }
+    let(:company_name) { nil }
+    let(:registration) do
+      double(:registration,
+             reg_identifier: reg_identifier,
+             company_name: company_name)
+    end
+
+    context "when there is a reg_identifier" do
+      let(:reg_identifier) { "CBDU1234" }
+
+      it "returns a heading with the name" do
+        result = subject.display_action_links_heading
+
+        expect(result).to eq("Actions for CBDU1234")
+      end
+    end
+
+    context "when there is a company_name" do
+      let(:company_name) { "Foo" }
+
+      it "returns a heading with the name" do
+        result = subject.display_action_links_heading
+
+        expect(result).to eq("Actions for Foo")
+      end
+    end
+
+    context "when there is no company_name or reg_identifier" do
+      it "returns a heading without a name or reg_identifier" do
+        result = subject.display_action_links_heading
+
+        expect(result).to eq("Actions")
+      end
+    end
+  end
 end

--- a/spec/presenters/new_registration_presenter_spec.rb
+++ b/spec/presenters/new_registration_presenter_spec.rb
@@ -7,6 +7,30 @@ RSpec.describe NewRegistrationPresenter do
   let(:view_context) { double(:view_context) }
   subject { described_class.new(new_registration, view_context) }
 
+  describe "#display_heading" do
+    let(:new_registration) { double(:new_registration, company_name: company_name) }
+
+    context "when there is a company_name" do
+      let(:company_name) { "Foo" }
+
+      it "returns a heading with the name" do
+        result = subject.display_heading
+
+        expect(result).to eq("New registration for Foo")
+      end
+    end
+
+    context "when there is no company_name" do
+      let(:company_name) { nil }
+
+      it "returns a heading without a name" do
+        result = subject.display_heading
+
+        expect(result).to eq("New registration")
+      end
+    end
+  end
+
   describe "#display_current_workflow_state" do
     let(:workflow_state) { "a_workflow_state" }
     let(:new_registration) { double(:new_registration, workflow_state: workflow_state) }

--- a/spec/presenters/new_registration_presenter_spec.rb
+++ b/spec/presenters/new_registration_presenter_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe NewRegistrationPresenter do
+  let(:new_registration) { double(:new_registration) }
+  let(:view_context) { double(:view_context) }
+  subject { described_class.new(new_registration, view_context) }
+
+  describe "#display_current_workflow_state" do
+    let(:workflow_state) { "a_workflow_state" }
+    let(:new_registration) { double(:new_registration, workflow_state: workflow_state) }
+
+    it "returns a displayable current workflow state string" do
+      result = subject.display_current_workflow_state
+
+      expect(result).to eq('The current form is "a_workflow_state"')
+    end
+  end
+end

--- a/spec/requests/new_registrations_spec.rb
+++ b/spec/requests/new_registrations_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "NewRegistrations", type: :request do
+  let(:transient_registration) { create(:new_registration, workflow_state: "check_your_tier_form") }
+
+  describe "/bo/new-registrations/:token" do
+    context "when a valid user is signed in" do
+      let(:user) { create(:user) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      it "renders the index template" do
+        get "/bo/new-registrations/#{transient_registration.token}"
+        expect(response).to render_template(:show)
+      end
+
+      it "returns a 200 response" do
+        get "/bo/new-registrations/#{transient_registration.token}"
+        expect(response).to have_http_status(200)
+      end
+
+      context "when no matching transient_registration exists" do
+        it "redirects to the dashboard" do
+          get "/bo/new-registrations/foo"
+
+          expect(response).to redirect_to(bo_path)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1054

We want NCCC staff to be able to access details of a new in-progress registration, as they can with renewals.

This PR sets up a version of the 'view details' page for in-progress registrations. This page should be linked to in the relevant search results.

We also don't want to include any finance info on this page.