### PR TITLE
Tell engine we are the back-office

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: 5f43afa3607b01b413fbc5bb2f35964686e0bb47
+  revision: 2225e58b86b3bebae7f0e657d295bf72af07d8a9
   branch: main
   specs:
     waste_carriers_engine (0.0.1)

--- a/config/initializers/waste_carriers_engine.rb
+++ b/config/initializers/waste_carriers_engine.rb
@@ -26,5 +26,13 @@ WasteCarriersEngine.configure do |configuration|
   configuration.airbrake_blocklist = [/password/i, /authorization/i]
 
   configuration.address_host = ENV["ADDRESSBASE_URL"] || "http://localhost:8005"
+
+  # By telling the engine it is hosted in the back-office it can make decisions
+  # about any changes in behaviour needed. For example, the payment confirmation
+  # email from Worldpay is only applicable to users in the front-office. This is
+  # because Worldpay does not send one if the merchant code is MOTO. So the
+  # engine can use this flag to determine whether to show payment confirmation
+  # related content
+  configuration.host_is_back_office = true
 end
 WasteCarriersEngine.start_airbrake


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1141

We have come across an issue where we need to change behaviour in the journey based on whether a registration or renewal is being carried out in either the front-office app or the back-office app.

The simplest way we felt to do this was to add a new flag to the config (see [Add host_is_back_office flag to config](https://github.com/DEFRA/waste-carriers-engine/pull/894)) and set it in the initializer.