### PR TITLE
Add letters link to nav

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,6 +31,12 @@
                               main_app.users_path %>
                 </li>
               <% end %>
+              <% if can?(:manage, FinalReminderLettersExport) %>
+                <li>
+                  <%= link_to t("layouts.application.menu.letters"),
+                              main_app.letters_path %>
+                </li>
+              <% end %>
               <% if can?(:import_conviction_data, current_user) %>
                 <li>
                   <%= link_to t("layouts.application.menu.conviction_imports"),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,6 +7,7 @@ en:
       menu:
         dashboard: "Registrations search"
         convictions: "Conviction checks"
+        letters: "Download letters"
         users: "Manage users"
         conviction_imports: "Import conviction data"
         feature_toggles: "Toggle features"


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-255

This change adds a link to the letter export section to the main nav for those who have permission to use it.