### PR TITLE
Allow NCCC to send new regs back from Worldpay to payment summary

### DIFF
--- a/app/views/new_registrations/show.html.erb
+++ b/app/views/new_registrations/show.html.erb
@@ -17,6 +17,13 @@
             <p>
               <%= t(".status.messages.worldpay.paragraph_1") %>
             </p>
+
+            <% if can? :revert_to_payment_summary, @transient_registration %>
+              <p>
+                <%= t(".status.messages.worldpay.paragraph_2.revert") %>
+              </p>
+              <%= link_to t(".status.actions.revert_to_payment_summary_button"), new_resource_worldpay_escape_path(@transient_registration._id), class: 'button' %>
+            <% end %>
           <% else %>
             <p>
               <%= @transient_registration.display_current_workflow_state %>

--- a/app/views/renewing_registrations/show.html.erb
+++ b/app/views/renewing_registrations/show.html.erb
@@ -33,7 +33,7 @@
                 <p>
                   <%= t(".status.messages.worldpay.paragraph_2.revert") %>
                 </p>
-                <%= link_to t(".status.actions.revert_to_payment_summary_button"), new_transient_registration_worldpay_escape_path(@transient_registration.reg_identifier), class: 'button' %>
+                <%= link_to t(".status.actions.revert_to_payment_summary_button"), new_resource_worldpay_escape_path(@transient_registration._id), class: 'button' %>
               <% elsif can? :record_worldpay_missed_payment, @transient_registration %>
                 <p>
                   <%= t(".status.messages.worldpay.paragraph_2.missed_payment") %>

--- a/config/locales/new_registrations.en.yml
+++ b/config/locales/new_registrations.en.yml
@@ -13,8 +13,11 @@ en:
           in_progress: "The current form is"
           worldpay:
             paragraph_1: "The user is currently attempting to pay by WorldPay."
+            paragraph_2:
+              revert: "If an error has occurred and the user is stuck, you can send the registration back to the payment summary page. They can try to pay with WorldPay again, or select an alternative payment method."
         actions:
           continue_button: "Continue as assisted digital"
+          revert_to_payment_summary_button: "Send back to payment summary"
       conviction_heading: "Convictions"
       conviction_link: "Conviction details"
       conviction_information:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -102,6 +102,11 @@ Rails.application.routes.draw do
                        only: %i[new create],
                        path: "payments/charge-adjust/positive",
                        path_names: { new: "" }
+
+              resources :worldpay_escapes,
+                       only: :new,
+                       path: "revert-to-payment-summary",
+                       path_names: { new: "" }
             end
 
   resources :new_registrations,
@@ -160,11 +165,6 @@ Rails.application.routes.draw do
               resources :conviction_rejection_forms,
                         only: %i[new create],
                         path: "convictions/reject",
-                        path_names: { new: "" }
-
-              resources :worldpay_escapes,
-                        only: :new,
-                        path: "revert-to-payment-summary",
                         path_names: { new: "" }
             end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,6 +80,11 @@ Rails.application.routes.draw do
                         path: "payments/worldpay-missed",
                         path_names: { new: "" }
 
+              resources :worldpay_escapes,
+                        only: :new,
+                        path: "revert-to-payment-summary",
+                        path_names: { new: "" }
+
               resource :finance_details,
                        only: :show,
                        path: "finance-details"
@@ -101,11 +106,6 @@ Rails.application.routes.draw do
               resource :positive_charge_adjust_form,
                        only: %i[new create],
                        path: "payments/charge-adjust/positive",
-                       path_names: { new: "" }
-
-              resources :worldpay_escapes,
-                       only: :new,
-                       path: "revert-to-payment-summary",
                        path_names: { new: "" }
             end
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1075

Renewals have a feature where if the current state is Worldpay, an NCCC user can click the “Revert from Worldpay” button on the view details page in the back office to kick the renewal back to the payment summary form.

This is useful if there is a Worldpay error, or if the user is otherwise stuck.

![image](https://user-images.githubusercontent.com/13369917/83858519-89b8de00-a714-11ea-9318-c294254b6f33.png)
