### PR TITLE
Show err msg when resend reminder to AD contact

### DIFF
--- a/app/controllers/resend_renewal_email_controller.rb
+++ b/app/controllers/resend_renewal_email_controller.rb
@@ -14,6 +14,8 @@ class ResendRenewalEmailController < ApplicationController
       )
     rescue Exceptions::MissingContactEmailError
       handle_missing_contact_email
+    rescue Exceptions::AssistedDigitalContactEmailError
+      handle_assisted_digital_contact_email
     rescue StandardError => e
       handle_resend_errored(e)
     end
@@ -38,6 +40,20 @@ class ResendRenewalEmailController < ApplicationController
   def handle_missing_contact_email
     message = I18n.t("resend_renewal_email.messages.missing.heading")
     description = I18n.t("resend_renewal_email.messages.missing.details")
+
+    flash_error(message, description)
+  end
+
+  # If the registration has a contact_email that matches the configured assisted
+  # digital one we know RenewalReminderMailer will throw a
+  # AssistedDigitalContactEmailError. This isn't something we want to record. So
+  # we don't worry about Airbrake or adding anything to the log.
+  def handle_assisted_digital_contact_email
+    message = I18n.t("resend_renewal_email.messages.assisted.heading")
+    description = I18n.t(
+      "resend_renewal_email.messages.assisted.details",
+      email: WasteCarriersEngine.configuration.assisted_digital_email
+    )
 
     flash_error(message, description)
   end

--- a/app/lib/exceptions.rb
+++ b/app/lib/exceptions.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 module Exceptions
+  class AssistedDigitalContactEmailError < StandardError
+    def initialize(reg_identifier)
+      super("Registration #{reg_identifier} contact email matches the assisted digital one. Sending is blocked.")
+    end
+  end
+
   class MissingContactEmailError < StandardError
     def initialize(reg_identifier)
       super("Registration #{reg_identifier} has no contact email. Cannot send mail.")

--- a/app/mailers/renewal_reminder_mailer.rb
+++ b/app/mailers/renewal_reminder_mailer.rb
@@ -14,7 +14,7 @@ class RenewalReminderMailer < ActionMailer::Base
   private
 
   def reminder_email(registration)
-    raise Exceptions::MissingContactEmailError, registration.reg_identifier unless registration.contact_email.present?
+    validate_contact_email(registration)
 
     @registration = registration
     subject = I18n.t(
@@ -29,5 +29,15 @@ class RenewalReminderMailer < ActionMailer::Base
       subject: subject,
       template_name: :first_reminder_email
     )
+  end
+
+  private
+
+  def validate_contact_email(registration)
+    raise Exceptions::MissingContactEmailError, registration.reg_identifier unless registration.contact_email.present?
+
+    assisted_digital_match = registration.contact_email == WasteCarriersEngine.configuration.assisted_digital_email
+
+    raise Exceptions::AssistedDigitalContactEmailError, registration.reg_identifier if assisted_digital_match
   end
 end

--- a/app/mailers/renewal_reminder_mailer.rb
+++ b/app/mailers/renewal_reminder_mailer.rb
@@ -31,8 +31,6 @@ class RenewalReminderMailer < ActionMailer::Base
     )
   end
 
-  private
-
   def validate_contact_email(registration)
     raise Exceptions::MissingContactEmailError, registration.reg_identifier unless registration.contact_email.present?
 

--- a/config/locales/resend_renewal_email.en.yml
+++ b/config/locales/resend_renewal_email.en.yml
@@ -2,6 +2,9 @@ en:
   resend_renewal_email:
     messages:
       success: Renewal email sent to %{email}
+      assisted:
+        heading: Sorry, there has been a problem re-sending the renewal email.
+        details: You have requested to resend a renewal email to the contact email address, but this address matches %{email}.
       error:
         heading: We could not send an email to %{email}
         details: The error has been logged. Try again later or contact an administrator.

--- a/spec/mailers/renewal_reminder_mailer_spec.rb
+++ b/spec/mailers/renewal_reminder_mailer_spec.rb
@@ -8,8 +8,10 @@ RSpec.describe RenewalReminderMailer, type: :mailer do
       allow(Rails.configuration).to receive(:email_service_email).and_return("test@example.com")
     end
 
+    let(:registration) { create(:registration, :expires_soon, contact_email: contact_email) }
+
     context "when the registration's contact email is missing" do
-      let(:registration) { create(:registration, expires_on: 3.days.from_now, contact_email: nil) }
+      let(:contact_email) { nil }
 
       it "throws an error" do
         instance = RenewalReminderMailer.new
@@ -19,7 +21,7 @@ RSpec.describe RenewalReminderMailer, type: :mailer do
     end
 
     context "when the registration's contact email is present" do
-      let(:registration) { create(:registration, expires_on: 3.days.from_now) }
+      let(:contact_email) { "foo@example.com" }
 
       it "sends a first reminder email" do
         mail = described_class.first_reminder_email(registration)
@@ -33,14 +35,14 @@ RSpec.describe RenewalReminderMailer, type: :mailer do
   end
 
   describe ".second_reminder_email" do
-    let(:registration) { create(:registration, expires_on: 3.days.from_now) }
+    let(:registration) { create(:registration, :expires_soon, contact_email: contact_email) }
 
     before do
       allow(Rails.configuration).to receive(:email_service_email).and_return("test@example.com")
     end
 
     context "when the registration's contact email is missing" do
