### PR TITLE
Display renewal reminder magic link in reg. detail

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ gem "defra_ruby_aws", "~> 0.3.0"
 # Use the waste carriers engine for the user journey
 gem "waste_carriers_engine",
     git: "https://github.com/DEFRA/waste-carriers-engine",
-    branch: "generate-renewal-token-on-request"
+    branch: "main"
 
 # Use the Defra Ruby Features gem to allow users with the correct permissions to
 # manage feature toggle (create / update / delete) from the back-office.

--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ gem "defra_ruby_aws", "~> 0.3.0"
 # Use the waste carriers engine for the user journey
 gem "waste_carriers_engine",
     git: "https://github.com/DEFRA/waste-carriers-engine",
-    branch: "main"
+    branch: "generate-renewal-token-on-request"
 
 # Use the Defra Ruby Features gem to allow users with the correct permissions to
 # manage feature toggle (create / update / delete) from the back-office.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: 3c3a6cb5b2eb61503ff3a2a9850281ab68f843a0
+  revision: 220bbefdfa6aad6b2ef40b599c0ca1cc47299356
   branch: main
   specs:
     waste_carriers_engine (0.0.1)

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -23,8 +23,7 @@ module ActionLinksHelper
   end
 
   def display_renewal_link_for?(resource)
-    return false unless WasteCarriersEngine::FeatureToggle.active?(:renew_via_magic_link)
-    return false unless WasteCarriersEngine::FeatureToggle.active?(:display_renewal_link)
+    return false unless WasteCarriersEngine::FeatureToggle.active?(:renewal_reminders)
 
     display_renew_link_for?(resource)
   end

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -22,6 +22,16 @@ module ActionLinksHelper
     ad_privacy_policy_path(reg_identifier: resource.reg_identifier)
   end
 
+  def renewal_link_for(resource)
+    return "" unless a_registration?(resource)
+
+    [
+      Rails.configuration.wcrs_renewals_url,
+      "/fo/renew/",
+      resource.renew_token
+    ].join
+  end
+
   def display_write_off_small_link_for?(resource)
     can?(:write_off_small, resource) && resource.balance != 0
   end

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -22,6 +22,13 @@ module ActionLinksHelper
     ad_privacy_policy_path(reg_identifier: resource.reg_identifier)
   end
 
+  def display_renewal_link_for?(resource)
+    return false unless WasteCarriersEngine::FeatureToggle.active?(:display_renewal_link)
+    return false unless can?(:renew, WasteCarriersEngine::Registration)
+
+    resource.can_start_renewal?
+  end
+
   def renewal_link_for(resource)
     return nil unless a_registration?(resource)
     return nil unless resource.renew_token.present?

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -32,11 +32,7 @@ module ActionLinksHelper
     return nil unless a_registration?(resource)
     return nil unless resource.renew_token.present?
 
-    [
-      Rails.configuration.wcrs_renewals_url,
-      "/fo/renew/",
-      resource.renew_token
-    ].join
+    RenewalMagicLinkService.run(token: resource.renew_token)
   end
 
   def display_write_off_small_link_for?(resource)

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -22,13 +22,13 @@ module ActionLinksHelper
     ad_privacy_policy_path(reg_identifier: resource.reg_identifier)
   end
 
-  def display_renewal_link_for?(resource)
+  def display_renewal_magic_link_for?(resource)
     return false unless WasteCarriersEngine::FeatureToggle.active?(:renewal_reminders)
 
     display_renew_link_for?(resource)
   end
 
-  def renewal_link_for(resource)
+  def renewal_magic_link_for(resource)
     return nil unless a_registration?(resource)
     return nil unless resource.renew_token.present?
 

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -23,7 +23,8 @@ module ActionLinksHelper
   end
 
   def renewal_link_for(resource)
