### PR TITLE
Add link to menu to feature toggles

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -36,6 +36,12 @@
                               main_app.conviction_imports_path %>
                 </li>
               <% end %>
+              <% if can?(:manage, WasteCarriersEngine::FeatureToggle, current_user) %>
+                <li>
+                  <%= link_to t("layouts.application.menu.feature_toggles"),
+                              features_engine.feature_toggles_path %>
+                </li>
+              <% end %>
             </ul>
           </nav>
       <% else %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9,6 +9,7 @@ en:
         convictions: "Conviction checks"
         users: "Manage users"
         conviction_imports: "Import conviction data"
+        feature_toggles: "Toggle features"
   shared:
     conviction_search_result:
       match_result: "Match result"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -222,7 +222,7 @@ Rails.application.routes.draw do
 
   mount DefraRubyMocks::Engine => "/bo/mocks"
 
-  mount DefraRubyFeatures::Engine => "/bo/features"
+  mount DefraRubyFeatures::Engine => "/bo/features", as: "features_engine"
 
   mount WasteCarriersEngine::Engine => "/bo", as: "basic_app_engine"
 end

--- a/spec/support/shared_examples/abilities/developer_examples.rb
+++ b/spec/support/shared_examples/abilities/developer_examples.rb
@@ -5,6 +5,10 @@ RSpec.shared_examples "developer examples" do
     should be_able_to(:import_conviction_data, :all)
   end
 
+  it "should be able to toggle features" do
+    should be_able_to(:manage, WasteCarriersEngine::FeatureToggle)
+  end
+
   it "should not be able to charge adjust a resource" do
     should_not be_able_to(:charge_adjust, WasteCarriersEngine::RenewingRegistration)
     should_not be_able_to(:charge_adjust, WasteCarriersEngine::Registration)

--- a/spec/support/shared_examples/abilities/non_developer_examples.rb
+++ b/spec/support/shared_examples/abilities/non_developer_examples.rb
@@ -4,4 +4,8 @@ RSpec.shared_examples "non-developer examples" do
   it "should not be able to import conviction data" do
     should_not be_able_to(:import_conviction_data, :all)
   end
+
+  it "should not be able to toggle features" do
+    should_not be_able_to(:manage, WasteCarriersEngine::FeatureToggle)
+  end
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1118

Adds a link to the main menu in the back-office to the feature toggles page.

The link and the page should only be accessible to users with the rol `developer`.