### PR TITLE
Switch defra-ruby-features to rubygems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,9 +55,7 @@ gem "waste_carriers_engine",
 
 # Use the Defra Ruby Features gem to allow users with the correct permissions to
 # manage feature toggle (create / update / delete) from the back-office.
-gem "defra-ruby-features",
-    git: "https://github.com/DEFRA/defra-ruby-features",
-    branch: "main"
+gem "defra_ruby_features", "~> 0.1"
 
 # Use the defra ruby mocks engine to add support for mocking external services
 # in live environment. Essentially with this gem added and enabled the app

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,4 @@
 GIT
-  remote: https://github.com/DEFRA/defra-ruby-features
-  revision: e2add40d661fbd59d34042d15e9e36a66b6e8ef0
-  branch: main
-  specs:
-    defra-ruby-features (0.1.0)
-      cancancan (~> 1.10)
-      devise (>= 4.4.3)
-      rails (~> 6.0.3, >= 6.0.3.2)
-
-GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
   revision: 47f438230915458d397b1ca37303021e5be7cc19
   branch: main
@@ -143,6 +133,10 @@ GEM
     defra_ruby_email (1.0.0)
       rails (~> 6.0.3.1)
       sprockets (~> 3.7.2)
+    defra_ruby_features (0.1.0)
+      cancancan (~> 1.10)
+      devise (>= 4.4.3)
+      rails (~> 6.0.3, >= 6.0.3.2)
     defra_ruby_mocks (2.0.0)
       nokogiri
       rails (~> 6.0.3.1)
@@ -443,8 +437,8 @@ DEPENDENCIES
   aws-healthcheck
   cancancan (~> 1.10)
   database_cleaner
-  defra-ruby-features!
   defra_ruby_aws (~> 0.3.0)
+  defra_ruby_features (~> 0.1)
   defra_ruby_mocks
   defra_ruby_style
   devise (>= 4.4.3)


### PR DESCRIPTION
We have now released a version of [defra-ruby-features](https://github.com/DEFRA/defra-ruby-features) to [rugbygems](https://rubygems.org/gems/defra_ruby_features).

We prefer to depend on released gems rather than directly referencing the GitHub repo as we believe it better manages the changes.

So this updates the project to use the new released gem.