### PR TITLE
Remove create new reg. link if feature disabled

### DIFF
--- a/app/presenters/ad_privacy_policy_presenter.rb
+++ b/app/presenters/ad_privacy_policy_presenter.rb
@@ -6,7 +6,7 @@ class AdPrivacyPolicyPresenter < WasteCarriersEngine::BasePresenter
     return renewal_path if reg_identifier.present?
     return resume_path if transient_registration.present?
 
-    new_registration_path
+    WasteCarriersEngine::Engine.routes.url_helpers.new_start_form_path
   end
 
   private
@@ -28,13 +28,5 @@ class AdPrivacyPolicyPresenter < WasteCarriersEngine::BasePresenter
       "new_#{transient_registration.workflow_state}_path".to_sym,
       token: transient_registration.token
     )
-  end
-
-  def new_registration_path
-    if WasteCarriersEngine::FeatureToggle.active?(:new_registration)
-      WasteCarriersEngine::Engine.routes.url_helpers.new_start_form_path
-    else
-      File.join(Rails.configuration.wcrs_backend_url, "registrations/start")
-    end
   end
 end

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -38,7 +38,7 @@
     </div>
   </div>
 
-  <% if can?(:create, WasteCarriersEngine::Registration) %>
+  <% if can?(:create, WasteCarriersEngine::Registration) && WasteCarriersEngine::FeatureToggle.active?(:new_registration) %>
     <div class="column-one-third">
       <div class="wcr-actions">
         <h2 class="heading-small">

--- a/spec/presenters/ad_privacy_policy_presenter_spec.rb
+++ b/spec/presenters/ad_privacy_policy_presenter_spec.rb
@@ -28,24 +28,8 @@ RSpec.describe AdPrivacyPolicyPresenter do
     end
 
     context "when neither 'reg_identifier' nor 'token' are present" do
-      before(:each) do
-        allow(WasteCarriersEngine::FeatureToggle).to receive(:active?).with(:new_registration) { feature_enabled }
-      end
-
-      context "and the 'new_registration' feature is enabled" do
-        let(:feature_enabled) { true }
-
-        it "returns a new registration start form path to the back-office" do
-          expect(subject.destination_path).to eq("/bo/start")
-        end
-      end
-
-      context "and the 'new_registration' feature is not enabled" do
-        let(:feature_enabled) { false }
-
-        it "returns a new registration start form path to the backend" do
-          expect(subject.destination_path).to eq("http://localhost:3000/registrations/start")
-        end
+      it "returns a new registration start form path to the back-office" do
+        expect(subject.destination_path).to eq("/bo/start")
       end
     end
   end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1163

RUBY-1163 highlights a bug that occurs because of users being forced to return to the old backend app from the new back-office to create a registration. In this case if the user is not already logged into the backend they'll be able to start a registration but eventually (at the 'What type of business are you?' page) it will throw up the sign-in page and lose the progress so far.

This is actually because the 'New or renew' and 'Location' pages were added to the journey later in WCR's life. Business type is the first of the old-old code and where the app starts to check user credentials.

We've always known there are issues and problems with switching between the apps. But we have not wanted to invest too much time in trying to resolve them because we are more focused on moving to just having one app.

Case in point, currently we don't have a 'Create new registration' link in our production version of the back-office because we know it will lead to these issues.

So to fix RUBY-1118 we need to update the logic for the 'Create new registration' link. If `:new_registration` is enabled the link should be shown. If disabled then the back-office should replicate the current process and not show the link. This means users are required to log int the backend to create new registrations, which nullifies this issue and others like it.