### PR TITLE
Add rake task to remove old transient_registrations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,3 +59,6 @@ EXPIRE_REGISTRATION_EXEMPTION_RUN_TIME=
 # numbers entered for limited or LLP organisations. To do this it will need
 # a valid companies house API key
 WCRS_COMPANIES_HOUSE_API_KEY=longvaluefullofnumbersandlettersinlowercase
+
+# Database cleanup config
+MAX_TRANSIENT_REGISTRATION_AGE_DAYS=30

--- a/.env.example
+++ b/.env.example
@@ -62,3 +62,4 @@ WCRS_COMPANIES_HOUSE_API_KEY=longvaluefullofnumbersandlettersinlowercase
 
 # Database cleanup config
 MAX_TRANSIENT_REGISTRATION_AGE_DAYS=30
+CLEANUP_TRANSIENT_REGISTRATIONS_RUN_TIME="00:35"

--- a/app/services/transient_registration_cleanup_service.rb
+++ b/app/services/transient_registration_cleanup_service.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class TransientRegistrationCleanupService < ::WasteCarriersEngine::BaseService
+  def run
+    transient_registrations_to_remove.destroy_all
+  end
+
+  private
+
+  # TransientRegistrations where the last_modified date is earlier than the oldest possible date
+  def transient_registrations_to_remove
+    WasteCarriersEngine::TransientRegistration.where("metaData.lastModified" => { "$lt" => oldest_possible_date })
+  end
+
+  def oldest_possible_date
+    max = Rails.configuration.max_transient_registration_age_days
+    max.days.ago
+  end
+end

--- a/app/services/transient_registration_cleanup_service.rb
+++ b/app/services/transient_registration_cleanup_service.rb
@@ -11,7 +11,7 @@ class TransientRegistrationCleanupService < ::WasteCarriersEngine::BaseService
   # renewals which have already been submitted
   def transient_registrations_to_remove
     WasteCarriersEngine::TransientRegistration.where(
-      "metaData.lastModified" => { "$lt" => oldest_possible_date },
+      "created_at" => { "$lt" => oldest_possible_date },
       "workflow_state" => { "$nin" => WasteCarriersEngine::RenewingRegistration::SUBMITTED_STATES }
     )
   end

--- a/app/services/transient_registration_cleanup_service.rb
+++ b/app/services/transient_registration_cleanup_service.rb
@@ -7,9 +7,13 @@ class TransientRegistrationCleanupService < ::WasteCarriersEngine::BaseService
 
   private
 
-  # TransientRegistrations where the last_modified date is earlier than the oldest possible date
+  # Remove any transient_registrations older than the cutoff, unless they are
+  # renewals which have already been submitted
   def transient_registrations_to_remove
-    WasteCarriersEngine::TransientRegistration.where("metaData.lastModified" => { "$lt" => oldest_possible_date })
+    WasteCarriersEngine::TransientRegistration.where(
+      "metaData.lastModified" => { "$lt" => oldest_possible_date },
+      "workflow_state" => { "$nin" => WasteCarriersEngine::RenewingRegistration::SUBMITTED_STATES }
+    )
   end
 
   def oldest_possible_date

--- a/config/application.rb
+++ b/config/application.rb
@@ -115,6 +115,9 @@ module WasteCarriersBackOffice
     # Digital or assisted digital metaData.route value
     config.metadata_route = "ASSISTED_DIGITAL"
 
+    # Database cleanup
+    config.max_transient_registration_age_days = ENV["MAX_TRANSIENT_REGISTRATION_AGE_DAYS"] || 30
+
     # Version info
     config.application_version = "0.0.1"
     config.application_name = "waste-carriers-back-office"

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -48,3 +48,9 @@ end
 every :day, at: (ENV["EXPIRE_REGISTRATION_EXEMPTION_RUN_TIME"] || "20:00"), roles: [:db] do
   rake "expire_registration:run"
 end
+
+# This is the transient registration cleanup job which will delete all records
+# that are too old
+every :day, at: (ENV["CLEANUP_TRANSIENT_REGISTRATIONS_RUN_TIME"] || "00:35"), roles: [:db] do
+  rake "cleanup:transient_registrations"
+end

