### PR TITLE
Don't display resume link for new regs unless users have permission

### DIFF
--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -31,12 +31,13 @@ module ActionLinksHelper
   end
 
   def display_resume_link_for?(resource)
-    return true if a_new_registration?(resource)
-    return false unless display_renewing_registration_links?(resource)
-    return false if resource.renewal_application_submitted?
-    return false if resource.workflow_state == "worldpay_form"
-
-    can?(:renew, resource)
+    if a_new_registration?(resource)
+      display_resume_link_for_new_registration?
+    elsif a_renewing_registration?(resource)
+      display_resume_link_for_renewal?(resource)
+    else
+      false
+    end
   end
 
   def display_payment_link_for?(resource)
@@ -139,6 +140,18 @@ module ActionLinksHelper
 
   def can_view_payments?(resource)
     resource.upper_tier? && can?(:view_payments, resource)
+  end
+
+  def display_resume_link_for_new_registration?
+    can?(:create, WasteCarriersEngine::Registration)
+  end
+
+  def display_resume_link_for_renewal?(resource)
+    return false unless display_renewing_registration_links?(resource)
+    return false if resource.renewal_application_submitted?
+    return false if resource.workflow_state == "worldpay_form"
+
+    can?(:renew, resource)
   end
 end
 # rubocop:enable Metrics/ModuleLength

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -171,16 +171,20 @@ RSpec.describe ActionLinksHelper, type: :helper do
     context "when the resource is a NewRegistration" do
       let(:resource) { build(:new_registration) }
 
-      it "returns true" do
-        expect(helper.display_resume_link_for?(resource)).to eq(true)
+      context "when the user does not have permission" do
+        before { allow(helper).to receive(:can?).and_return(false) }
+
+        it "returns false" do
+          expect(helper.display_resume_link_for?(resource)).to eq(false)
+        end
       end
-    end
 
-    context "when the resource is not a RenewingRegistration" do
-      let(:resource) { build(:registration) }
+      context "when the user has permission" do
+        before { allow(helper).to receive(:can?).and_return(true) }
 
-      it "returns false" do
-        expect(helper.display_resume_link_for?(resource)).to eq(false)
+        it "returns true" do
+          expect(helper.display_resume_link_for?(resource)).to eq(true)
+        end
       end
     end
 
@@ -229,6 +233,14 @@ RSpec.describe ActionLinksHelper, type: :helper do
             expect(helper.display_resume_link_for?(resource)).to eq(true)
           end
         end
+      end
+    end
+
+    context "when the resource is not a NewRegistration or a RenewingRegistration" do
+      let(:resource) { build(:registration) }
+
+      it "returns false" do
+        expect(helper.display_resume_link_for?(resource)).to eq(false)
       end
     end
   end

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe ActionLinksHelper, type: :helper do
     let(:resource) { double(:resource, balance: balance) }
 
     before do
-      allow(helper).to receive(:can?).and_return(can)
+      allow(helper).to receive(:can?).with(:write_off_small, resource).and_return(can)
     end
 
     context "when the user has permission to write off small" do
@@ -69,10 +69,10 @@ RSpec.describe ActionLinksHelper, type: :helper do
     let(:resource) { double(:resource, balance: balance) }
 
     before do
-      allow(helper).to receive(:can?).and_return(can)
+      allow(helper).to receive(:can?).with(:write_off_large, resource).and_return(can)
     end
 
-    context "when the user has permission to write off small" do
+    context "when the user has permission to write off large" do
       let(:can) { true }
 
       context "when the balance is equal to 0" do
@@ -90,7 +90,7 @@ RSpec.describe ActionLinksHelper, type: :helper do
       end
     end
 
-    context "when the user does not have permissions to write off small" do
+    context "when the user does not have permissions to write off large" do
       let(:can) { false }
 
       it "returns false" do
@@ -172,7 +172,7 @@ RSpec.describe ActionLinksHelper, type: :helper do
       let(:resource) { build(:new_registration) }
 
       context "when the user does not have permission" do
-        before { allow(helper).to receive(:can?).and_return(false) }
+        before { allow(helper).to receive(:can?).with(:create, WasteCarriersEngine::Registration).and_return(false) }
 
         it "returns false" do
           expect(helper.display_resume_link_for?(resource)).to eq(false)
@@ -180,7 +180,7 @@ RSpec.describe ActionLinksHelper, type: :helper do
       end
 
       context "when the user has permission" do
-        before { allow(helper).to receive(:can?).and_return(true) }
+        before { allow(helper).to receive(:can?).with(:create, WasteCarriersEngine::Registration).and_return(true) }
 
         it "returns true" do
           expect(helper.display_resume_link_for?(resource)).to eq(true)
@@ -219,7 +219,7 @@ RSpec.describe ActionLinksHelper, type: :helper do
         before { resource.workflow_state = "location_form" }
 
         context "when the user does not have permission" do
-          before { allow(helper).to receive(:can?).and_return(false) }
+          before { allow(helper).to receive(:can?).with(:renew, resource).and_return(false) }
 
           it "returns false" do
             expect(helper.display_resume_link_for?(resource)).to eq(false)
@@ -227,7 +227,7 @@ RSpec.describe ActionLinksHelper, type: :helper do
         end
 
         context "when the user has permission" do
-          before { allow(helper).to receive(:can?).and_return(true) }
+          before { allow(helper).to receive(:can?).with(:renew, resource).and_return(true) }
 
           it "returns true" do
             expect(helper.display_resume_link_for?(resource)).to eq(true)
@@ -304,7 +304,8 @@ RSpec.describe ActionLinksHelper, type: :helper do
       let(:resource) { build(:registration) }
 
       before do
-        allow(helper).to receive(:can?).and_return(can)
+        allow(helper).to receive(:can?).with(:revoke, resource).and_return(can)
+        allow(helper).to receive(:can?).with(:cease, resource).and_return(can)
       end
 
       context "when the user has permission for revoking" do
@@ -354,7 +355,7 @@ RSpec.describe ActionLinksHelper, type: :helper do
       let(:resource) { build(:registration) }
 
       before do
-        allow(helper).to receive(:can?).and_return(can)
+        allow(helper).to receive(:can?).with(:cancel, WasteCarriersEngine::Registration).and_return(can)
       end
 
       context "when the user has permission for cancelling" do
@@ -696,7 +697,7 @@ RSpec.describe ActionLinksHelper, type: :helper do
         before { resource.metaData.status = %w[ACTIVE EXPIRED PENDING].sample }
 
         context "when the user does not have permission" do
-          before { allow(helper).to receive(:can?).and_return(false) }
+          before { allow(helper).to receive(:can?).with(:transfer_registration, WasteCarriersEngine::Registration).and_return(false) }
 
           it "returns false" do
             expect(helper.display_transfer_link_for?(resource)).to eq(false)
@@ -704,7 +705,7 @@ RSpec.describe ActionLinksHelper, type: :helper do
         end
 
         context "when the user has permission" do
-          before { allow(helper).to receive(:can?).and_return(true) }
+          before { allow(helper).to receive(:can?).with(:transfer_registration, WasteCarriersEngine::Registration).and_return(true) }
 
           it "returns true" do
             expect(helper.display_transfer_link_for?(resource)).to eq(true)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1055

Users who can't create new registrations (ie finance users) should not see the 'resume' link for in-progress new registrations.