### PR TITLE
Update payment confirmation behaviour

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: 2225e58b86b3bebae7f0e657d295bf72af07d8a9
+  revision: 4b06e59b654bb236fde3469e24d0980126efbbc3
   branch: main
   specs:
     waste_carriers_engine (0.0.1)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1141
https://eaflood.atlassian.net/browse/RUBY-1165

This updates the back-office to a version of the engine where payment confirmation content is shown based on whether or not it is hosted in the back or front-office.

We have come across an issue where we need to change behaviour in the journey based on whether a registration or renewal is being carried out in either the front-office app or the back-office app.

We should have known, but have just realised that Worldpay does not send payment confirmation emails if the merchant code used is MOTO.

So now we don't show payment confirmation content in the registration and renewal journeys if they are being done from the back-office.

This version of the engine does include an updated version of the Edit view which includes the payment confirmation (though it remains uneditable).