### PR TITLE
Add payment confirmation email to view details

### DIFF
--- a/app/views/registrations/show.html.erb
+++ b/app/views/registrations/show.html.erb
@@ -50,6 +50,10 @@
         <% if @registration.main_people.any? %>
           <%= render "shared/registrations/main_people_details", resource: @registration %>
         <% end %>
+
+        <% if @registration.receipt_email.present? && !@registration.receipt_email.empty? %>
+          <%= render "shared/registrations/receipt_email_panel", resource: @registration %>
+        <% end %>
       </div>
 
       <div class="column-one-third">

--- a/app/views/registrations/show.html.erb
+++ b/app/views/registrations/show.html.erb
@@ -51,7 +51,7 @@
           <%= render "shared/registrations/main_people_details", resource: @registration %>
         <% end %>
 
-        <% if @registration.receipt_email.present? && !@registration.receipt_email.empty? %>
+        <% if @registration.receipt_email.present? %>
           <%= render "shared/registrations/receipt_email_panel", resource: @registration %>
         <% end %>
       </div>

--- a/app/views/shared/registrations/_receipt_email_panel.html.erb
+++ b/app/views/shared/registrations/_receipt_email_panel.html.erb
@@ -1,6 +1,15 @@
 <h2 class="heading-medium">
     <%= t(".heading") %>
 </h2>
-<p>
-  <%= resource.receipt_email %>
-</p>
+<table>
+  <tbody>
+    <tr>
+      <th>
+        <%= t(".labels.email") %>
+      </th>
+      <td>
+        <%= resource.receipt_email %>
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/app/views/shared/registrations/_receipt_email_panel.html.erb
+++ b/app/views/shared/registrations/_receipt_email_panel.html.erb
@@ -1,0 +1,6 @@
+<h2 class="heading-medium">
+    <%= t(".heading") %>
+</h2>
+<p>
+  <%= resource.receipt_email %>
+</p>

--- a/config/locales/shared/registrations.en.yml
+++ b/config/locales/shared/registrations.en.yml
@@ -93,7 +93,9 @@ en:
           revoked: "Revoked"
         reason: "Reason:"
       receipt_email_panel:
-        heading: Payment confirmation email
+        heading: Card payment confirmation
+        labels:
+          email: "Email address"
       finance_details:
         finance_information:
           lower_tier_message: "Lower tier registration - charges are not applicable."

--- a/config/locales/shared/registrations.en.yml
+++ b/config/locales/shared/registrations.en.yml
@@ -92,6 +92,8 @@ en:
           ceased: "Ceased"
           revoked: "Revoked"
         reason: "Reason:"
+      receipt_email_panel:
+        heading: Payment confirmation email
       finance_details:
         finance_information:
           lower_tier_message: "Lower tier registration - charges are not applicable."


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1159

Now we are collecting a payment confirmation email during the registration and renewal journey we should really be showing it in the view details page. Else there will be no means to see this in the system.

<details><summary>Example</summary>

<img width="651" alt="Screenshot 2020-07-16 at 22 32 42" src="https://user-images.githubusercontent.com/1789650/87724971-4f7f3980-c7b4-11ea-93b8-1d86ef960735.png">

</details>