### PR TITLE
Update registration seeding API

### DIFF
--- a/app/services/api/load_seeded_data_service.rb
+++ b/app/services/api/load_seeded_data_service.rb
@@ -14,7 +14,7 @@ module Api
       @seed["reg_identifier"] = reg_identifier
       @seed["expires_on"] = Rails.configuration.expires_after.years.from_now unless @seed["custom_expire"]
 
-      WasteCarriersEngine::Registration.find_or_create_by(@seed.except(*%w[_id custom_expire]))
+      WasteCarriersEngine::Registration.find_or_create_by(@seed.except("_id", "custom_expire"))
     end
 
     def reg_identifier

--- a/app/services/api/load_seeded_data_service.rb
+++ b/app/services/api/load_seeded_data_service.rb
@@ -12,9 +12,9 @@ module Api
 
     def seed_registration
       @seed["reg_identifier"] = reg_identifier
-      @seed["expires_on"] = Rails.configuration.expires_after.years.from_now
+      @seed["expires_on"] = Rails.configuration.expires_after.years.from_now unless @seed["custom_expire"]
 
-      WasteCarriersEngine::Registration.find_or_create_by(@seed.except("_id"))
+      WasteCarriersEngine::Registration.find_or_create_by(@seed.except(*%w[_id custom_expire]))
     end
 
     def reg_identifier
@@ -22,7 +22,7 @@ module Api
     end
 
     def generate_reg_identifier
-      tier_identifier = @seed["tier"] == "lower" ? "L" : "U"
+      tier_identifier = @seed["tier"].downcase == "lower" ? "L" : "U"
       unique_identifier = ::WasteCarriersEngine::GenerateRegIdentifierService.run.to_s
 
       "CBD#{tier_identifier}#{unique_identifier}"

--- a/spec/requests/api/registrations_spec.rb
+++ b/spec/requests/api/registrations_spec.rb
@@ -43,7 +43,6 @@ RSpec.describe "Registrations API", type: :request do
 
       it "generates a new registration with a CBDL number" do
         allow(Rails.configuration).to receive(:expires_after).and_return(1)
-        expected_registrations_count = WasteCarriersEngine::Registration.count + 1
 
         post "/bo/api/registrations", data, format: :json
 

--- a/spec/requests/api/registrations_spec.rb
+++ b/spec/requests/api/registrations_spec.rb
@@ -30,11 +30,42 @@ RSpec.describe "Registrations API", type: :request do
 
       response_info = JSON.parse(response.body)
       expect(response_info).to have_key("reg_identifier")
+      expect(response_info["reg_identifier"]).to start_with("CBDU")
 
       registration = WasteCarriersEngine::Registration.find_by reg_identifier: response_info["reg_identifier"]
 
       expect(registration.expires_on.to_date).to eq(1.year.from_now.to_date)
       expect(WasteCarriersEngine::Registration.count).to eq(expected_registrations_count)
+    end
+
+    context "when the tier is LOWER" do
+      let(:data) { File.read("#{Rails.root}/spec/support/fixtures/lower_tier_registration_seed.json") }
+
+      it "generates a new registration with a CBDL number" do
+        allow(Rails.configuration).to receive(:expires_after).and_return(1)
+        expected_registrations_count = WasteCarriersEngine::Registration.count + 1
+
+        post "/bo/api/registrations", data, format: :json
+
+        response_info = JSON.parse(response.body)
+        expect(response_info["reg_identifier"]).to start_with("CBDL")
+      end
+    end
+
+    context "when the custom expire is set" do
+      let(:data) { File.read("#{Rails.root}/spec/support/fixtures/expire_set_registration_seed.json") }
+
+      it "generates a new registration without overriding the expires_on date value" do
+        expected_registrations_count = WasteCarriersEngine::Registration.count + 1
+
+        post "/bo/api/registrations", data, format: :json
+
+        response_info = JSON.parse(response.body)
+        registration = WasteCarriersEngine::Registration.find_by reg_identifier: response_info["reg_identifier"]
+
+        expect(registration.expires_on.to_s).to eq("2021-05-14T10:38:22+00:00")
+        expect(WasteCarriersEngine::Registration.count).to eq(expected_registrations_count)
+      end
     end
   end
 end

