### PR TITLE
Convert max transient reg age in days to integer

### DIFF
--- a/app/services/transient_registration_cleanup_service.rb
+++ b/app/services/transient_registration_cleanup_service.rb
@@ -28,7 +28,7 @@ class TransientRegistrationCleanupService < ::WasteCarriersEngine::BaseService
   end
 
   def oldest_possible_date
-    max = Rails.configuration.max_transient_registration_age_days
+    max = Rails.configuration.max_transient_registration_age_days.to_i
     max.days.ago
   end
 end

--- a/spec/services/transient_registration_cleanup_service_spec.rb
+++ b/spec/services/transient_registration_cleanup_service_spec.rb
@@ -4,6 +4,10 @@ require "rails_helper"
 
 RSpec.describe TransientRegistrationCleanupService do
   describe ".run" do
+    before do
+      allow(Rails.configuration).to receive(:max_transient_registration_age_days).and_return("30")
+    end
+
     let(:transient_registration) { create(:new_registration) }
     let(:token) { transient_registration.token }
 


### PR DESCRIPTION
If the value comes from an env var, it was being read in as a string, which caused the `.days.ago` call to fail. Converting it to an integer beforehand solves this issue.