### PR TITLE
Allow finance admins to add missed Worldpay payments to in-progress new registrations

### DIFF
--- a/app/controllers/worldpay_missed_payment_new_registrations_controller.rb
+++ b/app/controllers/worldpay_missed_payment_new_registrations_controller.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class WorldpayMissedPaymentNewRegistrationsController < ApplicationController
+  include CanFetchResource
+
+  prepend_before_action :authenticate_user!
+  before_action :authorize, only: %i[new]
+
+  def new
+    if ready_to_complete_and_add_missed_payment?
+      complete_new_registration
+      redirect_to new_resource_worldpay_missed_payment_form_path(@registration._id)
+    else
+      redirect_to new_registration_path(@resource.token)
+    end
+  end
+
+  private
+
+  def authorize
+    authorize! :record_worldpay_missed_payment, @resource
+  end
+
+  def ready_to_complete_and_add_missed_payment?
+    new_registration? && correct_workflow_state?
+  end
+
+  def new_registration?
+    @resource.is_a?(WasteCarriersEngine::NewRegistration)
+  end
+
+  def correct_workflow_state?
+    @resource.workflow_state == "worldpay_form"
+  end
+
+  def complete_new_registration
+    @registration = WasteCarriersEngine::RegistrationCompletionService.run(@resource)
+  end
+end

--- a/app/views/new_registrations/show.html.erb
+++ b/app/views/new_registrations/show.html.erb
@@ -23,6 +23,11 @@
                 <%= t(".status.messages.worldpay.paragraph_2.revert") %>
               </p>
               <%= link_to t(".status.actions.revert_to_payment_summary_button"), new_resource_worldpay_escape_path(@transient_registration._id), class: 'button' %>
+            <% elsif can? :record_worldpay_missed_payment, @transient_registration %>
+              <p>
+                <%= t(".status.messages.worldpay.paragraph_2.missed_payment") %>
+              </p>
+              <%= link_to t(".status.actions.missed_worldpay_payment_button"), new_resource_worldpay_missed_payment_new_registration_path(@transient_registration._id), class: 'button' %>
             <% end %>
           <% else %>
             <p>

--- a/config/locales/new_registrations.en.yml
+++ b/config/locales/new_registrations.en.yml
@@ -15,9 +15,11 @@ en:
             paragraph_1: "The user is currently attempting to pay by WorldPay."
             paragraph_2:
               revert: "If an error has occurred and the user is stuck, you can send the registration back to the payment summary page. They can try to pay with WorldPay again, or select an alternative payment method."
+              missed_payment: "If an error has occurred and payment has been received, but not recorded, you can record a missed WorldPay payment."
         actions:
           continue_button: "Continue as assisted digital"
           revert_to_payment_summary_button: "Send back to payment summary"
+          missed_worldpay_payment_button: "Add a missed WorldPay payment"
       conviction_heading: "Convictions"
       conviction_link: "Conviction details"
       conviction_information:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -85,6 +85,11 @@ Rails.application.routes.draw do
                         path: "revert-to-payment-summary",
                         path_names: { new: "" }
 
+              resources :worldpay_missed_payment_new_registrations,
+                        only: :new,
+                        path: "missed-worldpay-payment-new-registration",
+                        path_names: { new: "" }
+
               resource :finance_details,
                        only: :show,
                        path: "finance-details"

--- a/spec/factories/new_registration.rb
+++ b/spec/factories/new_registration.rb
@@ -2,5 +2,47 @@
 
 FactoryBot.define do
   factory :new_registration, class: WasteCarriersEngine::NewRegistration do
+    metaData { build(:metaData) }
+
+    trait :has_required_data do
+      location { "england" }
+      declared_convictions { "no" }
+      temp_cards { 1 }
+      contact_email { "foo@example.com" }
+      first_name { "Jane" }
+      last_name { "Doe" }
+      metaData { build(:metaData, route: "DIGITAL") }
+
+      temp_check_your_tier { "unknown" }
+      sequence :reg_identifier
+
+      has_addresses
+      has_postcode
+      has_key_people
+      upper
+
+      after(:build, :create) do |new_registration|
+        new_registration.prepare_for_payment(:worldpay, nil)
+      end
+    end
+
+    trait :upper do
+      tier { WasteCarriersEngine::NewRegistration::UPPER_TIER }
+    end
+
+    trait :has_key_people do
+      key_people do
+        [build(:key_person, :does_not_require_conviction_check, :main)]
+      end
+    end
+
+    trait :has_postcode do
+      temp_company_postcode { "BS1 5AH" }
+      temp_contact_postcode { "BS1 5AH" }
+    end
+
+    trait :has_addresses do
+      addresses { [build(:address, :registered), build(:address, :contact)] }
+    end
   end
 end

--- a/spec/requests/worldpay_missed_payment_new_registrations_controller_spec.rb
+++ b/spec/requests/worldpay_missed_payment_new_registrations_controller_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "WorldpayMissedPaymentNewRegistrations", type: :request do
+  let(:transient_registration) { create(:new_registration, :has_required_data) }
+  let(:_id) { transient_registration._id }
+
+  describe "GET /bo/resources/:_id/missed-worldpay-payment-new-registration" do
+    let(:user) { create(:user) }
+    before(:each) do
+      sign_in(user)
+    end
+
+    context "when the user has the correct role" do
+      let(:user) { create(:user, :finance_admin) }
+
+      context "when the workflow_state is worldpay_form" do
+        before do
+          transient_registration.update_attributes(workflow_state: "worldpay_form")
+        end
+
+        it "creates a new registration and redirects to the 'add missed payment' form" do
+          old_registration_count = WasteCarriersEngine::Registration.count
+          old_new_registration_count = WasteCarriersEngine::NewRegistration.count
+          expected_reg_identifier = transient_registration.reg_identifier
+
+          get "/bo/resources/#{_id}/missed-worldpay-payment-new-registration"
+
+          expect(WasteCarriersEngine::Registration.count).to eq(old_registration_count + 1)
+          expect(WasteCarriersEngine::NewRegistration.count).to eq(old_new_registration_count - 1)
+
+          registration = WasteCarriersEngine::Registration.where(reg_identifier: expected_reg_identifier).first
+          expect(response).to redirect_to new_resource_worldpay_missed_payment_form_path(registration._id)
+        end
+      end
+
+      context "when the workflow_state is not worldpay_form" do
+        before do
+          transient_registration.update_attributes(workflow_state: "payment_summary_form")
+        end
+
+        it "renders the new registration details page" do
+          get "/bo/resources/#{_id}/missed-worldpay-payment-new-registration"
+
+          expect(response).to redirect_to new_registration_path(transient_registration.token)
+        end
+      end
+    end
+
+    context "when the user does not have the correct role" do
+      let(:user) { create(:user, :agency) }
+
+      it "renders the permissions error page" do
+        get "/bo/resources/#{_id}/missed-worldpay-payment-new-registration"
+        expect(response).to redirect_to "/bo/pages/permission"
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1093

Finance admin users should be able to add a missed Worldpay payment to an in-progress new registration that is stuck in the "worldpay_form" workflow status.

Because our finance forms are built to work with Registrations rather than NewRegistrations, this new controller converts the NewRegistration into a Registration before adding the payment.

![image](https://user-images.githubusercontent.com/13369917/84024889-93477d80-a982-11ea-901c-dd6f8715d768.png)