--- a/spec/services/api/load_seeded_data_service_spec.rb
+++ b/spec/services/api/load_seeded_data_service_spec.rb
@@ -6,7 +6,8 @@ module Api
   RSpec.describe LoadSeededDataService do
     describe ".run" do
       it "creates a new registration after assigning a new reg_identifier" do
-        seed = {}
+        seed = {"tier" => "UPPER"}
+
         registration = double(:registration)
 
         expect(WasteCarriersEngine::Registration).to receive(:find_or_create_by).and_return(registration)

--- a/spec/services/api/load_seeded_data_service_spec.rb
+++ b/spec/services/api/load_seeded_data_service_spec.rb
@@ -6,7 +6,7 @@ module Api
   RSpec.describe LoadSeededDataService do
     describe ".run" do
       it "creates a new registration after assigning a new reg_identifier" do
-        seed = {"tier" => "UPPER"}
+        seed = { "tier" => "UPPER" }
 
         registration = double(:registration)
 

--- a/spec/support/fixtures/expire_set_registration_seed.json
+++ b/spec/support/fixtures/expire_set_registration_seed.json
@@ -1,0 +1,157 @@
+{
+    "tier" : "UPPER",
+    "registrationType" : "carrier_dealer",
+    "businessType" : "limitedCompany",
+    "otherBusinesses" : "no",
+    "constructionWaste" : "yes",
+    "companyName" : "UT Company limited",
+    "firstName" : "Bob",
+    "lastName" : "Carolgees",
+    "phoneNumber" : "012345678",
+    "contactEmail" : "user@example.com",
+    "accountEmail" : "user@example.com",
+    "declaredConvictions" : "no",
+    "declaration" : "1",
+    "metaData" : {
+        "dateRegistered" : "2018-05-14T10:38:17.311Z",
+        "anotherString" : "userDetailAddedAtRegistration",
+        "lastModified" : "2018-05-14T10:38:22.692Z",
+        "dateActivated" : "2018-05-14T10:38:22.692Z",
+        "status" : "ACTIVE",
+        "route" : "DIGITAL",
+        "distance" : "n/a"
+    },
+    "financeDetails" : {
+        "orders" : [
+            {
+                "orderId" : "1526294297",
+                "orderItems" : [
+                    {
+                        "amount" : 15400,
+                        "currency" : "GBP",
+                        "description" : "Initial Registration",
+                        "reference" : "",
+                        "type" : "NEW"
+                    },
+                    {
+                        "amount" : 1000,
+                        "currency" : "GBP",
+                        "description" : "2x Copy cards",
+                        "reference" : "",
+                        "type" : "COPY_CARDS"
+                    }
+                ],
+                "orderCode" : "1526294297",
+                "paymentMethod" : "ONLINE",
+                "merchantId" : "EASERRSIMECOM",
+                "totalAmount" : 16400,
+                "currency" : "GBP",
+                "dateCreated" : "2018-05-14T10:38:18.000Z",
+                "worldPayStatus" : "AUTHORISED",
+                "dateLastUpdated" : "2018-05-14T10:38:22.826Z",
+                "updatedByUser" : "user@example.com",
+                "description" : "New Waste Carrier Registration: CBDU4 for UT Company limited, Plus 2 copy cards"
+            }
+        ],
+        "payments" : [
+            {
+                "orderKey" : "1526294297",
+                "amount" : 16400,
+                "currency" : "GBP",
+                "mac_code" : "fa5f24ee0cb5cb6bc739fc7834ad074b",
+                "dateReceived" : "2018-05-14T10:38:22.675Z",
+                "dateEntered" : "2018-05-14T10:38:22.679Z",
+                "registrationReference" : "Worldpay",
+                "worldPayPaymentStatus" : "AUTHORISED",
+                "updatedByUser" : "user@example.com",
+                "comment" : "Paid via Worldpay",
+                "paymentType" : "WORLDPAY"
+            }
+        ],
+        "balance" : 0
+    },
+    "reg_uuid" : "MEhGfN-GH-2tPVdeqZmbQA",
+    "company_no" : "00445790",
+    "addresses" : [
+        {
+            "uprn" : "200000567267",
+            "addressType" : "REGISTERED",
+            "addressMode" : "address-results",
+            "houseNumber" : "ENVIRONMENT AGENCY",
+            "addressLine1" : "BOW BRIDGE CLOSE",
+            "townCity" : "ROTHERHAM",
+            "postcode" : "BS1 5AH",
+            "country" : "",
+            "dependentLocality" : "",
+            "dependentThoroughfare" : "",
+            "administrativeArea" : "ROTHERHAM",
+            "localAuthorityUpdateDate" : "",
+            "royalMailUpdateDate" : "",
+            "easting" : "442265",
+            "northing" : "391948",
+            "location" : {
+                "lat" : 53.410015,
+                "lon" : -1.339531
+            }
+        },
+        {
+            "addressType" : "POSTAL",
+            "houseNumber" : "ENVIRONMENT AGENCY",
+            "addressLine1" : "BOW BRIDGE CLOSE",
+            "addressLine2" : "",
+            "addressLine3" : "",
+            "addressLine4" : "",
+            "townCity" : "ROTHERHAM",
+            "postcode" : "BS1 5AH",
+            "country" : "",
+            "firstName" : "Bob",
+            "lastName" : "Carolgees"
+        }
+    ],
+    "key_people" : [
+        {
+            "position" : "Director",
+            "first_name" : "Rigoberto",
+            "last_name" : "Mohr",
+            "dob" : "1984-05-01T00:00:00.000Z",
+            "person_type" : "KEY",
+            "conviction_search_result" : {
+                "match_result" : "NO",
+                "searched_at" : "2018-05-14T10:37:54.908Z",
+                "confirmed" : "no"
+            }
+        },
+        {
+            "position" : "Director",
+            "first_name" : "Rosalia",
+            "last_name" : "Mitchell",
+            "dob" : "1984-05-01T00:00:00.000Z",
+            "person_type" : "KEY",
+            "conviction_search_result" : {
+                "match_result" : "NO",
+                "searched_at" : "2018-05-14T10:37:56.303Z",
+                "confirmed" : "no"
+            }
+        },
+        {
+            "position" : "Director",
+            "first_name" : "Haleigh",
+            "last_name" : "Hickle",
+            "dob" : "1984-05-01T00:00:00.000Z",
+            "person_type" : "KEY",
+            "conviction_search_result" : {
+                "match_result" : "NO",
+                "searched_at" : "2018-05-14T10:37:57.529Z",
+                "confirmed" : "no"
+            }
+        }
+    ],
+    "copy_cards" : "2",
+    "custom_expire" : "true",
+    "expires_on" : "2021-05-14T10:38:22.692Z",
+    "conviction_search_result" : {
+        "match_result" : "NO",
+        "searched_at" : "2018-05-14T10:37:50.372Z",
+        "confirmed" : "no"
+    }
+}

