### PR TITLE
Show err msg when resend reminder to empty contact

### DIFF
--- a/app/controllers/resend_renewal_email_controller.rb
+++ b/app/controllers/resend_renewal_email_controller.rb
@@ -14,8 +14,8 @@ class ResendRenewalEmailController < ApplicationController
       )
     rescue Exceptions::MissingContactEmailError
       handle_missing_contact_email
-    rescue StandardError => error
-      handle_resend_errored(error)
+    rescue StandardError => e
+      handle_resend_errored(e)
     end
 
     redirect_back(fallback_location: "/")

--- a/app/controllers/resend_renewal_email_controller.rb
+++ b/app/controllers/resend_renewal_email_controller.rb
@@ -12,13 +12,10 @@ class ResendRenewalEmailController < ApplicationController
       flash_success(
         I18n.t("resend_renewal_email.messages.success", email: registration.contact_email)
       )
-    rescue StandardError => e
-      Airbrake.notify e, registration: registration.reg_identifier
-      Rails.logger.error "Failed to send renewal email for registration #{registration.reg_identifier}"
-
-      flash_message(
-        I18n.t("resend_renewal_email.messages.failure", email: registration.contact_email)
-      )
+    rescue Exceptions::MissingContactEmailError
+      handle_missing_contact_email
+    rescue StandardError => error
+      handle_resend_errored(error)
     end
 
     redirect_back(fallback_location: "/")
@@ -26,11 +23,34 @@ class ResendRenewalEmailController < ApplicationController
 
   private
 
+  def authenticate_user!
+    authorize! :renew, WasteCarriersEngine::Registration
+  end
+
   def registration
     @_registration ||= WasteCarriersEngine::Registration.find_by(reg_identifier: params[:reg_identifier])
   end
 
-  def authenticate_user!
-    authorize! :renew, WasteCarriersEngine::Registration
+  # If the registration has a missing contact_email we know
+  # RenewalReminderMailer will throw a MissingContactEmailError. There is not
+  # really anything we can do and the reason for the missing field is legacy
+  # issues. So we don't worry about Airbrake or adding anything to the log.
+  def handle_missing_contact_email
+    message = I18n.t("resend_renewal_email.messages.missing.heading")
+    description = I18n.t("resend_renewal_email.messages.missing.details")
+
+    flash_error(message, description)
+  end
+
+  # Here we do notify Airbrake and log an error. If we get here it's for an
+  # unexpected reason hence we want to know about it.
+  def handle_resend_errored(error)
+    Airbrake.notify error, registration: registration.reg_identifier
+    Rails.logger.error "Error resending renewal email for registration #{registration.reg_identifier}"
+
+    message = I18n.t("resend_renewal_email.messages.error.heading", email: registration.contact_email)
+    description = I18n.t("resend_renewal_email.messages.error.details")
+
+    flash_error(message, description)
   end
 end

--- a/app/lib/exceptions.rb
+++ b/app/lib/exceptions.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Exceptions
+  class MissingContactEmailError < StandardError
+    def initialize(reg_identifier)
+      super("Registration #{reg_identifier} has no contact email. Cannot send mail.")
+    end
+  end
+end

--- a/app/mailers/renewal_reminder_mailer.rb
+++ b/app/mailers/renewal_reminder_mailer.rb
@@ -14,6 +14,8 @@ class RenewalReminderMailer < ActionMailer::Base
   private
 
   def reminder_email(registration)
