### PR TITLE
Add extend grace window toggle to .yml file

### DIFF
--- a/config/feature_toggles.yml
+++ b/config/feature_toggles.yml
@@ -7,3 +7,5 @@ email_reminders:
   active: <%= ENV["FEATURE_TOGGLE_EMAIL_REMINDERS"] %>
 renew_via_magic_link:
   active: <%= ENV["RENEW_VIA_MAGIC_LINK"] %>
+use_extended_grace_window:
+  active: <%= ENV["USE_EXTENDED_GRACE_WINDOW"] %>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1153

[PR #953](https://github.com/DEFRA/waste-carriers-back-office/pull/953) updated the back-office to allow NCCC users to renew an expired registration even outside of the grace window. This was to help NCCC avoid the admin overhead of dealing with registrations that they wish to renew but can't because the system tells them it's too late. Now they can decide for themselves.

The feature is controlled by a feature toggle, but we omitted to add it to the `config/feature_toggles.yml` file. It's not needed for the toggle to work. But the file is acting as a great single point of documentation for what toggles actually exist.

So this changes adds it to the file.