### PR TITLE
Fix bug in ordering mixed resources

### DIFF
--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -20,7 +20,9 @@ class SearchService < ::WasteCarriersEngine::BaseService
   end
 
   def search_results
-    @_search_results ||= matching_resources.sort_by(&:reg_identifier)
+    @_search_results ||= matching_resources.sort_by do |resource|
+      resource.reg_identifier || ""
+    end
   end
 
   def matching_resources

--- a/spec/services/search_service_spec.rb
+++ b/spec/services/search_service_spec.rb
@@ -25,6 +25,18 @@ RSpec.describe SearchService do
     end
     let(:matching_registration) { WasteCarriersEngine::Registration.where(reg_identifier: matching_renewal.reg_identifier).first }
 
+    context "when there are results in different collections" do
+      let(:term) { "search for me" }
+
+      it "returns aggregated results from the different collections" do
+        matching_renewal = create(:renewing_registration, company_name: term)
+        matching_new_registration = create(:new_registration, company_name: term)
+
+        expect(service[:results]).to include(matching_renewal)
+        expect(service[:results]).to include(matching_new_registration)
+      end
+    end
+
     context "when there is a match on a reg_identifier" do
       let(:term) { matching_renewal.reg_identifier }
 


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-1053

Fix bug on ordering different resources. It was using the value of `reg_identifier`, but when dealing with in-progress new registration that value is setted to `nil`.