+    raise Exceptions::MissingContactEmailError, registration.reg_identifier unless registration.contact_email.present?
+
     @registration = registration
     subject = I18n.t(
       ".renewal_reminder_mailer.first_reminder_email.subject",

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -19,8 +19,7 @@
 
 <div class="grid-row">
   <div class="column-full">
-    <%= render("shared/success", message: flash[:success]) if flash[:success].present? %>
-    <%= render("shared/message", message: flash[:message]) if flash[:message].present? %>
+    <%= render("shared/flash_messages") %>
   </div>
 </div>
 

--- a/app/views/registrations/show.html.erb
+++ b/app/views/registrations/show.html.erb
@@ -2,8 +2,7 @@
   <div class="column-full">
     <%= render("waste_carriers_engine/shared/back", back_path: bo_path) %>
 
-    <%= render("shared/success", message: flash[:success]) if flash[:success].present? %>
-    <%= render("shared/message", message: flash[:message]) if flash[:message].present? %>
+    <%= render("shared/flash_messages") %>
 
     <div class="grid-row">
       <div class="column-two-thirds">

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,6 +33,7 @@ module WasteCarriersBackOffice
     # config.i18n.default_locale = :de
 
     config.autoload_paths << "#{config.root}/app/forms/concerns"
+    config.autoload_paths << "#{config.root}/app/lib"
 
     # Enable the asset pipeline
     config.assets.enabled = true

--- a/config/locales/resend_renewal_email.en.yml
+++ b/config/locales/resend_renewal_email.en.yml
@@ -2,4 +2,9 @@ en:
   resend_renewal_email:
     messages:
       success: Renewal email sent to %{email}
-      failure: We could not send an email to %{email}
+      error:
+        heading: We could not send an email to %{email}
+        details: The error has been logged. Try again later or contact an administrator.
+      missing:
+        heading: Sorry, there has been a problem re-sending the renewal email.
+        details: You have requested to resend a renewal email to the contact email address, but this address is missing from the registration.

--- a/spec/mailers/renewal_reminder_mailer_spec.rb
+++ b/spec/mailers/renewal_reminder_mailer_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe RenewalReminderMailer, type: :mailer do
       it "throws an error" do
         instance = RenewalReminderMailer.new
 
-        expect { instance.first_reminder_email(registration) }.to raise_error(Exceptions::MissingContactEmailError)
+        expect { instance.second_reminder_email(registration) }.to raise_error(Exceptions::MissingContactEmailError)
       end
     end
 

--- a/spec/mailers/renewal_reminder_mailer_spec.rb
+++ b/spec/mailers/renewal_reminder_mailer_spec.rb
@@ -4,19 +4,31 @@ require "rails_helper"
 
 RSpec.describe RenewalReminderMailer, type: :mailer do
   describe ".first_reminder_email" do
-    let(:registration) { create(:registration, expires_on: 3.days.from_now) }
-
     before do
       allow(Rails.configuration).to receive(:email_service_email).and_return("test@example.com")
     end
 
-    it "sends a first reminder email" do
-      mail = described_class.first_reminder_email(registration)
+    context "when the registration's contact email is missing" do
+      let(:registration) { create(:registration, expires_on: 3.days.from_now, contact_email: nil) }
 
-      expect(registration).to receive(:renew_token)
-      expect(mail.subject).to include("Renew waste carrier registration")
-      expect(mail.to).to eq([registration.contact_email])
-      expect(mail.body.encoded).to include(registration.reg_identifier)
+      it "throws an error" do
+        instance = RenewalReminderMailer.new
+
+        expect { instance.first_reminder_email(registration) }.to raise_error(Exceptions::MissingContactEmailError)
+      end
+    end
+
+    context "when the registration's contact email is present" do
+      let(:registration) { create(:registration, expires_on: 3.days.from_now) }
+
+      it "sends a first reminder email" do
+        mail = described_class.first_reminder_email(registration)
+
+        expect(registration).to receive(:renew_token)
+        expect(mail.subject).to include("Renew waste carrier registration")
+        expect(mail.to).to eq([registration.contact_email])
+        expect(mail.body.encoded).to include(registration.reg_identifier)
+      end
     end
   end
 
@@ -27,13 +39,27 @@ RSpec.describe RenewalReminderMailer, type: :mailer do
       allow(Rails.configuration).to receive(:email_service_email).and_return("test@example.com")
     end
 
-    it "sends a second reminder email" do
-      mail = described_class.second_reminder_email(registration)
+    context "when the registration's contact email is missing" do
+      let(:registration) { create(:registration, expires_on: 3.days.from_now, contact_email: nil) }
 
-      expect(registration).to receive(:renew_token)
-      expect(mail.subject).to include("Renew waste carrier registration")
-      expect(mail.to).to eq([registration.contact_email])
-      expect(mail.body.encoded).to include(registration.reg_identifier)
+      it "throws an error" do
+        instance = RenewalReminderMailer.new
+
+        expect { instance.first_reminder_email(registration) }.to raise_error(Exceptions::MissingContactEmailError)
+      end
+    end
+
+    context "when the registration's contact email is present" do
+      let(:registration) { create(:registration, expires_on: 3.days.from_now) }
+
+      it "sends a second reminder email" do
+        mail = described_class.second_reminder_email(registration)
+
+        expect(registration).to receive(:renew_token)
+        expect(mail.subject).to include("Renew waste carrier registration")
+        expect(mail.to).to eq([registration.contact_email])
+        expect(mail.body.encoded).to include(registration.reg_identifier)
+      end
     end
   end
 end

--- a/spec/requests/resend_renewal_email_spec.rb
+++ b/spec/requests/resend_renewal_email_spec.rb
@@ -41,8 +41,6 @@ RSpec.describe "ResendRenewalEmail", type: :request do
         let(:email) { nil }
 
         it "does not send an email, redirects to the previous page and displays a flash 'error' message" do
-          # expect(RenewalReminderMailer).to receive(:second_reminder_email).and_raise(Exceptions::MissingContactEmailError)
-
           expected_count = ActionMailer::Base.deliveries.count
 
           get request_path, headers: { "HTTP_REFERER" => "/" }

--- a/spec/requests/resend_renewal_email_spec.rb
+++ b/spec/requests/resend_renewal_email_spec.rb
@@ -4,12 +4,13 @@ require "rails_helper"
 
 RSpec.describe "ResendRenewalEmail", type: :request do
   describe "GET /bo/resend-renewal-email/:reg_identifier" do
-    let(:registration) { create(:registration, :expires_soon) }
+    before(:each) { sign_in(user) }
+
     let(:request_path) { "/bo/resend-renewal-email/#{registration.reg_identifier}" }
 
     context "when a finance user is signed in" do
       let(:user) { create(:user, :finance) }
-      before { sign_in(user) }
+      let(:registration) { create(:registration, :expires_soon) }
 
       it "redirects to permission page" do
         get request_path, headers: { "HTTP_REFERER" => "/" }
@@ -20,29 +21,53 @@ RSpec.describe "ResendRenewalEmail", type: :request do
 
     context "when an agency user is signed in" do
       let(:user) { create(:user, :agency) }
-      before { sign_in(user) }
+      let(:registration) { create(:registration, :expires_soon, contact_email: email) }
 
-      it "sends an email and redirects to the previous page" do
-        expected_count = ActionMailer::Base.deliveries.count + 1
+      context "and the registration has a contact email" do
+        let(:email) { "simone@example.com" }
 
-        get request_path, headers: { "HTTP_REFERER" => "/" }
+        it "sends an email, redirects to the previous page and displays a flash 'success' message" do
+          expected_count = ActionMailer::Base.deliveries.count + 1
 
-        expect(ActionMailer::Base.deliveries.count).to eq(expected_count)
-        expect(response).to redirect_to("/")
+          get request_path, headers: { "HTTP_REFERER" => "/" }
+
+          expect(ActionMailer::Base.deliveries.count).to eq(expected_count)
+          expect(response).to redirect_to("/")
+          expect(request.flash[:success]).to eq("Renewal email sent to #{email}")
+        end
       end
 
-      context "when an error happens", disable_bullet: true do
-        before do
-          expect(RenewalReminderMailer).to receive(:second_reminder_email).and_raise(StandardError)
-        end
+      context "and the registration has no contact email" do
+        let(:email) { nil }
 
-        it "does not sends an email and redirects to the previous page" do
+        it "does not send an email, redirects to the previous page and displays a flash 'error' message" do
+          # expect(RenewalReminderMailer).to receive(:second_reminder_email).and_raise(Exceptions::MissingContactEmailError)
+
           expected_count = ActionMailer::Base.deliveries.count
 
           get request_path, headers: { "HTTP_REFERER" => "/" }
 
           expect(ActionMailer::Base.deliveries.count).to eq(expected_count)
           expect(response).to redirect_to("/")
+          expect(request.flash[:error]).to eq("Sorry, there has been a problem re-sending the renewal email.")
+        end
+      end
+
+      context "when an error happens", disable_bullet: true do
+        before do
+          allow(RenewalReminderMailer).to receive(:second_reminder_email).and_raise(StandardError)
+        end
+
+        let(:email) { "oops@example.com" }
+
+        it "does not send an email, redirects to the previous page and displays a flash 'error' message" do
+          expected_count = ActionMailer::Base.deliveries.count
+
+          get request_path, headers: { "HTTP_REFERER" => "/" }
+
+          expect(ActionMailer::Base.deliveries.count).to eq(expected_count)
+          expect(response).to redirect_to("/")
+          expect(request.flash[:error]).to eq("We could not send an email to #{email}")
         end
       end
     end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1168

Currently, if you click the 'Resend renewal reminder' link on a registration with an empty contact email it will just say 'Renewal sent to'.

With this message, you could be mistaken for thinking it sent successfully. Or if you spot it, it wouldn't be immediately obvious what the issue is.

We now have a design to display an error message if the link is clicked and the contact email is blank. This change implements it.

<details><summary>Example</summary>

<img width="979" alt="Screenshot 2020-07-27 at 22 53 26" src="https://user-images.githubusercontent.com/1789650/88597880-1d958f00-d060-11ea-94cc-218eb02aeb0d.png">

</details>