### PR TITLE
Add link to re-send a renewal reminder email

### DIFF
--- a/app/controllers/resend_renewal_email_controller.rb
+++ b/app/controllers/resend_renewal_email_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class ResendRenewalEmailController < ApplicationController
+  before_action :authenticate_user!
+
+  def new
+    begin
+      RenewalReminderMailer.second_reminder_email(registration).deliver_now
+
+      flash[:success] = I18n.t("resend_renewal_email.messages.success", email: registration.contact_email)
+    rescue StandardError => e
+      Airbrake.notify e, registration: registration.reg_identifier
+      Rails.logger.error "Failed to send renewal email for registration #{registration.reg_identifier}"
+
+      flash[:message] = I18n.t("resend_renewal_email.messages.failure", email: registration.contact_email)
+    end
+
+    redirect_to :back
+  end
+
+  private
+
+  def registration
+    @_registration ||= WasteCarriersEngine::Registration.find_by(reg_identifier: params[:reg_identifier])
+  end
+
+  def authenticate_user!
+    authorize! :renew, WasteCarriersEngine::Registration
+  end
+end

--- a/app/views/shared/registrations/_action_links_panel.html.erb
+++ b/app/views/shared/registrations/_action_links_panel.html.erb
@@ -14,6 +14,9 @@
       <li>
         <%= link_to t(".actions_box.links.renew"), renew_link_for(resource) %>
       </li>
+      <li>
+        <%= link_to t(".actions_box.links.resend_renewal_email"), resend_renewal_email_path(reg_identifier: resource.reg_identifier) %>
+      </li>
     <% end %>
 
     <% if display_transfer_link_for?(resource) %>

--- a/config/locales/resend_renewal_email.en.yml
+++ b/config/locales/resend_renewal_email.en.yml
@@ -1,0 +1,5 @@
+en:
+  resend_renewal_email:
+    messages:
+      success: Renewal email sent to %{email}
+      failure: We could not send an email to %{email}

--- a/config/locales/shared/registrations.en.yml
+++ b/config/locales/shared/registrations.en.yml
@@ -65,6 +65,7 @@ en:
         actions_box:
           heading: "Actions for %{reg_identifier}"
           links:
+            resend_renewal_email: "Resend renewal email"
             continue_button: "Continue as assisted digital"
             renew: "Renew"
             transfer: "Transfer to another account"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,10 @@ Rails.application.routes.draw do
       resources :registrations, only: %i[show create]
       resources :renewals, only: :show
     end
+
+    get "/resend-renewal-email/:reg_identifier",
+      to: "resend_renewal_email#new",
+      as: "resend_renewal_email"
   end
 
   devise_for :users,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,9 +15,7 @@ Rails.application.routes.draw do
       resources :renewals, only: :show
     end
 
-    get "/resend-renewal-email/:reg_identifier",
-      to: "resend_renewal_email#new",
-      as: "resend_renewal_email"
+    get "/resend-renewal-email/:reg_identifier", to: "resend_renewal_email#new", as: "resend_renewal_email"
   end
 
   devise_for :users,

--- a/spec/requests/resend_renewal_email_spec.rb
+++ b/spec/requests/resend_renewal_email_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "ResendRenewalEmail", type: :request do
+  describe "GET /bo/resend-renewal-email/:reg_identifier" do
+    let(:registration) { create(:registration, :expires_soon) }
+    let(:request_path) { "/bo/resend-renewal-email/#{registration.reg_identifier}" }
+
+    context "when a finance user is signed in" do
+      let(:user) { create(:user, :finance) }
+      before { sign_in(user) }
+
+      it "redirects to permission page" do
+        get request_path, {}, "HTTP_REFERER" => "/"
+
+        expect(response).to redirect_to("/bo/pages/permission")
+      end
+    end
+
+    context "when an agency user is signed in" do
+      let(:user) { create(:user, :agency) }
+      before { sign_in(user) }
+
+      it "sends an email and redirects to the previous page" do
+        expected_count = ActionMailer::Base.deliveries.count + 1
+
+        get request_path, {}, "HTTP_REFERER" => "/"
+
+        expect(ActionMailer::Base.deliveries.count).to eq(expected_count)
+        expect(response).to redirect_to("/")
+      end
+
+      context "when an error happens", disable_bullet: true do
+        before do
+          expect(RenewalReminderMailer).to receive(:second_reminder_email).and_raise(StandardError)
+        end
+
+        it "does not sends an email and redirects to the previous page" do
+          expected_count = ActionMailer::Base.deliveries.count
+
+          get request_path, {}, "HTTP_REFERER" => "/"
+
+          expect(ActionMailer::Base.deliveries.count).to eq(expected_count)
+          expect(response).to redirect_to("/")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
From: 	https://eaflood.atlassian.net/browse/RUBY-1046

This send a renewal reminder email to the user using a button in the registration details page.
Given that the first email reminder will always generate a new renew token, but we don't want to generate a new token if present when we send again a renewal email, and given that the second renewa email has the same template as the first but deals with the creation of the renewal link as needed here, we are using the second renewal email when sending via back office link.

<details>
<summary>Flash messages screenshots</summary>
<img width="1043" alt="Screenshot 2020-05-26 at 13 07 05" src="https://user-images.githubusercontent.com/1385397/82899229-86726500-9f52-11ea-99ce-e2b0d146f3a1.png">
<img width="1109" alt="Screenshot 2020-05-26 at 13 08 03" src="https://user-images.githubusercontent.com/1385397/82899235-8a05ec00-9f52-11ea-95f1-efe0b9666619.png">

</details>