### PR TITLE
Remove older transient_registrations with no created_at

### DIFF
--- a/app/services/transient_registration_cleanup_service.rb
+++ b/app/services/transient_registration_cleanup_service.rb
@@ -3,6 +3,7 @@
 class TransientRegistrationCleanupService < ::WasteCarriersEngine::BaseService
   def run
     transient_registrations_to_remove.destroy_all
+    no_created_at_transient_registrations_to_remove.destroy_all
   end
 
   private
@@ -12,6 +13,16 @@ class TransientRegistrationCleanupService < ::WasteCarriersEngine::BaseService
   def transient_registrations_to_remove
     WasteCarriersEngine::TransientRegistration.where(
       "created_at" => { "$lt" => oldest_possible_date },
+      "workflow_state" => { "$nin" => WasteCarriersEngine::RenewingRegistration::SUBMITTED_STATES }
+    )
+  end
+
+  # Older transient_registrations may not have a created_at attribute. When
+  # this is the case, we go off the value of last_modified instead.
+  def no_created_at_transient_registrations_to_remove
+    WasteCarriersEngine::TransientRegistration.where(
+      "created_at" => nil,
+      "metaData.lastModified" => { "$lt" => oldest_possible_date },
       "workflow_state" => { "$nin" => WasteCarriersEngine::RenewingRegistration::SUBMITTED_STATES }
     )
   end

--- a/spec/services/transient_registration_cleanup_service_spec.rb
+++ b/spec/services/transient_registration_cleanup_service_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe TransientRegistrationCleanupService do
 
     context "when a transient_registration was created more than 30 days ago" do
       before do
-        transient_registration.update_attributes!(created_at: Time.now - 31.days)
+        transient_registration.update_attributes(created_at: Time.now - 31.days)
       end
 
       it "deletes it" do
@@ -23,11 +23,55 @@ RSpec.describe TransientRegistrationCleanupService do
           expect { described_class.run }.to_not change { WasteCarriersEngine::TransientRegistration.where(token: token).count }.from(1)
         end
       end
+
+      context "when the transient_registration was last modified within the last 30 days" do
+        before do
+          transient_registration.metaData.set(last_modified: Time.now - 31.days)
+        end
+
+        it "deletes it" do
+          expect { described_class.run }.to change { WasteCarriersEngine::TransientRegistration.where(token: token).count }.from(1).to(0)
+        end
+      end
     end
 
     context "when a transient_registration was created within the last 30 days" do
       it "does not delete it" do
         expect { described_class.run }.to_not change { WasteCarriersEngine::TransientRegistration.where(token: token).count }.from(1)
+      end
+    end
+
+    context "when a transient_registration has no created_at" do
+      before do
+        transient_registration.unset(:created_at)
+      end
+
+      context "when a transient_registration was last modified more than 30 days ago" do
+        before do
+          transient_registration.metaData.set(last_modified: Time.now - 31.days)
+        end
+
+        it "deletes it" do
+          expect { described_class.run }.to change { WasteCarriersEngine::TransientRegistration.where(token: token).count }.from(1).to(0)
+        end
+
+        context "when the transient_registration is a submitted renewal" do
+          let(:transient_registration) { create(:renewing_registration, workflow_state: "renewal_received_pending_payment_form") }
+
+          it "does not delete it" do
+            expect { described_class.run }.to_not change { WasteCarriersEngine::TransientRegistration.where(token: token).count }.from(1)
+          end
+        end
+      end
+
+      context "when a transient_registration was last modified within the last 30 days" do
+        before do
+          transient_registration.metaData.set(last_modified: Time.now - 1.days)
+        end
+
+        it "does not delete it" do
+          expect { described_class.run }.to_not change { WasteCarriersEngine::TransientRegistration.where(token: token).count }.from(1)
+        end
       end
     end
   end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-10

When I first wrote this service in https://github.com/DEFRA/waste-carriers-back-office/pull/886 I was planning to deal with the older transient_registrations that don't have a `created_at` value set by just having a one-off script to clean them out.

However, on further thinking, phasing them out will likely be a more gradual process. So it makes more sense to build it into this scheduled task instead.

The added code will find any transient_registrations which don't have a `created_at` and are not submitted renewals, and then delete them based on their `last_modified` date.