-    return "" unless a_registration?(resource)
+    return nil unless a_registration?(resource)
+    return nil unless resource.renew_token.present?
 
     [
       Rails.configuration.wcrs_renewals_url,

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -23,6 +23,7 @@ module ActionLinksHelper
   end
 
   def display_renewal_link_for?(resource)
+    return false unless WasteCarriersEngine::FeatureToggle.active?(:renew_via_magic_link)
     return false unless WasteCarriersEngine::FeatureToggle.active?(:display_renewal_link)
 
     display_renew_link_for?(resource)

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -24,9 +24,8 @@ module ActionLinksHelper
 
   def display_renewal_link_for?(resource)
     return false unless WasteCarriersEngine::FeatureToggle.active?(:display_renewal_link)
-    return false unless can?(:renew, WasteCarriersEngine::Registration)
 
-    resource.can_start_renewal?
+    display_renew_link_for?(resource)
   end
 
   def renewal_link_for(resource)

--- a/app/mailers/renewal_reminder_mailer.rb
+++ b/app/mailers/renewal_reminder_mailer.rb
@@ -19,7 +19,7 @@ class RenewalReminderMailer < ActionMailer::Base
       ".renewal_reminder_mailer.first_reminder_email.subject",
       reg_identifier: registration.reg_identifier
     )
-    @renew_link = generate_renew_link(registration)
+    @renew_link = RenewalMagicLinkService.run(token: registration.renew_token)
 
     mail(
       to: registration.contact_email,
@@ -27,13 +27,5 @@ class RenewalReminderMailer < ActionMailer::Base
       subject: subject,
       template_name: :first_reminder_email
     )
-  end
-
-  def generate_renew_link(registration)
-    [
-      Rails.configuration.wcrs_renewals_url,
-      "/fo/renew/",
-      registration.renew_token
-    ].join
   end
 end

--- a/app/services/renewal_magic_link_service.rb
+++ b/app/services/renewal_magic_link_service.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class RenewalMagicLinkService < ::WasteCarriersEngine::BaseService
+  def run(token:)
+    [
+      Rails.configuration.wcrs_renewals_url,
+      "/fo/renew/",
+      token
+    ].join
+  end
+end

--- a/app/views/registrations/show.html.erb
+++ b/app/views/registrations/show.html.erb
@@ -54,6 +54,10 @@
         <% if @registration.receipt_email.present? %>
           <%= render "shared/registrations/receipt_email_panel", resource: @registration %>
         <% end %>
+
+        <% if WasteCarriersEngine::FeatureToggle.active?(:display_renewal_link) && renewal_link_for(@registration) %>
+          <%= render "shared/registrations/renewal_link_panel", resource: @registration %>
+        <% end %>
       </div>
 
       <div class="column-one-third">

--- a/app/views/registrations/show.html.erb
+++ b/app/views/registrations/show.html.erb
@@ -55,7 +55,7 @@
           <%= render "shared/registrations/receipt_email_panel", resource: @registration %>
         <% end %>
 
-        <% if display_renewal_link_for?(@registration) %>
+        <% if display_renewal_magic_link_for?(@registration) %>
           <%= render "shared/registrations/renewal_link_panel", resource: @registration %>
         <% end %>
       </div>

--- a/app/views/registrations/show.html.erb
+++ b/app/views/registrations/show.html.erb
@@ -55,7 +55,7 @@
           <%= render "shared/registrations/receipt_email_panel", resource: @registration %>
         <% end %>
 
-        <% if WasteCarriersEngine::FeatureToggle.active?(:display_renewal_link) && renewal_link_for(@registration) %>
+        <% if display_renewal_link_for?(@registration) %>
           <%= render "shared/registrations/renewal_link_panel", resource: @registration %>
         <% end %>
       </div>

--- a/app/views/shared/registrations/_renewal_link_panel.html.erb
+++ b/app/views/shared/registrations/_renewal_link_panel.html.erb
@@ -1,0 +1,12 @@
+<h2 class="heading-medium">
+    <%= t(".heading") %>
+</h2>
+<table>
+  <tbody>
+    <tr>
+      <td>
+        <%= renewal_link_for(resource) %>
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/config/locales/shared/registrations.en.yml
+++ b/config/locales/shared/registrations.en.yml
@@ -96,6 +96,8 @@ en:
         heading: Card payment confirmation
         labels:
           email: "Email address"
