### PR TITLE
Add resume link for in progress new registrations

### DIFF
--- a/app/controllers/ad_privacy_policy_controller.rb
+++ b/app/controllers/ad_privacy_policy_controller.rb
@@ -5,5 +5,8 @@ class AdPrivacyPolicyController < ApplicationController
 
   def show
     @reg_identifier = params[:reg_identifier]
+
+    @token = params[:token]
+    @transient_registration = WasteCarriersEngine::TransientRegistration.where(token: @token).first if @token.present?
   end
 end

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -12,6 +12,8 @@ module ActionLinksHelper
   end
 
   def resume_link_for(resource)
+    return ad_privacy_policy_path(token: resource.token) if a_new_registration?(resource)
+
     ad_privacy_policy_path(reg_identifier: resource.reg_identifier)
   end
 
@@ -28,6 +30,7 @@ module ActionLinksHelper
   end
 
   def display_resume_link_for?(resource)
+    return true if a_new_registration?(resource)
     return false unless display_renewing_registration_links?(resource)
     return false if resource.renewal_application_submitted?
     return false if resource.workflow_state == "worldpay_form"
@@ -48,6 +51,7 @@ module ActionLinksHelper
   end
 
   def display_finance_details_link_for?(resource)
+    return false if a_new_registration?(resource)
     return false unless resource.upper_tier? && resource.finance_details.present?
     return true unless a_renewing_registration?(resource)
 

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/ModuleLength
 module ActionLinksHelper
   def details_link_for(resource)
     if a_new_registration?(resource)
@@ -140,3 +141,4 @@ module ActionLinksHelper
     resource.upper_tier? && can?(:view_payments, resource)
   end
 end
+# rubocop:enable Metrics/ModuleLength

--- a/app/helpers/waste_carriers_engine/ad_privacy_policy_helper.rb
+++ b/app/helpers/waste_carriers_engine/ad_privacy_policy_helper.rb
@@ -5,9 +5,18 @@ module WasteCarriersEngine
     def destination_path
       if @reg_identifier.present?
         WasteCarriersEngine::Engine.routes.url_helpers.new_renewal_start_form_path(token: @reg_identifier)
+      elsif @transient_registration.present?
+        resume_path_for(@transient_registration)
       else
         WasteCarriersEngine::Engine.routes.url_helpers.new_start_form_path
       end
+    end
+
+    def resume_path_for(transient_registration)
+      WasteCarriersEngine::Engine.routes.url_helpers.send(
+        "new_#{transient_registration.workflow_state}_path".to_sym,
+        token: transient_registration.token
+      )
     end
   end
 end

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -100,7 +100,15 @@ RSpec.describe ActionLinksHelper, type: :helper do
   end
 
   describe "resume_link_for" do
-    context "when the resource is a transient_registration" do
+    context "when the resource is a new_registration" do
+      let(:resource) { build(:new_registration) }
+
+      it "returns the correct path" do
+        expect(helper.resume_link_for(resource)).to eq(ad_privacy_policy_path(token: resource.token))
+      end
+    end
+
+    context "when the resource is a renewing_registration" do
       let(:resource) { build(:renewing_registration) }
 
       it "returns the correct path" do
@@ -160,6 +168,14 @@ RSpec.describe ActionLinksHelper, type: :helper do
   end
 
   describe "#display_resume_link_for?" do
+    context "when the resource is a NewRegistration" do
+      let(:resource) { build(:new_registration) }
+
+      it "returns true" do
+        expect(helper.display_resume_link_for?(resource)).to eq(true)
+      end
+    end
+
     context "when the resource is not a RenewingRegistration" do
       let(:resource) { build(:registration) }
 
@@ -537,6 +553,14 @@ RSpec.describe ActionLinksHelper, type: :helper do
     before do
       allow(resource).to receive(:upper_tier?).and_return(upper_tier)
       allow(resource).to receive(:finance_details).and_return(finance_details)
+    end
+
+    context "when the resource is a new registration" do
+      let(:resource) { build(:new_registration) }
+
+      it "returns false" do
+        expect(helper.display_finance_details_link_for?(resource)).to be_falsey
+      end
     end
 
     context "when the resource is a renewing registration" do

--- a/spec/helpers/waste_carriers_engine/ad_privacy_policy_helper_spec.rb
+++ b/spec/helpers/waste_carriers_engine/ad_privacy_policy_helper_spec.rb
@@ -18,6 +18,15 @@ module WasteCarriersEngine
           expect(helper.destination_path).to eq("/bo/start")
         end
       end
+
+      context "when a transient registration has been defined in the controller" do
+        it "returns a resume link for the given transient resource" do
+          transient_registration = build(:new_registration, workflow_state: "business_type_form", token: "token")
+          assign(:transient_registration, transient_registration)
+
+          expect(helper.destination_path).to eq("/bo/token/business-type")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-1055

This also hides the finance details link for new registration details in all cases.