### PR TITLE
Don't display reg_identifiers for in-progress new regs

### DIFF
--- a/app/presenters/base_registration_presenter.rb
+++ b/app/presenters/base_registration_presenter.rb
@@ -91,14 +91,8 @@ class BaseRegistrationPresenter < WasteCarriersEngine::BasePresenter
   end
 
   def display_action_links_heading
-    text_path = ".shared.registrations.action_links_panel.actions_box.heading"
-    if reg_identifier.present?
-      I18n.t("#{text_path}.with_reg_identifier", reg_identifier: reg_identifier)
-    elsif company_name.present?
-      I18n.t("#{text_path}.with_company_name", company_name: company_name)
-    else
-      I18n.t("#{text_path}.without_company_name_or_reg_identifier")
-    end
+    I18n.t(".shared.registrations.action_links_panel.actions_box.heading.with_reg_identifier",
+           reg_identifier: reg_identifier)
   end
 
   private

--- a/app/presenters/new_registration_presenter.rb
+++ b/app/presenters/new_registration_presenter.rb
@@ -13,6 +13,15 @@ class NewRegistrationPresenter < BaseRegistrationPresenter
     "#{I18n.t('.new_registrations.show.status.messages.in_progress')} \"#{current_workflow_state}\""
   end
 
+  def display_action_links_heading
+    text_path = ".shared.registrations.action_links_panel.actions_box.heading"
+    if company_name.present?
+      I18n.t("#{text_path}.with_company_name", company_name: company_name)
+    else
+      I18n.t("#{text_path}.without_company_name_or_reg_identifier")
+    end
+  end
+
   private
 
   def current_workflow_state

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -76,7 +76,9 @@
           <% @results.each do |result| %>
             <tr>
               <td>
-                <%= result.reg_identifier %>
+                <% unless result.is_a?(WasteCarriersEngine::NewRegistration) %>
+                  <%= result.reg_identifier %>
+                <% end %>
               </td>
               <td>
                 <%= result.company_name %>

--- a/app/views/shared/registrations/_action_links_panel.html.erb
+++ b/app/views/shared/registrations/_action_links_panel.html.erb
@@ -3,7 +3,6 @@
     <%= resource.display_action_links_heading %>
   </h2>
   <ul>
-    <!-- TODO: This `display_resume_link_for?` will need to be updated when we build NewRegistration -->
     <% if display_resume_link_for?(resource) %>
       <li>
         <%= link_to t(".actions_box.links.continue_button"), resume_link_for(resource) %>

--- a/spec/presenters/base_registration_presenter_spec.rb
+++ b/spec/presenters/base_registration_presenter_spec.rb
@@ -352,40 +352,16 @@ RSpec.describe BaseRegistrationPresenter do
   end
 
   describe "#display_action_links_heading" do
-    let(:reg_identifier) { nil }
-    let(:company_name) { nil }
+    let(:reg_identifier) { "CBDU1234" }
     let(:registration) do
       double(:registration,
-             reg_identifier: reg_identifier,
-             company_name: company_name)
+             reg_identifier: reg_identifier)
     end
 
-    context "when there is a reg_identifier" do
-      let(:reg_identifier) { "CBDU1234" }
+    it "returns a heading with the reg_identifier" do
+      result = subject.display_action_links_heading
 
-      it "returns a heading with the name" do
-        result = subject.display_action_links_heading
-
-        expect(result).to eq("Actions for CBDU1234")
-      end
-    end
-
-    context "when there is a company_name" do
-      let(:company_name) { "Foo" }
-
-      it "returns a heading with the name" do
-        result = subject.display_action_links_heading
-
-        expect(result).to eq("Actions for Foo")
-      end
-    end
-
-    context "when there is no company_name or reg_identifier" do
-      it "returns a heading without a name or reg_identifier" do
-        result = subject.display_action_links_heading
-
-        expect(result).to eq("Actions")
-      end
+      expect(result).to eq("Actions for CBDU1234")
     end
   end
 end

--- a/spec/presenters/new_registration_presenter_spec.rb
+++ b/spec/presenters/new_registration_presenter_spec.rb
@@ -41,4 +41,30 @@ RSpec.describe NewRegistrationPresenter do
       expect(result).to eq('The current form is "a_workflow_state"')
     end
   end
+
+  describe "#display_action_links_heading" do
+    let(:company_name) { nil }
+    let(:new_registration) do
+      double(:new_registration,
+             company_name: company_name)
+    end
+
+    context "when there is a company_name" do
+      let(:company_name) { "Foo" }
+
+      it "returns a heading with the name" do
+        result = subject.display_action_links_heading
+
+        expect(result).to eq("Actions for Foo")
+      end
+    end
+
+    context "when there is no company_name" do
+      it "returns a heading without a name" do
+        result = subject.display_action_links_heading
+
+        expect(result).to eq("Actions")
+      end
+    end
+  end
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1053

Since the reg_identifier isn't officially set until the application is submitted, we decided not to display it on the search or the view details page.

On the search result, we leave it blank. On the view details page, we just use the company name instead (if present).