### PR TITLE
Integrate feature toggles engine

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,12 @@ gem "waste_carriers_engine",
     git: "https://github.com/DEFRA/waste-carriers-engine",
     branch: "main"
 
+# Use the Defra Ruby Features gem to allow users with the correct permissions to
+# manage feature toggle (create / update / delete) from the back-office.
+gem "defra-ruby-features",
+    git: "https://github.com/DEFRA/defra-ruby-features",
+    branch: "main"
+
 # Use the defra ruby mocks engine to add support for mocking external services
 # in live environment. Essentially with this gem added and enabled the app
 # also becomes a 'mock' for external services like companies house.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: 1f748a1deb3678bbc645c6fe814a8afd470cc9fc
+  revision: 2e42dfb1eb323767bd7f0699b2469b2d49e773f4
   branch: main
   specs:
     waste_carriers_engine (0.0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,12 @@
 GIT
+  remote: https://github.com/DEFRA/defra-ruby-features
+  revision: 4d94a5c259067b6e706dbda673d1e035ccd119cf
+  branch: main
+  specs:
+    defra-ruby-features (0.1.0)
+      rails (~> 6.0.3, >= 6.0.3.2)
+
+GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
   revision: 1f748a1deb3678bbc645c6fe814a8afd470cc9fc
   branch: main
@@ -92,7 +100,7 @@ GEM
     aws-eventstream (1.1.0)
     aws-healthcheck (1.0.1)
       rails (>= 3.0)
-    aws-partitions (1.335.0)
+    aws-partitions (1.336.0)
     aws-sdk-core (3.102.1)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
@@ -101,7 +109,7 @@ GEM
     aws-sdk-kms (1.35.0)
       aws-sdk-core (~> 3, >= 3.99.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.71.1)
+    aws-sdk-s3 (1.72.0)
       aws-sdk-core (~> 3, >= 3.102.1)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)
@@ -433,6 +441,7 @@ DEPENDENCIES
   aws-healthcheck
   cancancan (~> 1.10)
   database_cleaner
+  defra-ruby-features!
   defra_ruby_aws (~> 0.3.0)
   defra_ruby_mocks
   defra_ruby_style

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -117,6 +117,7 @@ class Ability
   def permissions_for_developer_user
     permissions_for_agency_user
 
+    can :manage, WasteCarriersEngine::FeatureToggle
     can :import_conviction_data, :all
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,8 @@ require "action_mailer/railtie"
 require "action_view/railtie"
 require "sprockets/railtie"
 
+require "defra_ruby_features"
+
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)

--- a/config/initializers/defra_ruby_features.rb
+++ b/config/initializers/defra_ruby_features.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "defra_ruby_features"
 
 DefraRubyFeatures.configure do |configuration|

--- a/config/initializers/defra_ruby_features.rb
+++ b/config/initializers/defra_ruby_features.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+require "defra_ruby_features"
+
+DefraRubyFeatures.configure do |configuration|
+  # Tell the engine where to find a model to use in order to persist feature toggles data
+  configuration.feature_toggle_model_name = "::WasteCarriersEngine::FeatureToggle"
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@
 
 # rubocop:disable Metrics/BlockLength
 Rails.application.routes.draw do
+  mount DefraRubyFeatures::Engine => "/bo/features"
 
   root to: "application#redirect_root_to_dashboard"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,8 +2,6 @@
 
 # rubocop:disable Metrics/BlockLength
 Rails.application.routes.draw do
-  mount DefraRubyFeatures::Engine => "/bo/features"
-
   root to: "application#redirect_root_to_dashboard"
 
   scope "/bo" do
@@ -223,6 +221,8 @@ Rails.application.routes.draw do
             path_names: { new: "" }
 
   mount DefraRubyMocks::Engine => "/bo/mocks"
+
+  mount DefraRubyFeatures::Engine => "/bo/features"
 
   mount WasteCarriersEngine::Engine => "/bo", as: "basic_app_engine"
 end


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-1118

This integrate the feature toggles engine in the back office app. It will allow backoffice users with correct permission to add, delete or toggle a feature toggle.

<details> 
<summary>New</summary>
<img width="529" alt="Screenshot 2020-06-29 at 12 46 52" src="https://user-images.githubusercontent.com/1385397/86008533-d4c2ca00-ba10-11ea-8f76-6dcea0e1670b.png">
</details>
<details> 
<summary>Index</summary>
<img width="668" alt="Screenshot 2020-06-29 at 14 01 50" src="https://user-images.githubusercontent.com/1385397/86008734-194e6580-ba11-11ea-88a7-84fe88260491.png">

</details>
