### PR TITLE
Generate renewal token when one is requested

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ gem "defra_ruby_aws", "~> 0.3.0"
 # Use the waste carriers engine for the user journey
 gem "waste_carriers_engine",
     git: "https://github.com/DEFRA/waste-carriers-engine",
-    branch: "generate-renewal-token-on-request"
+    branch: "main"
 
 # Use the Defra Ruby Features gem to allow users with the correct permissions to
 # manage feature toggle (create / update / delete) from the back-office.

--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ gem "defra_ruby_aws", "~> 0.3.0"
 # Use the waste carriers engine for the user journey
 gem "waste_carriers_engine",
     git: "https://github.com/DEFRA/waste-carriers-engine",
-    branch: "main"
+    branch: "generate-renewal-token-on-request"
 
 # Use the Defra Ruby Features gem to allow users with the correct permissions to
 # manage feature toggle (create / update / delete) from the back-office.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: e92f470c3768a6b714c64e3ada21594e97770391
-  branch: generate-renewal-token-on-request
+  revision: 3c3a6cb5b2eb61503ff3a2a9850281ab68f843a0
+  branch: main
   specs:
     waste_carriers_engine (0.0.1)
       aasm (~> 4.12)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: 4b06e59b654bb236fde3469e24d0980126efbbc3
-  branch: main
+  revision: e92f470c3768a6b714c64e3ada21594e97770391
+  branch: generate-renewal-token-on-request
   specs:
     waste_carriers_engine (0.0.1)
       aasm (~> 4.12)

--- a/app/mailers/renewal_reminder_mailer.rb
+++ b/app/mailers/renewal_reminder_mailer.rb
@@ -4,14 +4,10 @@ class RenewalReminderMailer < ActionMailer::Base
   helper "waste_carriers_engine/mailer"
 
   def first_reminder_email(registration)
-    generate_magic_link(registration)
-
     reminder_email(registration)
   end
 
   def second_reminder_email(registration)
-    generate_magic_link(registration) unless registration.renew_token.present?
-
     reminder_email(registration)
   end
 
@@ -39,11 +35,5 @@ class RenewalReminderMailer < ActionMailer::Base
       "/fo/renew/",
       registration.renew_token
     ].join
-  end
-
-  def generate_magic_link(registration)
-    return unless WasteCarriersEngine::FeatureToggle.active?(:renew_via_magic_link)
-
-    registration.generate_renew_token!
   end
 end

--- a/spec/mailers/renewal_reminder_mailer_spec.rb
+++ b/spec/mailers/renewal_reminder_mailer_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe RenewalReminderMailer, type: :mailer do
     it "sends a first reminder email" do
       mail = described_class.first_reminder_email(registration)
 
-      expect(registration).to receive(:generate_renew_token!)
+      expect(registration).to receive(:renew_token)
       expect(mail.subject).to include("Renew waste carrier registration")
       expect(mail.to).to eq([registration.contact_email])
       expect(mail.body.encoded).to include(registration.reg_identifier)
@@ -34,7 +34,7 @@ RSpec.describe RenewalReminderMailer, type: :mailer do
     it "sends a second reminder email" do
       mail = described_class.second_reminder_email(registration)
 
-      expect(registration).to receive(:generate_renew_token!)
+      expect(registration).to receive(:renew_token)
       expect(mail.subject).to include("Renew waste carrier registration")
       expect(mail.to).to eq([registration.contact_email])
       expect(mail.body.encoded).to include(registration.reg_identifier)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1166

If a registration is eligible for renewal NCCC would like us to display the same renewal link that gets included in the renewal reminder emails and letters in registration details.

Currently though we only generate the token used in the link when first generating the reminder email. A registration is eligible for renewal before this is done. And when we first release there will be hundreds that are eligible which will never go through the reminder process because it is too late.

The simplest solution we have for this is to generate it if required. We made that change in the engine in [PR #898](https://github.com/DEFRA/waste-carriers-engine/pull/898). This change updates the back-office to use the new functionality.