### PR TITLE
Allow individual pages to include page_scripts

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,6 @@
 <% content_for(:head) do %>
   <%= stylesheet_link_tag "application", media: "all" %>
+  <%= yield :page_scripts %>
   <%= csrf_meta_tags %>
 <% end %>
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1141

As part of https://github.com/DEFRA/waste-carriers-engine/pull/892 I wanted to add the ability to include JavaScript on specific pages.

This change allows us to use `content_for :page_scripts` on individual views and yield it as part of the template. See the engine PR for an example.