### PR TITLE
Only display renew/new reg links to those who can use them

### DIFF
--- a/app/views/shared/registrations/_expired_panel.html.erb
+++ b/app/views/shared/registrations/_expired_panel.html.erb
@@ -2,14 +2,13 @@
   <h2 class="heading-medium">
     <%= t(".heading", date: resource.display_expiry_date) %>
   </h2>
-  <% if resource.can_start_renewal? %>
+  <% if display_renew_link_for?(resource) %>
     <%= link_to t(".links.renew"),
                 WasteCarriersEngine::Engine.routes.url_helpers.new_renewal_start_form_path(resource.reg_identifier),
                 class: 'button' %>
-  <!-- TODO: restore when internal route exists https://eaflood.atlassian.net/browse/RUBY-786 -->
-  <%# else %>
-    <%#= link_to t(".links.new_registration"),
-                "#{Rails.configuration.wcrs_backend_url}/registrations/start",
+  <% elsif can?(:create, WasteCarriersEngine::Registration) && WasteCarriersEngine::FeatureToggle.active?(:new_registration) %>
+    <%= link_to t(".links.new_registration"),
+                ad_privacy_policy_path,
                 class: 'button' %>
   <% end %>
 </div>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1176

Previously we displayed this "Renew" button to all back office users, including ones who didn't have permission.

This PR changes it to use a different method which checks permissions as well as the state of the registration.

While in here, I also noticed a TODO which could now be resolved. So if it is now impossible to renew, but the user can make a new reg instead, we'll display a link to that.