### PR TITLE
Remove link to certificate from renewal complete

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: 47f438230915458d397b1ca37303021e5be7cc19
+  revision: cbb67891bfe5a99fa79f57e9f0e61561f92d0c22
   branch: main
   specs:
     waste_carriers_engine (0.0.1)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1154

The link in the page takes you to the frontend where if you are not signed in, you then have to in order to access the link. We don't provide this link on the new 'new registration' done page. It is also our intention to remove accounts in the near future so access to this will be removed anyway.

So this change is just about removing the link in the page to make it consistent with the new registration complete page, and with our future intentions. The change was actually done in the engine as [PR #887](https://github.com/DEFRA/waste-carriers-engine/pull/887). We are just updating the version of the engine to bring the change into the back-office.

<details><summary>Before</summary>

![Screenshot 2020-07-14 at 11 26 59](https://user-images.githubusercontent.com/1789650/87416104-1ed9ad00-c5c6-11ea-8d49-30745cc58278.png)

</details>

<details><summary>After</summary>

![Screenshot 2020-07-14 at 11 33 37](https://user-images.githubusercontent.com/1789650/87416142-2ef18c80-c5c6-11ea-903f-9dd3a0abc8f3.png)

</details>