### PR TITLE
Fix defra-ruby-features ActiveRecord error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,7 +57,7 @@ gem "waste_carriers_engine",
 # manage feature toggle (create / update / delete) from the back-office.
 gem "defra-ruby-features",
     git: "https://github.com/DEFRA/defra-ruby-features",
-    branch: "main"
+    branch: "remove-base-application-record"
 
 # Use the defra ruby mocks engine to add support for mocking external services
 # in live environment. Essentially with this gem added and enabled the app

--- a/Gemfile
+++ b/Gemfile
@@ -57,7 +57,7 @@ gem "waste_carriers_engine",
 # manage feature toggle (create / update / delete) from the back-office.
 gem "defra-ruby-features",
     git: "https://github.com/DEFRA/defra-ruby-features",
-    branch: "remove-base-application-record"
+    branch: "main"
 
 # Use the defra ruby mocks engine to add support for mocking external services
 # in live environment. Essentially with this gem added and enabled the app

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DEFRA/defra-ruby-features
-  revision: 4d94a5c259067b6e706dbda673d1e035ccd119cf
-  branch: main
+  revision: 9c7d17dcb271cd3ff65a88a22afcfd10423e6aae
+  branch: remove-base-application-record
   specs:
     defra-ruby-features (0.1.0)
       rails (~> 6.0.3, >= 6.0.3.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DEFRA/defra-ruby-features
-  revision: 9c7d17dcb271cd3ff65a88a22afcfd10423e6aae
-  branch: remove-base-application-record
+  revision: 01d45f5caad159033c9885a9a7a04e6df4dae63e
+  branch: main
   specs:
     defra-ruby-features (0.1.0)
       rails (~> 6.0.3, >= 6.0.3.2)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1118

We think there is an issue when using our new [defra-ruby-features](https://github.com/DEFRA/defra-ruby-features) engine in a WCR 'production' environment. It seems to be related to an `ApplicationRecord` class in the engine that isn't actually used.

So we have [updated the features engine](https://github.com/DEFRA/defra-ruby-features/pull/1) to remove the file. This updates the back-office to use that latest version.