+      renewal_link_panel:
+        heading: Renewal link
       finance_details:
         finance_information:
           lower_tier_message: "Lower tier registration - charges are not applicable."

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -127,6 +127,34 @@ RSpec.describe ActionLinksHelper, type: :helper do
     end
   end
 
+  describe "renewal_link_for" do
+    context "when the resource is a new registration" do
+      let(:resource) { build(:new_registration, token: "foo") }
+
+      it "returns an empty string" do
+        expect(helper.renewal_link_for(resource)).to eq("")
+      end
+    end
+
+    context "when the resource is a renewing registration" do
+      let(:resource) { build(:renewing_registration) }
+
+      it "returns an empty string" do
+        expect(helper.renewal_link_for(resource)).to eq("")
+      end
+    end
+
+    context "when the resource is a registration" do
+      let(:resource) { build(:registration, renew_token: renew_token) }
+      let(:renew_token) { "footoken" }
+
+      it "returns the registration path" do
+        expect(helper.renewal_link_for(resource))
+          .to eq("#{Rails.configuration.wcrs_renewals_url}/fo/renew/#{renew_token}")
+      end
+    end
+  end
+
   describe "#display_refund_link_for?" do
     let(:resource) { build(:finance_details, balance: balance) }
 

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe ActionLinksHelper, type: :helper do
     end
   end
 
-  describe "#display_renewal_link_for?" do
+  describe "#display_renewal_magic_link_for?" do
     let(:resource) { build(:registration) }
 
     context "when the 'renewal_reminders' feature toggle is enabled" do
@@ -139,7 +139,7 @@ RSpec.describe ActionLinksHelper, type: :helper do
         let(:resource) { build(:renewing_registration) }
 
         it "returns false" do
-          expect(helper.display_renewal_link_for?(resource)).to eq(false)
+          expect(helper.display_renewal_magic_link_for?(resource)).to eq(false)
         end
       end
 
@@ -147,7 +147,7 @@ RSpec.describe ActionLinksHelper, type: :helper do
         before { allow(helper).to receive(:can?).and_return(false) }
 
         it "returns false" do
-          expect(helper.display_renewal_link_for?(resource)).to eq(false)
+          expect(helper.display_renewal_magic_link_for?(resource)).to eq(false)
         end
       end
 
@@ -158,7 +158,7 @@ RSpec.describe ActionLinksHelper, type: :helper do
           before { allow(resource).to receive(:can_start_renewal?).and_return(false) }
 
           it "returns false" do
-            expect(helper.display_renewal_link_for?(resource)).to eq(false)
+            expect(helper.display_renewal_magic_link_for?(resource)).to eq(false)
           end
         end
 
@@ -166,7 +166,7 @@ RSpec.describe ActionLinksHelper, type: :helper do
           before { allow(resource).to receive(:can_start_renewal?).and_return(true) }
 
           it "returns true" do
-            expect(helper.display_renewal_link_for?(resource)).to eq(true)
+            expect(helper.display_renewal_magic_link_for?(resource)).to eq(true)
           end
         end
       end
@@ -178,17 +178,17 @@ RSpec.describe ActionLinksHelper, type: :helper do
       end
 
       it "returns false" do
-        expect(helper.display_renewal_link_for?(resource)).to eq(false)
+        expect(helper.display_renewal_magic_link_for?(resource)).to eq(false)
       end
     end
   end
 
-  describe "renewal_link_for" do
+  describe "#renewal_magic_link_for" do
     context "when the resource is a new registration" do
       let(:resource) { build(:new_registration, token: "foo") }
 
       it "returns an nil" do
-        expect(helper.renewal_link_for(resource)).to be_nil
+        expect(helper.renewal_magic_link_for(resource)).to be_nil
       end
     end
 
