### PR TITLE
Merge email_reminders and renew_via_magic_link

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,7 +31,7 @@
                               main_app.users_path %>
                 </li>
               <% end %>
-              <% if can?(:manage, FinalReminderLettersExport) %>
+              <% if WasteCarriersEngine::FeatureToggle.active?(:renewal_reminders) && can?(:manage, FinalReminderLettersExport) %>
                 <li>
                   <%= link_to t("layouts.application.menu.letters"),
                               main_app.letters_path %>

--- a/app/views/shared/registrations/_action_links_panel.html.erb
+++ b/app/views/shared/registrations/_action_links_panel.html.erb
@@ -13,7 +13,7 @@
       <li>
         <%= link_to t(".actions_box.links.renew"), renew_link_for(resource) %>
       </li>
-      <% if WasteCarriersEngine::FeatureToggle.active?(:email_reminders) %>
+      <% if WasteCarriersEngine::FeatureToggle.active?(:renewal_reminders) %>
         <li>
           <%= link_to t(".actions_box.links.resend_renewal_email"), resend_renewal_email_path(reg_identifier: resource.reg_identifier) %>
         </li>

--- a/config/feature_toggles.yml
+++ b/config/feature_toggles.yml
@@ -3,9 +3,7 @@ new_registration:
   active: <%= ENV["FEATURE_TOGGLE_NEW_REGISTRATION"] %>
 api:
   active: <%= ENV["FEATURE_TOGGLE_API"] %>
-email_reminders:
-  active: <%= ENV["FEATURE_TOGGLE_EMAIL_REMINDERS"] %>
-renew_via_magic_link:
-  active: <%= ENV["RENEW_VIA_MAGIC_LINK"] %>
+renewal_reminders:
+  active: <%= ENV["FEATURE_TOGGLE_RENEWAL_REMINDERS"] %>
 use_extended_grace_window:
   active: <%= ENV["USE_EXTENDED_GRACE_WINDOW"] %>

--- a/config/feature_toggles.yml
+++ b/config/feature_toggles.yml
@@ -7,3 +7,5 @@ renewal_reminders:
   active: <%= ENV["FEATURE_TOGGLE_RENEWAL_REMINDERS"] %>
 use_extended_grace_window:
   active: <%= ENV["USE_EXTENDED_GRACE_WINDOW"] %>
+display_covid_warning_in_letters:
+  active: <%= ENV["FEATURE_TOGGLE_DISPLAY_COVID_WARNING"] %>

--- a/lib/tasks/email.rake
+++ b/lib/tasks/email.rake
@@ -10,7 +10,7 @@ namespace :email do
     namespace :first do
       desc "Send first email reminder to all registrations expiring in X days (default is 28)"
       task send: :environment do
-        return unless WasteCarriersEngine::FeatureToggle.active?(:email_reminders)
+        return unless WasteCarriersEngine::FeatureToggle.active?(:renewal_reminders)
 
         FirstRenewalReminderService.run
       end
@@ -19,7 +19,7 @@ namespace :email do
     namespace :second do
       desc "Send second email reminder to all registrations expiring in X days (default is 14)"
       task send: :environment do
-        return unless WasteCarriersEngine::FeatureToggle.active?(:email_reminders)
+        return unless WasteCarriersEngine::FeatureToggle.active?(:renewal_reminders)
 
         SecondRenewalReminderService.run
       end

--- a/spec/mailers/renewal_reminder_mailer_spec.rb
+++ b/spec/mailers/renewal_reminder_mailer_spec.rb
@@ -3,10 +3,6 @@
 require "rails_helper"
 
 RSpec.describe RenewalReminderMailer, type: :mailer do
-  before do
-    allow(WasteCarriersEngine::FeatureToggle).to receive(:active?).with(:renew_via_magic_link).and_return(true)
-  end
-
   describe ".first_reminder_email" do
     let(:registration) { create(:registration, expires_on: 3.days.from_now) }
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1170

Our intention was to provide automated renewal reminders and build on it with adding magic links and being able to renew through them.

So we added added 2 separate feature toggles to control what was enabled.

In hindsight, the app hasn't actually been built to operate for each of the combinations those 2 feature toggles could be in. Essentially now we consider renewals will only ever be shipped with magic link functionality.

So this change simplifies the logic around renewals by merging these toggles into a new `renewal_reminders` feature toggle.

It also encompass changes to ensure renewal reminder content is correctly enabled and disabled depending on the state of the toggle.