### PR TITLE
Extend back office renewal grace period

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ gem "defra_ruby_aws", "~> 0.3.0"
 # Use the waste carriers engine for the user journey
 gem "waste_carriers_engine",
     git: "https://github.com/DEFRA/waste-carriers-engine",
-    branch: "main"
+    branch: "expiry-refactor"
 
 # Use the Defra Ruby Features gem to allow users with the correct permissions to
 # manage feature toggle (create / update / delete) from the back-office.
@@ -117,6 +117,7 @@ group :test do
   gem "database_cleaner"
   gem "factory_bot_rails"
   gem "rails-controller-testing"
+  gem "timecop"
 
   # Generates a test coverage report on every `bundle exec rspec` call. We use
   # the output to feed SonarCloud's stats and analysis

--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ gem "defra_ruby_aws", "~> 0.3.0"
 # Use the waste carriers engine for the user journey
 gem "waste_carriers_engine",
     git: "https://github.com/DEFRA/waste-carriers-engine",
-    branch: "expiry-refactor"
+    branch: "main"
 
 # Use the Defra Ruby Features gem to allow users with the correct permissions to
 # manage feature toggle (create / update / delete) from the back-office.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: 8f00002f354675e6c8b2942905dc2d2157d80802
-  branch: main
+  revision: 0bffdbc8c11ed5ab30ebf6162280638b39c4dce6
+  branch: expiry-refactor
   specs:
     waste_carriers_engine (0.0.1)
       aasm (~> 4.12)
@@ -392,6 +392,7 @@ GEM
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
+    timecop (0.9.1)
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
@@ -463,6 +464,7 @@ DEPENDENCIES
   secure_headers (~> 5.0)
   simplecov (~> 0.17.1)
   spring
+  timecop
   turbolinks
   uglifier (>= 1.3.0)
   waste_carriers_engine!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: 0bffdbc8c11ed5ab30ebf6162280638b39c4dce6
-  branch: expiry-refactor
+  revision: 1eb289d1503a4ff11a1086a8a74d3541b86885c8
+  branch: main
   specs:
     waste_carriers_engine (0.0.1)
       aasm (~> 4.12)

--- a/app/services/waste_carriers_engine/expiry_check_service.rb
+++ b/app/services/waste_carriers_engine/expiry_check_service.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require WasteCarriersEngine::Engine.root.join(
+  "app",
+  "services",
+  "waste_carriers_engine",
+  "expiry_check_service"
+)
+
+module WasteCarriersEngine
+  class ExpiryCheckService
+    def in_expiry_grace_window?
+      last_day_of_grace_window = if FeatureToggle.active?(:use_extended_grace_window)
+                                   last_day_of_extended_grace_window
+                                 else
+                                   last_day_of_standard_grace_window
+                                 end
+
+      current_day_is_within_grace_window?(last_day_of_grace_window)
+    end
+
+    private
+
+    def last_day_of_extended_grace_window
+      (expiry_date.to_date + Rails.configuration.expires_after.years) - 1.day
+    end
+  end
+end

