### PR TITLE
Update whenever to latest

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ gem "kaminari", "~> 1.1"
 gem "kaminari-mongoid", "~> 1.0"
 
 # Use Whenever to manage cron tasks
-gem "whenever", "~> 0.10.0"
+gem "whenever", "~> 1.0"
 
 gem "wicked_pdf"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -423,7 +423,7 @@ GEM
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    whenever (0.10.0)
+    whenever (1.0.0)
       chronic (>= 0.6.3)
     whenever-test (1.0.1)
       whenever
@@ -470,7 +470,7 @@ DEPENDENCIES
   waste_carriers_engine!
   web-console
   webmock (~> 3.4)
-  whenever (~> 0.10.0)
+  whenever (~> 1.0)
   whenever-test (~> 1.0)
   wicked_pdf
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1061

It's not actually needed for RUBY-1061. But we spotted that whenever was both out of date with the latest released version and not in sync with the version used in our Capistrano deployment project **rails-deployment** when working on it.

This takes the opportunity to update it to the latest.