### PR TITLE
Update flash message logic

### DIFF
--- a/app/controllers/bank_transfer_payment_forms_controller.rb
+++ b/app/controllers/bank_transfer_payment_forms_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class BankTransferPaymentFormsController < ResourceFormsController
+  include CanSetFlashMessages
+
   def new
     super(BankTransferPaymentForm, "bank_transfer_payment_form")
   end
@@ -10,9 +12,8 @@ class BankTransferPaymentFormsController < ResourceFormsController
 
     return unless super(BankTransferPaymentForm, "bank_transfer_payment_form")
 
-    flash[:success] = I18n.t(
-      "payments.messages.success",
-      amount: @bank_transfer_payment_form.amount
+    flash_success(
+      I18n.t("payments.messages.success", amount: @bank_transfer_payment_form.amount)
     )
   end
 

--- a/app/controllers/cancels_controller.rb
+++ b/app/controllers/cancels_controller.rb
@@ -2,6 +2,7 @@
 
 class CancelsController < ApplicationController
   include CanFetchResource
+  include CanSetFlashMessages
   include FinanceDetailsHelper
 
   prepend_before_action :authenticate_user!
@@ -13,9 +14,8 @@ class CancelsController < ApplicationController
     @resource.metaData.cancel
     @resource.save!
 
-    flash[:success] = I18n.t(
-      "cancels.messages.success",
-      reg_identifier: @resource.reg_identifier
+    flash_success(
+      I18n.t("cancels.messages.success", reg_identifier: @resource.reg_identifier)
     )
 
     redirect_to details_path_for(@resource)

--- a/app/controllers/cash_payment_forms_controller.rb
+++ b/app/controllers/cash_payment_forms_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class CashPaymentFormsController < ResourceFormsController
+  include CanSetFlashMessages
+
   def new
     super(CashPaymentForm, "cash_payment_form")
   end
@@ -10,9 +12,8 @@ class CashPaymentFormsController < ResourceFormsController
 
     return unless super(CashPaymentForm, "cash_payment_form")
 
-    flash[:success] = I18n.t(
-      "payments.messages.success",
-      amount: @cash_payment_form.amount
+    flash_success(
+      I18n.t("payments.messages.success", amount: @cash_payment_form.amount)
     )
   end
 

--- a/app/controllers/cheque_payment_forms_controller.rb
+++ b/app/controllers/cheque_payment_forms_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ChequePaymentFormsController < ResourceFormsController
+  include CanSetFlashMessages
+
   def new
     super(ChequePaymentForm, "cheque_payment_form")
   end
@@ -10,9 +12,8 @@ class ChequePaymentFormsController < ResourceFormsController
 
     return unless super(ChequePaymentForm, "cheque_payment_form")
 
-    flash[:success] = I18n.t(
-      "payments.messages.success",
-      amount: @cheque_payment_form.amount
+    flash_success(
+      I18n.t("payments.messages.success", amount: @cheque_payment_form.amount)
     )
   end
 

--- a/app/controllers/concerns/can_set_flash_messages.rb
+++ b/app/controllers/concerns/can_set_flash_messages.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module CanSetFlashMessages
+  extend ActiveSupport::Concern
+
+  def flash_success(message)
+    flash[:success] = message
+  end
+
+  def flash_message(message)
+    flash[:message] = message
+  end
+
+  def flash_error(error, description)
+    flash[:error] = error
+    flash[:error_details] = description
+  end
+end

--- a/app/controllers/conviction_imports_controller.rb
+++ b/app/controllers/conviction_imports_controller.rb
@@ -39,9 +39,8 @@ class ConvictionImportsController < ApplicationController
   end
 
   def add_error_flash_message(error)
-    flash[:error] = I18n.t(
-      "conviction_imports.flash_messages.error",
-      error: error
+    flash_error(
+      I18n.t("conviction_imports.flash_messages.error", error: error), nil
     )
   end
 end

--- a/app/controllers/conviction_imports_controller.rb
+++ b/app/controllers/conviction_imports_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ConvictionImportsController < ApplicationController
+  include CanSetFlashMessages
+
   before_action :authorize
 
   def new; end
@@ -31,9 +33,8 @@ class ConvictionImportsController < ApplicationController
   def add_success_flash_message
     conviction_records_count = WasteCarriersEngine::ConvictionsCheck::Entity.count
 
-    flash[:success] = I18n.t(
-      "conviction_imports.flash_messages.successful",
-      count: conviction_records_count
+    flash_success(
+      I18n.t("conviction_imports.flash_messages.successful", count: conviction_records_count)
     )
   end
 

--- a/app/controllers/negative_charge_adjust_forms_controller.rb
+++ b/app/controllers/negative_charge_adjust_forms_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class NegativeChargeAdjustFormsController < ResourceFormsController
+  include CanSetFlashMessages
   include FinanceDetailsHelper
 
   before_renew_or_complete :process_charge_adjust
@@ -12,9 +13,11 @@ class NegativeChargeAdjustFormsController < ResourceFormsController
   def create
     return unless super(NegativeChargeAdjustForm, "negative_charge_adjust_form")
 
-    flash[:success] = I18n.t(
-      "negative_charge_adjust_forms.messages.success",
-      amount: display_pence_as_pounds_and_cents(@negative_charge_adjust_form.amount)
+    flash_success(
+      I18n.t(
+        "negative_charge_adjust_forms.messages.success",
+        amount: display_pence_as_pounds_and_cents(@negative_charge_adjust_form.amount)
+      )
     )
   end
 

--- a/app/controllers/positive_charge_adjust_forms_controller.rb
+++ b/app/controllers/positive_charge_adjust_forms_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class PositiveChargeAdjustFormsController < ResourceFormsController
+  include CanSetFlashMessages
   include FinanceDetailsHelper
 
   before_renew_or_complete :process_charge_adjust
@@ -12,9 +13,11 @@ class PositiveChargeAdjustFormsController < ResourceFormsController
   def create
     return unless super(PositiveChargeAdjustForm, "positive_charge_adjust_form")
 
-    flash[:success] = I18n.t(
-      "positive_charge_adjust_forms.messages.success",
-      amount: display_pence_as_pounds_and_cents(@positive_charge_adjust_form.amount)
+    flash_success(
+      I18n.t(
+        "positive_charge_adjust_forms.messages.success",
+        amount: display_pence_as_pounds_and_cents(@positive_charge_adjust_form.amount)
+      )
     )
   end
 

--- a/app/controllers/postal_order_payment_forms_controller.rb
+++ b/app/controllers/postal_order_payment_forms_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class PostalOrderPaymentFormsController < ResourceFormsController
+  include CanSetFlashMessages
+
   def new
     super(PostalOrderPaymentForm, "postal_order_payment_form")
   end
@@ -10,9 +12,8 @@ class PostalOrderPaymentFormsController < ResourceFormsController
 
     return unless super(PostalOrderPaymentForm, "postal_order_payment_form")
 
-    flash[:success] = I18n.t(
-      "payments.messages.success",
-      amount: @postal_order_payment_form.amount
+    flash_success(
+      I18n.t("payments.messages.success", amount: @postal_order_payment_form.amount)
     )
   end
 

--- a/app/controllers/refunds_controller.rb
+++ b/app/controllers/refunds_controller.rb
@@ -2,6 +2,7 @@
 
 class RefundsController < ApplicationController
   include CanFetchResource
+  include CanSetFlashMessages
   include FinanceDetailsHelper
 
   prepend_before_action :authorise_user!
@@ -29,9 +30,8 @@ class RefundsController < ApplicationController
     )
 
     if response
-      flash[:success] = I18n.t(
-        "refunds.flash_messages.successful",
-        amount: display_pence_as_pounds_and_cents(amount_to_refund)
+      flash_success(
+        I18n.t("refunds.flash_messages.successful", amount: display_pence_as_pounds_and_cents(amount_to_refund))
       )
     else
       flash[:error] = I18n.t("refunds.flash_messages.error")

--- a/app/controllers/refunds_controller.rb
+++ b/app/controllers/refunds_controller.rb
@@ -34,7 +34,9 @@ class RefundsController < ApplicationController
         I18n.t("refunds.flash_messages.successful", amount: display_pence_as_pounds_and_cents(amount_to_refund))
       )
     else
-      flash[:error] = I18n.t("refunds.flash_messages.error")
+      flash_error(
+        I18n.t("refunds.flash_messages.error"), nil
+      )
     end
 
     redirect_to resource_finance_details_path(@resource._id)

--- a/app/controllers/resend_renewal_email_controller.rb
+++ b/app/controllers/resend_renewal_email_controller.rb
@@ -16,7 +16,9 @@ class ResendRenewalEmailController < ApplicationController
       Airbrake.notify e, registration: registration.reg_identifier
       Rails.logger.error "Failed to send renewal email for registration #{registration.reg_identifier}"
 
-      flash[:message] = I18n.t("resend_renewal_email.messages.failure", email: registration.contact_email)
+      flash_message(
+        I18n.t("resend_renewal_email.messages.failure", email: registration.contact_email)
+      )
     end
 
     redirect_back(fallback_location: "/")

--- a/app/controllers/resend_renewal_email_controller.rb
+++ b/app/controllers/resend_renewal_email_controller.rb
@@ -1,13 +1,17 @@
 # frozen_string_literal: true
 
 class ResendRenewalEmailController < ApplicationController
+  include CanSetFlashMessages
+
   before_action :authenticate_user!
 
   def new
     begin
       RenewalReminderMailer.second_reminder_email(registration).deliver_now
 
-      flash[:success] = I18n.t("resend_renewal_email.messages.success", email: registration.contact_email)
+      flash_success(
+        I18n.t("resend_renewal_email.messages.success", email: registration.contact_email)
+      )
     rescue StandardError => e
       Airbrake.notify e, registration: registration.reg_identifier
       Rails.logger.error "Failed to send renewal email for registration #{registration.reg_identifier}"

--- a/app/controllers/reversal_forms_controller.rb
+++ b/app/controllers/reversal_forms_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class ReversalFormsController < ResourceFormsController
+  include CanSetFlashMessages
   include FinanceDetailsHelper
 
   def index
@@ -24,9 +25,8 @@ class ReversalFormsController < ResourceFormsController
       reason: @reversal_form.reason
     )
 
-    flash[:success] = I18n.t(
-      "reversal_forms.flash_messages.successful",
-      amount: display_pence_as_pounds_and_cents(@payment.amount)
+    flash_success(
+      I18n.t("reversal_forms.flash_messages.successful", amount: display_pence_as_pounds_and_cents(@payment.amount))
     )
   end
 

--- a/app/controllers/worldpay_missed_payment_forms_controller.rb
+++ b/app/controllers/worldpay_missed_payment_forms_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class WorldpayMissedPaymentFormsController < ResourceFormsController
+  include CanSetFlashMessages
+
   before_renew_or_complete :change_state_if_possible
 
   def new
@@ -12,9 +14,8 @@ class WorldpayMissedPaymentFormsController < ResourceFormsController
 
     return unless super(WorldpayMissedPaymentForm, "worldpay_missed_payment_form")
 
-    flash[:success] = I18n.t(
-      "payments.messages.success",
-      amount: @worldpay_missed_payment_form.amount
+    flash_success(
+      I18n.t("payments.messages.success", amount: @worldpay_missed_payment_form.amount)
     )
   end
 

--- a/app/controllers/write_off_forms_controller.rb
+++ b/app/controllers/write_off_forms_controller.rb
@@ -18,7 +18,10 @@ class WriteOffFormsController < ResourceFormsController
     return unless super(WriteOffForm, "write_off_form")
 
     flash_success(
-      I18n.t("write_off_forms.flash_messages.successful", amount: display_pence_as_pounds_and_cents(amount_to_write_off))
+      I18n.t(
+        "write_off_forms.flash_messages.successful",
+        amount: display_pence_as_pounds_and_cents(amount_to_write_off)
+      )
     )
   end
 

--- a/app/controllers/write_off_forms_controller.rb
+++ b/app/controllers/write_off_forms_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class WriteOffFormsController < ResourceFormsController
+  include CanSetFlashMessages
   include FinanceDetailsHelper
 
   before_renew_or_complete :process_write_off
@@ -16,9 +17,8 @@ class WriteOffFormsController < ResourceFormsController
 
     return unless super(WriteOffForm, "write_off_form")
 
-    flash[:success] = I18n.t(
-      "write_off_forms.flash_messages.successful",
-      amount: display_pence_as_pounds_and_cents(amount_to_write_off)
+    flash_success(
+      I18n.t("write_off_forms.flash_messages.successful", amount: display_pence_as_pounds_and_cents(amount_to_write_off))
     )
   end
 

--- a/app/views/conviction_imports/new.html.erb
+++ b/app/views/conviction_imports/new.html.erb
@@ -8,7 +8,7 @@
 
     <p><%= t(".paragraph_1") %></p>
 
-    <%= render("shared/error", message: flash[:error], details: flash[:error_details]) if flash[:error].present? %>
+    <%= render("shared/flash_messages") %>
 
     <%= form_tag(conviction_imports_path) do %>
       <div class="form-group">

--- a/app/views/finance_details/show.html.erb
+++ b/app/views/finance_details/show.html.erb
@@ -6,9 +6,7 @@
       <%= t(".heading", reg_identifier: @resource.reg_identifier) %>
     </h1>
 
-    <%= render("shared/message", message: flash[:message]) if flash[:message].present? %>
-    <%= render("shared/success", message: flash[:success]) if flash[:success].present? %>
-    <%= render("shared/error", message: flash[:error], details: flash[:error_details]) if flash[:error].present? %>
+    <%= render("shared/flash_messages") %>
   </div>
 </div>
 

--- a/app/views/shared/_flash_messages.html.erb
+++ b/app/views/shared/_flash_messages.html.erb
@@ -1,0 +1,3 @@
+<%= render("shared/message", message: flash[:message]) if flash[:message].present? %>
+<%= render("shared/success", message: flash[:success]) if flash[:success].present? %>
+<%= render("shared/error", message: flash[:error], details: flash[:error_details]) if flash[:error].present? %>

--- a/app/views/transient_finance_details/show.html.erb
+++ b/app/views/transient_finance_details/show.html.erb
@@ -6,8 +6,7 @@
       <%= t(".heading", reg_identifier: @transient_registration.reg_identifier) %>
     </h1>
 
-    <%= render("shared/message", message: flash[:message]) if flash[:message].present? %>
-    <%= render("shared/error", error: flash[:error], details: flash[:error_details]) if flash[:error].present? %>
+    <%= render("shared/flash_messages") %>
   </div>
 </div>
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1168
https://eaflood.atlassian.net/browse/RUBY-1169

When resending the renewal reminder email from the registration details screen it has been flagged its doesn't really work from a UI perspective if the contact email is missing or the AD default.

So we have an update to the design which requires us to show a flash message styled as an error. Initially, it looked like we didn't support this. But turns out that is due to the differences between WEX and WCR and how flash messages have been implemented.

So to prevent anyone else getting confused, this brings WCR into line with WEX.

Note. The use of a `shared/_flash_messages.html.erb` partial is different from WEX. But if accepted we will look to

- move the partial into the [waste-carriers-engine](https://github.com/DEFRA/waste-carriers-engine)
- add the same partial to [waste-exemptions-engine](https://github.com/DEFRA/waste-exemptions-engine) and refactor the views to use it
