### PR TITLE
Add 'continue as assisted digital' button to new reg view

### DIFF
--- a/app/views/new_registrations/show.html.erb
+++ b/app/views/new_registrations/show.html.erb
@@ -21,6 +21,9 @@
             <p>
               <%= @transient_registration.display_current_workflow_state %>
             </p>
+            <% if display_resume_link_for?(@transient_registration) %>
+              <%= link_to t(".status.actions.continue_button"), resume_link_for(@transient_registration), class: 'button' %>
+            <% end %>
           <% end %>
         </div>
 

--- a/config/locales/new_registrations.en.yml
+++ b/config/locales/new_registrations.en.yml
@@ -13,6 +13,8 @@ en:
           in_progress: "The current form is"
           worldpay:
             paragraph_1: "The user is currently attempting to pay by WorldPay."
+        actions:
+          continue_button: "Continue as assisted digital"
       conviction_heading: "Convictions"
       conviction_link: "Conviction details"
       conviction_information:


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1055

This is in addition to the link in the actions panel.

![image](https://user-images.githubusercontent.com/13369917/83534503-d324e580-a4e8-11ea-88ee-f4e9bb9676bc.png)