--- a/spec/support/fixtures/lower_tier_registration_seed.json
+++ b/spec/support/fixtures/lower_tier_registration_seed.json
@@ -1,0 +1,156 @@
+{
+    "tier" : "LOWER",
+    "registrationType" : "carrier_dealer",
+    "businessType" : "limitedCompany",
+    "otherBusinesses" : "no",
+    "constructionWaste" : "yes",
+    "companyName" : "UT Company limited",
+    "firstName" : "Bob",
+    "lastName" : "Carolgees",
+    "phoneNumber" : "012345678",
+    "contactEmail" : "user@example.com",
+    "accountEmail" : "user@example.com",
+    "declaredConvictions" : "no",
+    "declaration" : "1",
+    "metaData" : {
+        "dateRegistered" : "2018-05-14T10:38:17.311Z",
+        "anotherString" : "userDetailAddedAtRegistration",
+        "lastModified" : "2018-05-14T10:38:22.692Z",
+        "dateActivated" : "2018-05-14T10:38:22.692Z",
+        "status" : "ACTIVE",
+        "route" : "DIGITAL",
+        "distance" : "n/a"
+    },
+    "financeDetails" : {
+        "orders" : [
+            {
+                "orderId" : "1526294297",
+                "orderItems" : [
+                    {
+                        "amount" : 15400,
+                        "currency" : "GBP",
+                        "description" : "Initial Registration",
+                        "reference" : "",
+                        "type" : "NEW"
+                    },
+                    {
+                        "amount" : 1000,
+                        "currency" : "GBP",
+                        "description" : "2x Copy cards",
+                        "reference" : "",
+                        "type" : "COPY_CARDS"
+                    }
+                ],
+                "orderCode" : "1526294297",
+                "paymentMethod" : "ONLINE",
+                "merchantId" : "EASERRSIMECOM",
+                "totalAmount" : 16400,
+                "currency" : "GBP",
+                "dateCreated" : "2018-05-14T10:38:18.000Z",
+                "worldPayStatus" : "AUTHORISED",
+                "dateLastUpdated" : "2018-05-14T10:38:22.826Z",
+                "updatedByUser" : "user@example.com",
+                "description" : "New Waste Carrier Registration: CBDU4 for UT Company limited, Plus 2 copy cards"
+            }
+        ],
+        "payments" : [
+            {
+                "orderKey" : "1526294297",
+                "amount" : 16400,
+                "currency" : "GBP",
+                "mac_code" : "fa5f24ee0cb5cb6bc739fc7834ad074b",
+                "dateReceived" : "2018-05-14T10:38:22.675Z",
+                "dateEntered" : "2018-05-14T10:38:22.679Z",
+                "registrationReference" : "Worldpay",
+                "worldPayPaymentStatus" : "AUTHORISED",
+                "updatedByUser" : "user@example.com",
+                "comment" : "Paid via Worldpay",
+                "paymentType" : "WORLDPAY"
+            }
+        ],
+        "balance" : 0
+    },
+    "reg_uuid" : "MEhGfN-GH-2tPVdeqZmbQA",
+    "company_no" : "00445790",
+    "addresses" : [
+        {
+            "uprn" : "200000567267",
+            "addressType" : "REGISTERED",
+            "addressMode" : "address-results",
+            "houseNumber" : "ENVIRONMENT AGENCY",
+            "addressLine1" : "BOW BRIDGE CLOSE",
+            "townCity" : "ROTHERHAM",
+            "postcode" : "BS1 5AH",
+            "country" : "",
+            "dependentLocality" : "",
+            "dependentThoroughfare" : "",
+            "administrativeArea" : "ROTHERHAM",
+            "localAuthorityUpdateDate" : "",
+            "royalMailUpdateDate" : "",
+            "easting" : "442265",
+            "northing" : "391948",
+            "location" : {
+                "lat" : 53.410015,
+                "lon" : -1.339531
+            }
+        },
+        {
+            "addressType" : "POSTAL",
+            "houseNumber" : "ENVIRONMENT AGENCY",
+            "addressLine1" : "BOW BRIDGE CLOSE",
+            "addressLine2" : "",
+            "addressLine3" : "",
+            "addressLine4" : "",
+            "townCity" : "ROTHERHAM",
+            "postcode" : "BS1 5AH",
+            "country" : "",
+            "firstName" : "Bob",
+            "lastName" : "Carolgees"
+        }
+    ],
+    "key_people" : [
+        {
+            "position" : "Director",
+            "first_name" : "Rigoberto",
+            "last_name" : "Mohr",
+            "dob" : "1984-05-01T00:00:00.000Z",
+            "person_type" : "KEY",
+            "conviction_search_result" : {
+                "match_result" : "NO",
+                "searched_at" : "2018-05-14T10:37:54.908Z",
+                "confirmed" : "no"
+            }
+        },
+        {
+            "position" : "Director",
+            "first_name" : "Rosalia",
+            "last_name" : "Mitchell",
+            "dob" : "1984-05-01T00:00:00.000Z",
+            "person_type" : "KEY",
+            "conviction_search_result" : {
+                "match_result" : "NO",
+                "searched_at" : "2018-05-14T10:37:56.303Z",
+                "confirmed" : "no"
+            }
+        },
+        {
+            "position" : "Director",
+            "first_name" : "Haleigh",
+            "last_name" : "Hickle",
+            "dob" : "1984-05-01T00:00:00.000Z",
+            "person_type" : "KEY",
+            "conviction_search_result" : {
+                "match_result" : "NO",
+                "searched_at" : "2018-05-14T10:37:57.529Z",
+                "confirmed" : "no"
+            }
+        }
+    ],
+    "copy_cards" : "2",
+    "expires_on" : "2021-05-14T10:38:22.692Z",
+    "conviction_search_result" : {
+        "match_result" : "NO",
+        "searched_at" : "2018-05-14T10:37:50.372Z",
+        "confirmed" : "no"
+    }
+}


### PR DESCRIPTION
This closes issues https://github.com/DEFRA/waste-carriers-acceptance-tests/issues/317 and https://github.com/DEFRA/waste-carriers-acceptance-tests/issues/327

From this change on, we can create registrations in the acceptance tests suite with custom expires_on dates.