--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+namespace :cleanup do
+  desc "Remove old transient_registrations from the database"
+  task test: :transient_registrations do
+    TransientRegistrationCleanupService.run
+
+    Airbrake.close
+  end
+end

--- a/spec/schedule_spec.rb
+++ b/spec/schedule_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Whenever schedule" do
 
   it "makes sure 'rake' statements exist" do
     rake_jobs = schedule.jobs[:rake]
-    expect(rake_jobs.count).to eq(5)
+    expect(rake_jobs.count).to eq(6)
   end
 
   it "picks up the EPR export run frequency and time" do
@@ -51,5 +51,12 @@ RSpec.describe "Whenever schedule" do
 
     expect(job_details[:every][0]).to eq(:day)
     expect(job_details[:every][1][:at]).to eq("20:00")
+  end
+
+  it "takes the transient registration cleanup execution time from the appropriate ENV variable" do
+    job_details = schedule.jobs[:rake].find { |h| h[:task] == "cleanup:transient_registrations" }
+
+    expect(job_details[:every][0]).to eq(:day)
+    expect(job_details[:every][1][:at]).to eq("00:35")
   end
 end

--- a/spec/services/transient_registration_cleanup_service_spec.rb
+++ b/spec/services/transient_registration_cleanup_service_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TransientRegistrationCleanupService do
+  describe ".run" do
+    let(:transient_registration) { create(:new_registration) }
+    let(:token) { transient_registration.token }
+
+    context "when a transient_registration has not been modified in more than 30 days" do
+      before do
+        transient_registration.metaData.update_attributes!(last_modified: Time.now - 31.days)
+      end
+
+      it "deletes it" do
+        expect { described_class.run }.to change { WasteCarriersEngine::TransientRegistration.where(token: token).count }.from(1).to(0)
+      end
+    end
+
+    context "when a transient_registration has been modified in the last 30 days" do
+      it "does not delete it" do
+        expect { described_class.run }.to_not change { WasteCarriersEngine::TransientRegistration.where(token: token).count }.from(1)
+      end
+    end
+  end
+end

--- a/spec/services/transient_registration_cleanup_service_spec.rb
+++ b/spec/services/transient_registration_cleanup_service_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe TransientRegistrationCleanupService do
     let(:transient_registration) { create(:new_registration) }
     let(:token) { transient_registration.token }
 
-    context "when a transient_registration has not been modified in more than 30 days" do
+    context "when a transient_registration was created more than 30 days ago" do
       before do
-        transient_registration.metaData.update_attributes!(last_modified: Time.now - 31.days)
+        transient_registration.update_attributes!(created_at: Time.now - 31.days)
       end
 
       it "deletes it" do
@@ -25,7 +25,7 @@ RSpec.describe TransientRegistrationCleanupService do
       end
     end
 
-    context "when a transient_registration has been modified in the last 30 days" do
+    context "when a transient_registration was created within the last 30 days" do
       it "does not delete it" do
         expect { described_class.run }.to_not change { WasteCarriersEngine::TransientRegistration.where(token: token).count }.from(1)
       end

--- a/spec/services/transient_registration_cleanup_service_spec.rb
+++ b/spec/services/transient_registration_cleanup_service_spec.rb
@@ -15,6 +15,14 @@ RSpec.describe TransientRegistrationCleanupService do
       it "deletes it" do
         expect { described_class.run }.to change { WasteCarriersEngine::TransientRegistration.where(token: token).count }.from(1).to(0)
       end
+
+      context "when the transient_registration is a submitted renewal" do
+        let(:transient_registration) { create(:renewing_registration, workflow_state: "renewal_received_pending_payment_form") }
+
+        it "does not delete it" do
+          expect { described_class.run }.to_not change { WasteCarriersEngine::TransientRegistration.where(token: token).count }.from(1)
+        end
+      end
     end
 
     context "when a transient_registration has been modified in the last 30 days" do


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-10

We've agreed that we shouldn't store transient_registrations for more than 30 days. So we need a way of clearing out the old ones.

This rake task will find and remove transient_registrations that are older than 30 days. It should also remove all related objects (eg transient_addresses).