### PR TITLE
Extend back office renewal grace period

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -89,7 +89,12 @@ module WasteCarriersBackOffice
     # Times
     config.renewal_window = ENV["WCRS_REGISTRATION_RENEWAL_WINDOW"].to_i
     config.expires_after = ENV["WCRS_REGISTRATION_EXPIRES_AFTER"].to_i
-    config.grace_window = ENV["WCRS_REGISTRATION_GRACE_WINDOW"].to_i
+    config.grace_window = if ENV["BO_CAN_ALWAYS_RENEW_EXPIRED"].to_s.downcase == "true"
+                            # Can renew for as long as a renewed registration would be active
+                            ENV["WCRS_REGISTRATION_EXPIRES_AFTER"].to_i * 365
+                          else
+                            ENV["WCRS_REGISTRATION_GRACE_WINDOW"].to_i
+                          end
 
     # Worldpay
     config.worldpay_url = if ENV["WCRS_MOCK_ENABLED"].to_s.downcase == "true"


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1153

Currently, if a user expires and is past the grace window, they have to make a new registration. This means they cannot keep their old reg number and have to pay an additional cost for a new reg (as renewals are cheaper).

NCCC will often choose to refund these users for that extra fee when they are contacted (although they are not obligated to do this). This is an admin-heavy process.

To make this easier for them, we’ve decided to allow NCCC users to always be able to renew an expired reg regardless of the grace window. This will mean they don’t need to deal with as much admin, and the user gets to keep their number.

This should not affect the front office.

---

This is a very MVP implementation that doesn't use the feature flag engine yet.