@@ -196,7 +196,7 @@ RSpec.describe ActionLinksHelper, type: :helper do
       let(:resource) { build(:renewing_registration) }
 
       it "returns nil" do
-        expect(helper.renewal_link_for(resource)).to be_nil
+        expect(helper.renewal_magic_link_for(resource)).to be_nil
       end
     end
 
@@ -206,7 +206,7 @@ RSpec.describe ActionLinksHelper, type: :helper do
         let(:renew_token) { "footoken" }
 
         it "returns the registration path" do
-          expect(helper.renewal_link_for(resource))
+          expect(helper.renewal_magic_link_for(resource))
             .to eq("#{Rails.configuration.wcrs_renewals_url}/fo/renew/#{renew_token}")
         end
       end
@@ -215,7 +215,7 @@ RSpec.describe ActionLinksHelper, type: :helper do
         let(:resource) { build(:registration) }
 
         it "returns nil" do
-          expect(helper.renewal_link_for(resource)).to be_nil
+          expect(helper.renewal_magic_link_for(resource)).to be_nil
         end
       end
     end

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -128,22 +128,36 @@ RSpec.describe ActionLinksHelper, type: :helper do
   end
 
   describe "#display_renewal_link_for?" do
-    context "when the resource is not a Registration" do
-      let(:resource) { build(:renewing_registration) }
+    let(:resource) { build(:registration) }
 
-      it "returns false" do
-        expect(helper.display_renewal_link_for?(resource)).to eq(false)
+    context "and the 'renew_via_magic_link' feature toggle is enabled" do
+      before do
+        allow(WasteCarriersEngine::FeatureToggle).to receive(:active?).with(:renew_via_magic_link).and_return(true)
       end
-    end
 
-    context "when the resource is a Registration" do
-      let(:resource) { build(:registration) }
+      context "but the 'display_renewal_link' feature toggle is not enabled" do
+        before do
+          allow(WasteCarriersEngine::FeatureToggle).to receive(:active?).with(:display_renewal_link).and_return(false)
+        end
+
+        it "returns false" do
+          expect(helper.display_renewal_link_for?(resource)).to eq(false)
+        end
+      end
 
       context "and the 'display_renewal_link' feature toggle is enabled" do
         before { allow(WasteCarriersEngine::FeatureToggle).to receive(:active?).and_return(true) }
 
         context "and the user does not have permission" do
           before { allow(helper).to receive(:can?).and_return(false) }
+
+          it "returns false" do
+            expect(helper.display_renewal_link_for?(resource)).to eq(false)
+          end
+        end
+
+        context "but the resource is not a Registration" do
+          let(:resource) { build(:renewing_registration) }
 
           it "returns false" do
             expect(helper.display_renewal_link_for?(resource)).to eq(false)
@@ -170,13 +184,13 @@ RSpec.describe ActionLinksHelper, type: :helper do
           end
         end
       end
+    end
 
-      context "when the 'display_renewal_link' feature toggle is not enabled" do
-        before { allow(WasteCarriersEngine::FeatureToggle).to receive(:active?).and_return(false) }
+    context "when the 'renew_via_magic_link' feature toggle is not enabled" do
+      before { allow(WasteCarriersEngine::FeatureToggle).to receive(:active?).and_return(false) }
 
-        it "returns false" do
-          expect(helper.display_renewal_link_for?(resource)).to eq(false)
-        end
+      it "returns false" do
+        expect(helper.display_renewal_link_for?(resource)).to eq(false)
       end
     end
   end

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -127,6 +127,60 @@ RSpec.describe ActionLinksHelper, type: :helper do
     end
   end
 
