### PR TITLE
Changes need to support switch to 'main' branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ gem "defra_ruby_aws", "~> 0.3.0"
 # Use the waste carriers engine for the user journey
 gem "waste_carriers_engine",
     git: "https://github.com/DEFRA/waste-carriers-engine",
-    branch: "master"
+    branch: "main"
 
 # Use the defra ruby mocks engine to add support for mocking external services
 # in live environment. Essentially with this gem added and enabled the app

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: 342b2e7a27a996682acff16611d421332bbd4a72
-  branch: master
+  revision: 1f748a1deb3678bbc645c6fe814a8afd470cc9fc
+  branch: main
   specs:
     waste_carriers_engine (0.0.1)
       aasm (~> 4.12)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Waste Carriers Back Office
 
-[![Build Status](https://travis-ci.com/DEFRA/waste-carriers-back-office.svg?branch=master)](https://travis-ci.com/DEFRA/waste-carriers-back-office)
+[![Build Status](https://travis-ci.com/DEFRA/waste-carriers-back-office.svg?branch=main)](https://travis-ci.com/DEFRA/waste-carriers-back-office)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_waste-carriers-back-office&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=DEFRA_waste-carriers-back-office)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_waste-carriers-back-office&metric=coverage)](https://sonarcloud.io/dashboard?id=DEFRA_waste-carriers-back-office)
-[![security](https://hakiri.io/github/DEFRA/waste-carriers-back-office/master.svg)](https://hakiri.io/github/DEFRA/waste-carriers-back-office/master)
+[![security](https://hakiri.io/github/DEFRA/waste-carriers-back-office/main.svg)](https://hakiri.io/github/DEFRA/waste-carriers-back-office/main)
+[![Licence](https://img.shields.io/badge/Licence-OGLv3-blue.svg)](http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3)
 
 The 'Register or renew as a waste carrier' service allows businesses, who deal with waste and have to register according to the regulations, to register online. Once registered, businesses can sign in again to edit their registrations if needed.
 
@@ -13,7 +14,7 @@ This project is the back office application which internal EA users use to manag
 
 ## Prequisites
 
-You'll need [Ruby 2.4.2](https://www.ruby-lang.org/en/) installed plus the [Bundler](http://bundler.io/) gem.
+You'll need [Ruby 2.7.1](https://www.ruby-lang.org/en/) installed plus the [Bundler](http://bundler.io/) gem.
 
 ## Installation
 


### PR DESCRIPTION
The ruby services team have agreed to move to the convention of using `main` instead of `master` for our default branch across all our projects.

These are the changes needed to the source code in order to support this in WCR.