### PR TITLE
Do not copy receipt_email when init. renewal

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: 3c3a6cb5b2eb61503ff3a2a9850281ab68f843a0
+  revision: 220bbefdfa6aad6b2ef40b599c0ca1cc47299356
   branch: main
   specs:
     waste_carriers_engine (0.0.1)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1172

This is the scenario

- User creates a new registration using the new journey in the FO
- User pays by card so a payment confirmation email is taken and :receipt_email is populated
- 3 years later user renews but as AD

Irrespective of how user pays, the renewed registration displays the payment confirmation section in Registration details

As we know that the payment confirmation email is only sent for digital users renewing or creating new registrations its a one-time thing against the registration.

So this means when a new renewal is initialised, we should not be copying the receipt email from the registration as it may not be applicable this time.

This updates the back-office to a version of the engine that ensures `receipt_email` is not copied over when the renewal is initialised.