-      let(:registration) { create(:registration, expires_on: 3.days.from_now, contact_email: nil) }
+      let(:contact_email) { nil }
 
       it "throws an error" do
         instance = RenewalReminderMailer.new
@@ -50,7 +52,7 @@ RSpec.describe RenewalReminderMailer, type: :mailer do
     end
 
     context "when the registration's contact email is present" do
-      let(:registration) { create(:registration, expires_on: 3.days.from_now) }
+      let(:contact_email) { "foo@example.com" }
 
       it "sends a second reminder email" do
         mail = described_class.second_reminder_email(registration)

--- a/spec/mailers/renewal_reminder_mailer_spec.rb
+++ b/spec/mailers/renewal_reminder_mailer_spec.rb
@@ -21,15 +21,31 @@ RSpec.describe RenewalReminderMailer, type: :mailer do
     end
 
     context "when the registration's contact email is present" do
-      let(:contact_email) { "foo@example.com" }
+      context "and it is valid" do
+        let(:contact_email) { "foo@example.com" }
 
-      it "sends a first reminder email" do
-        mail = described_class.first_reminder_email(registration)
+        it "sends the first reminder email" do
+          mail = described_class.first_reminder_email(registration)
 
-        expect(registration).to receive(:renew_token)
-        expect(mail.subject).to include("Renew waste carrier registration")
-        expect(mail.to).to eq([registration.contact_email])
-        expect(mail.body.encoded).to include(registration.reg_identifier)
+          expect(registration).to receive(:renew_token)
+          expect(mail.subject).to include("Renew waste carrier registration")
+          expect(mail.to).to eq([registration.contact_email])
+          expect(mail.body.encoded).to include(registration.reg_identifier)
+        end
+      end
+
+      context "but it matches the assisted digital email" do
+        before do
+          allow(WasteCarriersEngine.configuration).to receive(:assisted_digital_email).and_return(contact_email)
+        end
+
+        let(:contact_email) { "nccc@example.com" }
+
+        it "throws an error" do
+          instance = RenewalReminderMailer.new
+
+          expect { instance.first_reminder_email(registration) }.to raise_error(Exceptions::AssistedDigitalContactEmailError)
+        end
       end
     end
   end
@@ -52,15 +68,31 @@ RSpec.describe RenewalReminderMailer, type: :mailer do
     end
 
     context "when the registration's contact email is present" do
-      let(:contact_email) { "foo@example.com" }
+      context "and it is valid" do
+        let(:contact_email) { "foo@example.com" }
 
-      it "sends a second reminder email" do
-        mail = described_class.second_reminder_email(registration)
+        it "sends the second reminder email" do
+          mail = described_class.second_reminder_email(registration)
 
-        expect(registration).to receive(:renew_token)
-        expect(mail.subject).to include("Renew waste carrier registration")
-        expect(mail.to).to eq([registration.contact_email])
-        expect(mail.body.encoded).to include(registration.reg_identifier)
+          expect(registration).to receive(:renew_token)
+          expect(mail.subject).to include("Renew waste carrier registration")
+          expect(mail.to).to eq([registration.contact_email])
+          expect(mail.body.encoded).to include(registration.reg_identifier)
+        end
+      end
+
+      context "but it matches the assisted digital email" do
+        before do
+          allow(WasteCarriersEngine.configuration).to receive(:assisted_digital_email).and_return(contact_email)
+        end
+
+        let(:contact_email) { "nccc@example.com" }
+
+        it "throws an error" do
+          instance = RenewalReminderMailer.new
+
+          expect { instance.second_reminder_email(registration) }.to raise_error(Exceptions::AssistedDigitalContactEmailError)
+        end
       end
     end
   end

--- a/spec/requests/resend_renewal_email_spec.rb
+++ b/spec/requests/resend_renewal_email_spec.rb
@@ -35,6 +35,24 @@ RSpec.describe "ResendRenewalEmail", type: :request do
           expect(response).to redirect_to("/")
           expect(request.flash[:success]).to eq("Renewal email sent to #{email}")
         end
+
+        context "but it matches the assisted digital email" do
+          before do
+            allow(WasteCarriersEngine.configuration).to receive(:assisted_digital_email).and_return(email)
+          end
+
+          let(:email) { "nccc@example.com" }
+
+          it "does not send an email, redirects to the previous page and displays a flash 'error' message" do
+            expected_count = ActionMailer::Base.deliveries.count
+
+            get request_path, headers: { "HTTP_REFERER" => "/" }
+
+            expect(ActionMailer::Base.deliveries.count).to eq(expected_count)
+            expect(response).to redirect_to("/")
+            expect(request.flash[:error]).to eq("Sorry, there has been a problem re-sending the renewal email.")
+          end
+        end
       end
 
       context "and the registration has no contact email" do


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1169

Currently, if you click the 'Resend renewal reminder' link on a registration with the assisted digital contact email it will send the email and display the success message 'Renewal email sent to nccc-carrierbroker@environment-agency.gov.uk'.

NCCC know to use this email address when handling an AD registration where the user has no email address at all. To avoid getting emails sent to them mistakenly they have asked us to not send the email and show an error instead if the contact email matches the AD one.

<details><summary>Example</summary>

<img width="983" alt="Screenshot 2020-07-28 at 00 25 20" src="https://user-images.githubusercontent.com/1789650/88601587-ec6d8c80-d068-11ea-9f41-36d1d8fed5e8.png">

</details>