--- a/spec/services/waste_carriers_engine/expiry_check_service_spec.rb
+++ b/spec/services/waste_carriers_engine/expiry_check_service_spec.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe ExpiryCheckService do
+    # Registration is made during British Summer Time (BST)
+    # UK local time is 00:30 on 28 March 2017
+    # UTC time is 23:30 on 27 March 2017
+    # Registration should expire on 28 March 2020
+    let!(:bst_registration) do
+      registration = create(:registration)
+      registration.metaData.status = "EXPIRED"
+      registration.metaData.date_registered = Time.find_zone("London").local(2017, 3, 28, 0, 30)
+      registration.expires_on = registration.metaData.date_registered + 3.years
+      registration.save!
+      registration
+    end
+
+    # Registration is made in during Greenwich Mean Time (GMT)
+    # UK local time & UTC are both 23:30 on 27 October 2015
+    # Registration should expire on 27 October 2018
+    let!(:gmt_registration) do
+      registration = build(:registration)
+      registration.metaData.status = "EXPIRED"
+      registration.metaData.date_registered = Time.find_zone("London").local(2015, 10, 27, 23, 30)
+      registration.expires_on = registration.metaData.date_registered + 3.years
+      registration.save!
+      registration
+    end
+
+    describe "#in_expiry_grace_window?" do
+      # You have to use let! to ensure it is not lazy-evaluated. If it is
+      # it will be called inside the Timecop.freeze methods listed below
+      # which means Date.today will evaluate to the date Timecop is freezing.
+      # This leads to false positives for some tests, and a fail for the outside
+      # renewal window.
+      let!(:registration) { build(:registration, expires_on: Date.today) }
+      subject { ExpiryCheckService.new(registration) }
+
+      context "when use_extended_grace_window is true" do
+        before { expect(FeatureToggle).to receive(:active?).with(:use_extended_grace_window).and_return(true) }
+
+        context "and the current date is less than 3 years after expiry" do
+          it "returns true" do
+            Timecop.freeze(Date.today + 2.years) do
+              expect(subject.in_expiry_grace_window?).to eq(true)
+            end
+          end
+        end
+
+        context "and the current date is more than 3 years after expiry" do
+          it "returns false" do
+            Timecop.freeze(Date.today + 3.years) do
+              expect(subject.in_expiry_grace_window?).to eq(false)
+            end
+          end
+        end
+
+        context "and the current date is before expiry" do
+          it "returns false" do
+            Timecop.freeze(Date.today - 1.year) do
+              expect(subject.in_expiry_grace_window?).to eq(false)
+            end
+          end
+        end
+      end
+
+      context "when the grace window is 3 days" do
+        before { allow(Rails.configuration).to receive(:grace_window).and_return(3) }
+
+        context "and the current date is within the window" do
+          it "returns true" do
+            Timecop.freeze((Date.today + 3.days) - 1.day) do
+              expect(subject.in_expiry_grace_window?).to eq(true)
+            end
+          end
+        end
+
+        context "and the current date is outside the window" do
+          it "returns false" do
+            Timecop.freeze(Date.today + 3.days) do
+              expect(subject.in_expiry_grace_window?).to eq(false)
+            end
+          end
+        end
+
+        context "when the registration was created in BST and expires in GMT" do
+          subject { ExpiryCheckService.new(bst_registration) }
+
+          it "should not be within the grace window for an extra day due to the time difference" do
+            # Skip ahead to the start of the day a reg should expire, plus the
+            # grace window
+            Timecop.freeze(Time.find_zone("London").local(2020, 3, 31, 0, 1)) do
+              # GMT is now in effect (not BST)
+              # UK local time & UTC are both 00:01 on 28 March 2020
+              expect(subject.in_expiry_grace_window?).to eq(false)
+            end
+          end
+        end
+
+        context "when the registration was created in GMT and expires in BST" do
+          subject { ExpiryCheckService.new(gmt_registration) }
+
+          it "should not be within the grace window for an extra day due to the time difference" do
+            # Skip ahead to the start of the day a reg should expire, plus the
+            # grace window
+            Timecop.freeze(Time.find_zone("London").local(2018, 10, 30, 0, 1)) do
+              # BST is now in effect (not GMT)
+              # UK local time is 00:01 on 27 October 2018
+              # UTC time is 23:01 on 26 October 2018
+              expect(subject.in_expiry_grace_window?).to eq(false)
+            end
+          end
+        end
+      end
+
+      context "when there is no grace window" do
+        before { allow(Rails.configuration).to receive(:grace_window).and_return(0) }
+
+        it "returns false" do
+          Timecop.freeze(Date.today + 3.days) do
+            expect(subject.in_expiry_grace_window?).to eq(false)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1153

Currently, if a user expires and is past the grace window, they have to make a new registration. This means they cannot keep their old reg number and have to pay an additional cost for a new reg (as renewals are cheaper).

NCCC will often choose to refund these users for that extra fee when they are contacted (although they are not obligated to do this). This is an admin-heavy process.

To make this easier for them, we’ve decided to allow NCCC users to always be able to renew an expired reg regardless of the grace window. This will mean they don’t need to deal with as much admin, and the user gets to keep their number.

This should not affect the front office.

---

Depends on https://github.com/DEFRA/waste-carriers-engine/pull/893