### PR TITLE
Add frame-ancestors settings to CSP

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -31,12 +31,14 @@ SecureHeaders::Configuration.default do |config|
   # The following were used for reference
   # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src
   # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/font-src
+  # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors
   #
   # We have to use single quotes here, even though it's against style - double doesn't work
   # rubocop:disable Lint/PercentStringArray
   config.csp = {
     default_src: %w['self'],
     font_src: %w['self' data:],
+    frame_ancestors: %w['none'],
     img_src: %w['self' www.google-analytics.com],
     object_src: %w['self'],
     script_src: %w['self' 'unsafe-inline' www.googletagmanager.com www.google-analytics.com],


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1067

We do not want potential attackers to be able to embed our service on other websites, for example in an iframe. So this PR updates our content security policy's frame ancestors setting to block this.

For more info, see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors