### PR TITLE
Update link to privacy policy

### DIFF
--- a/app/helpers/ad_privacy_policy_helper.rb
+++ b/app/helpers/ad_privacy_policy_helper.rb
@@ -2,7 +2,7 @@
 
 module AdPrivacyPolicyHelper
   def link_to_privacy_policy
-    path = File.join(Rails.configuration.wcrs_frontend_url, "privacy")
+    path = File.join(Rails.configuration.wcrs_renewals_url, "/fo/pages/privacy")
 
     link_to(t(".privacy_policy"), path, target: "_blank")
   end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1074

We should link to the front office instead of the frontend.