+  describe "#display_renewal_link_for?" do
+    context "when the resource is not a Registration" do
+      let(:resource) { build(:renewing_registration) }
+
+      it "returns false" do
+        expect(helper.display_renewal_link_for?(resource)).to eq(false)
+      end
+    end
+
+    context "when the resource is a Registration" do
+      let(:resource) { build(:registration) }
+
+      context "and the 'display_renewal_link' feature toggle is enabled" do
+        before { allow(WasteCarriersEngine::FeatureToggle).to receive(:active?).and_return(true) }
+
+        context "and the user does not have permission" do
+          before { allow(helper).to receive(:can?).and_return(false) }
+
+          it "returns false" do
+            expect(helper.display_renewal_link_for?(resource)).to eq(false)
+          end
+        end
+
+        context "and the user has permission" do
+          before { allow(helper).to receive(:can?).and_return(true) }
+
+          context "and the resource cannot begin a renewal" do
+            before { allow(resource).to receive(:can_start_renewal?).and_return(false) }
+
+            it "returns false" do
+              expect(helper.display_renewal_link_for?(resource)).to eq(false)
+            end
+          end
+
+          context "and the resource can begin a renewal" do
+            before { allow(resource).to receive(:can_start_renewal?).and_return(true) }
+
+            it "returns true" do
+              expect(helper.display_renewal_link_for?(resource)).to eq(true)
+            end
+          end
+        end
+      end
+
+      context "when the 'display_renewal_link' feature toggle is not enabled" do
+        before { allow(WasteCarriersEngine::FeatureToggle).to receive(:active?).and_return(false) }
+
+        it "returns false" do
+          expect(helper.display_renewal_link_for?(resource)).to eq(false)
+        end
+      end
+    end
+  end
+
   describe "renewal_link_for" do
     context "when the resource is a new registration" do
       let(:resource) { build(:new_registration, token: "foo") }

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -131,26 +131,36 @@ RSpec.describe ActionLinksHelper, type: :helper do
     context "when the resource is a new registration" do
       let(:resource) { build(:new_registration, token: "foo") }
 
-      it "returns an empty string" do
-        expect(helper.renewal_link_for(resource)).to eq("")
+      it "returns an nil" do
+        expect(helper.renewal_link_for(resource)).to be_nil
       end
     end
 
     context "when the resource is a renewing registration" do
       let(:resource) { build(:renewing_registration) }
 
-      it "returns an empty string" do
-        expect(helper.renewal_link_for(resource)).to eq("")
+      it "returns nil" do
+        expect(helper.renewal_link_for(resource)).to be_nil
       end
     end
 
     context "when the resource is a registration" do
-      let(:resource) { build(:registration, renew_token: renew_token) }
-      let(:renew_token) { "footoken" }
+      context "and has a renewal_token" do
+        let(:resource) { build(:registration, renew_token: renew_token) }
+        let(:renew_token) { "footoken" }
 
-      it "returns the registration path" do
-        expect(helper.renewal_link_for(resource))
-          .to eq("#{Rails.configuration.wcrs_renewals_url}/fo/renew/#{renew_token}")
+        it "returns the registration path" do
+          expect(helper.renewal_link_for(resource))
+            .to eq("#{Rails.configuration.wcrs_renewals_url}/fo/renew/#{renew_token}")
+        end
+      end
+
+      context "but doesn't have a renewal token" do
+        let(:resource) { build(:registration) }
+
+        it "returns nil" do
+          expect(helper.renewal_link_for(resource)).to be_nil
+        end
       end
     end
   end

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -130,64 +130,52 @@ RSpec.describe ActionLinksHelper, type: :helper do
   describe "#display_renewal_link_for?" do
     let(:resource) { build(:registration) }
 
-    context "and the 'renew_via_magic_link' feature toggle is enabled" do
+    context "when the 'renewal_reminders' feature toggle is enabled" do
       before do
-        allow(WasteCarriersEngine::FeatureToggle).to receive(:active?).with(:renew_via_magic_link).and_return(true)
+        allow(WasteCarriersEngine::FeatureToggle).to receive(:active?).with(:renewal_reminders).and_return(true)
       end
 
-      context "but the 'display_renewal_link' feature toggle is not enabled" do
-        before do
-          allow(WasteCarriersEngine::FeatureToggle).to receive(:active?).with(:display_renewal_link).and_return(false)
-        end
+      context "but the resource is not a Registration" do
+        let(:resource) { build(:renewing_registration) }
 
         it "returns false" do
           expect(helper.display_renewal_link_for?(resource)).to eq(false)
         end
       end
 
