### PR TITLE
Fix cleanup:transient_registrations rake task

### DIFF
--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -2,9 +2,7 @@
 
 namespace :cleanup do
   desc "Remove old transient_registrations from the database"
-  task test: :transient_registrations do
+  task transient_registrations: :environment do
     TransientRegistrationCleanupService.run
-
-    Airbrake.close
   end
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-10

This was totally broken and throwing errors. Now it should work.