-      context "and the 'display_renewal_link' feature toggle is enabled" do
-        before { allow(WasteCarriersEngine::FeatureToggle).to receive(:active?).and_return(true) }
+      context "and the user does not have permission" do
+        before { allow(helper).to receive(:can?).and_return(false) }
 
-        context "and the user does not have permission" do
-          before { allow(helper).to receive(:can?).and_return(false) }
+        it "returns false" do
+          expect(helper.display_renewal_link_for?(resource)).to eq(false)
+        end
+      end
+
+      context "and the user has permission" do
+        before { allow(helper).to receive(:can?).and_return(true) }
+
+        context "and the resource cannot begin a renewal" do
+          before { allow(resource).to receive(:can_start_renewal?).and_return(false) }
 
           it "returns false" do
             expect(helper.display_renewal_link_for?(resource)).to eq(false)
           end
         end
 
-        context "but the resource is not a Registration" do
-          let(:resource) { build(:renewing_registration) }
+        context "and the resource can begin a renewal" do
+          before { allow(resource).to receive(:can_start_renewal?).and_return(true) }
 
-          it "returns false" do
-            expect(helper.display_renewal_link_for?(resource)).to eq(false)
-          end
-        end
-
-        context "and the user has permission" do
-          before { allow(helper).to receive(:can?).and_return(true) }
-
-          context "and the resource cannot begin a renewal" do
-            before { allow(resource).to receive(:can_start_renewal?).and_return(false) }
-
-            it "returns false" do
-              expect(helper.display_renewal_link_for?(resource)).to eq(false)
-            end
-          end
-
-          context "and the resource can begin a renewal" do
-            before { allow(resource).to receive(:can_start_renewal?).and_return(true) }
-
-            it "returns true" do
-              expect(helper.display_renewal_link_for?(resource)).to eq(true)
-            end
+          it "returns true" do
+            expect(helper.display_renewal_link_for?(resource)).to eq(true)
           end
         end
       end
     end
 
-    context "when the 'renew_via_magic_link' feature toggle is not enabled" do
-      before { allow(WasteCarriersEngine::FeatureToggle).to receive(:active?).and_return(false) }
+    context "when the 'renewal_reminders' feature toggle is not enabled" do
+      before do
+        allow(WasteCarriersEngine::FeatureToggle).to receive(:active?).with(:renewal_reminders).and_return(false)
+      end
 
       it "returns false" do
         expect(helper.display_renewal_link_for?(resource)).to eq(false)

--- a/spec/services/renewal_magic_link_service_spec.rb
+++ b/spec/services/renewal_magic_link_service_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RenewalMagicLinkService do
+  before(:each) do
+    allow(Rails.configuration).to receive(:wcrs_renewals_url).and_return("http://example.com")
+  end
+
+  let(:service) do
+    RenewalMagicLinkService.run(token: token)
+  end
+
+  context "when token is nil" do
+    let(:token) { nil }
+
+    it "returns the magic link without the token" do
+      expect(service).to eq("http://example.com/fo/renew/")
+    end
+  end
+
+  context "when the token is set" do
+    let(:token) { "footoken" }
+
+    it "returns a magic link with the token" do
+      expect(service).to eq("http://example.com/fo/renew/#{token}")
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1166

If a registration is eligible for renewal NCCC would like us to display the same renewal link that gets included in the renewal reminder emails and letters in registration details.

However, the link should not be clickable but shown as plain text. This is to avoid a user accidentally clicking on it and starting the renewal.

The reasoning behind it is so NCCC users can manually send the link to someone, for example, a 3rd party agent, who has a different email from the contact email stored in the registration.

<details><summary>Example</summary>

<img width="654" alt="Screenshot 2020-07-24 at 00 35 48" src="https://user-images.githubusercontent.com/1789650/88348573-b4eba100-cd45-11ea-82a4-09d1ec064fa1.png">

</details>