### PR TITLE
Don't allow resending/sharing of magic link emails that users can't use

### DIFF
--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -22,12 +22,6 @@ module ActionLinksHelper
     ad_privacy_policy_path(reg_identifier: resource.reg_identifier)
   end
 
-  def display_renewal_magic_link_for?(resource)
-    return false unless WasteCarriersEngine::FeatureToggle.active?(:renewal_reminders)
-
-    display_renew_link_for?(resource)
-  end
-
   def renewal_magic_link_for(resource)
     return nil unless a_registration?(resource)
     return nil unless resource.renew_token.present?
@@ -122,7 +116,7 @@ module ActionLinksHelper
     can?(:transfer_registration, WasteCarriersEngine::Registration)
   end
 
-  def display_resend_renewal_reminder_link_for?(resource)
+  def display_ways_to_share_magic_link_for?(resource)
     return false unless WasteCarriersEngine::FeatureToggle.active?(:renewal_reminders)
     return false unless display_registration_links?(resource)
     return false unless can?(:renew, WasteCarriersEngine::Registration)

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -122,6 +122,12 @@ module ActionLinksHelper
     can?(:transfer_registration, WasteCarriersEngine::Registration)
   end
 
+  def display_resend_renewal_reminder_link_for?(resource)
+    return false unless WasteCarriersEngine::FeatureToggle.active?(:renewal_reminders)
+
+    display_renew_link_for?(resource)
+  end
+
   private
 
   def display_renewing_registration_links?(resource)

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -120,8 +120,8 @@ module ActionLinksHelper
     return false unless WasteCarriersEngine::FeatureToggle.active?(:renewal_reminders)
     return false unless display_registration_links?(resource)
     return false unless can?(:renew, WasteCarriersEngine::Registration)
-    
-    resource.can_start_renewal?
+
+    resource.can_start_front_office_renewal?
   end
 
   private

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -124,8 +124,10 @@ module ActionLinksHelper
 
   def display_resend_renewal_reminder_link_for?(resource)
     return false unless WasteCarriersEngine::FeatureToggle.active?(:renewal_reminders)
-
-    display_renew_link_for?(resource)
+    return false unless display_registration_links?(resource)
+    return false unless can?(:renew, WasteCarriersEngine::Registration)
+    
+    resource.can_start_renewal?
   end
 
   private

--- a/app/models/waste_carriers_engine/registration.rb
+++ b/app/models/waste_carriers_engine/registration.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require WasteCarriersEngine::Engine.root.join(
+  "app",
+  "models",
+  "waste_carriers_engine",
+  "registration"
+)
+
+module WasteCarriersEngine
+  class Registration
+    def can_start_front_office_renewal?
+      renewable_tier? && renewable_status? && renewable_front_office_date?
+    end
+
+    private
+
+    def renewable_front_office_date?
+      return true if check_service.in_standard_expiry_grace_window?
+      return false if check_service.expired?
+
+      check_service.in_renewal_window?
+    end
+  end
+end

--- a/app/services/waste_carriers_engine/expiry_check_service.rb
+++ b/app/services/waste_carriers_engine/expiry_check_service.rb
@@ -19,6 +19,10 @@ module WasteCarriersEngine
       current_day_is_within_grace_window?(last_day_of_grace_window)
     end
 
+    def in_standard_expiry_grace_window?
+      current_day_is_within_grace_window?(last_day_of_standard_grace_window)
+    end
+
     private
 
     def last_day_of_extended_grace_window

--- a/app/views/registrations/show.html.erb
+++ b/app/views/registrations/show.html.erb
@@ -55,7 +55,7 @@
           <%= render "shared/registrations/receipt_email_panel", resource: @registration %>
         <% end %>
 
-        <% if display_renewal_magic_link_for?(@registration) %>
+        <% if display_ways_to_share_magic_link_for?(@registration) %>
           <%= render "shared/registrations/renewal_magic_link_panel", resource: @registration %>
         <% end %>
       </div>

--- a/app/views/shared/registrations/_action_links_panel.html.erb
+++ b/app/views/shared/registrations/_action_links_panel.html.erb
@@ -15,7 +15,7 @@
       </li>
     <% end %>
 
-    <% if display_resend_renewal_email_link_for?(resource) %>
+    <% if display_ways_to_share_magic_link_for?(resource) %>
       <li>
         <%= link_to t(".actions_box.links.resend_renewal_email"), resend_renewal_email_path(reg_identifier: resource.reg_identifier) %>
       </li>

--- a/app/views/shared/registrations/_action_links_panel.html.erb
+++ b/app/views/shared/registrations/_action_links_panel.html.erb
@@ -13,11 +13,12 @@
       <li>
         <%= link_to t(".actions_box.links.renew"), renew_link_for(resource) %>
       </li>
-      <% if WasteCarriersEngine::FeatureToggle.active?(:renewal_reminders) %>
-        <li>
-          <%= link_to t(".actions_box.links.resend_renewal_email"), resend_renewal_email_path(reg_identifier: resource.reg_identifier) %>
-        </li>
-      <% end %>
+    <% end %>
+
+    <% if display_resend_renewal_email_link_for?(resource) %>
+      <li>
+        <%= link_to t(".actions_box.links.resend_renewal_email"), resend_renewal_email_path(reg_identifier: resource.reg_identifier) %>
+      </li>
     <% end %>
 
     <% if display_transfer_link_for?(resource) %>

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -808,4 +808,60 @@ RSpec.describe ActionLinksHelper, type: :helper do
       end
     end
   end
+
+  describe "#display_resend_renewal_reminder_link_for?" do
+    let(:resource) { build(:registration) }
+
+    context "when the 'renewal_reminders' feature toggle is enabled" do
+      before do
+        allow(WasteCarriersEngine::FeatureToggle).to receive(:active?).with(:renewal_reminders).and_return(true)
+      end
+
+      context "but the resource is not a Registration" do
+        let(:resource) { build(:renewing_registration) }
+
+        it "returns false" do
+          expect(helper.display_resend_renewal_reminder_link_for?(resource)).to eq(false)
+        end
+      end
+
+      context "and the user does not have permission" do
+        before { allow(helper).to receive(:can?).and_return(false) }
+
+        it "returns false" do
+          expect(helper.display_resend_renewal_reminder_link_for?(resource)).to eq(false)
+        end
+      end
+
+      context "and the user has permission" do
+        before { allow(helper).to receive(:can?).and_return(true) }
+
+        context "and the resource cannot begin a renewal" do
+          before { allow(resource).to receive(:can_start_renewal?).and_return(false) }
+
+          it "returns false" do
+            expect(helper.display_resend_renewal_reminder_link_for?(resource)).to eq(false)
+          end
+        end
+
+        context "and the resource can begin a renewal" do
+          before { allow(resource).to receive(:can_start_renewal?).and_return(true) }
+
+          it "returns true" do
+            expect(helper.display_resend_renewal_reminder_link_for?(resource)).to eq(true)
+          end
+        end
+      end
+    end
+
+    context "when the 'renewal_reminders' feature toggle is not enabled" do
+      before do
+        allow(WasteCarriersEngine::FeatureToggle).to receive(:active?).with(:renewal_reminders).and_return(false)
+      end
+
+      it "returns false" do
+        expect(helper.display_resend_renewal_reminder_link_for?(resource)).to eq(false)
+      end
+    end
+  end
 end

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -127,62 +127,6 @@ RSpec.describe ActionLinksHelper, type: :helper do
     end
   end
 
-  describe "#display_renewal_magic_link_for?" do
-    let(:resource) { build(:registration) }
-
-    context "when the 'renewal_reminders' feature toggle is enabled" do
-      before do
-        allow(WasteCarriersEngine::FeatureToggle).to receive(:active?).with(:renewal_reminders).and_return(true)
-      end
-
-      context "but the resource is not a Registration" do
-        let(:resource) { build(:renewing_registration) }
-
-        it "returns false" do
-          expect(helper.display_renewal_magic_link_for?(resource)).to eq(false)
-        end
-      end
-
-      context "and the user does not have permission" do
-        before { allow(helper).to receive(:can?).and_return(false) }
-
-        it "returns false" do
-          expect(helper.display_renewal_magic_link_for?(resource)).to eq(false)
-        end
-      end
-
-      context "and the user has permission" do
-        before { allow(helper).to receive(:can?).and_return(true) }
-
-        context "and the resource cannot begin a renewal" do
-          before { allow(resource).to receive(:can_start_renewal?).and_return(false) }
-
-          it "returns false" do
-            expect(helper.display_renewal_magic_link_for?(resource)).to eq(false)
-          end
-        end
-
-        context "and the resource can begin a renewal" do
-          before { allow(resource).to receive(:can_start_renewal?).and_return(true) }
-
-          it "returns true" do
-            expect(helper.display_renewal_magic_link_for?(resource)).to eq(true)
-          end
-        end
-      end
-    end
-
-    context "when the 'renewal_reminders' feature toggle is not enabled" do
-      before do
-        allow(WasteCarriersEngine::FeatureToggle).to receive(:active?).with(:renewal_reminders).and_return(false)
-      end
-
-      it "returns false" do
-        expect(helper.display_renewal_magic_link_for?(resource)).to eq(false)
-      end
-    end
-  end
-
   describe "#renewal_magic_link_for" do
     context "when the resource is a new registration" do
       let(:resource) { build(:new_registration, token: "foo") }
@@ -809,7 +753,7 @@ RSpec.describe ActionLinksHelper, type: :helper do
     end
   end
 
-  describe "#display_resend_renewal_reminder_link_for?" do
+  describe "#display_ways_to_share_magic_link_for?" do
     let(:resource) { build(:registration) }
 
     context "when the 'renewal_reminders' feature toggle is not enabled" do
@@ -818,7 +762,7 @@ RSpec.describe ActionLinksHelper, type: :helper do
       end
 
       it "returns false" do
-        expect(helper.display_resend_renewal_reminder_link_for?(resource)).to eq(false)
+        expect(helper.display_ways_to_share_magic_link_for?(resource)).to eq(false)
       end
     end
 
@@ -831,7 +775,7 @@ RSpec.describe ActionLinksHelper, type: :helper do
         let(:resource) { build(:renewing_registration) }
 
         it "returns false" do
-          expect(helper.display_resend_renewal_reminder_link_for?(resource)).to eq(false)
+          expect(helper.display_ways_to_share_magic_link_for?(resource)).to eq(false)
         end
       end
 
@@ -839,7 +783,7 @@ RSpec.describe ActionLinksHelper, type: :helper do
         before { allow(helper).to receive(:can?).and_return(false) }
 
         it "returns false" do
-          expect(helper.display_resend_renewal_reminder_link_for?(resource)).to eq(false)
+          expect(helper.display_ways_to_share_magic_link_for?(resource)).to eq(false)
         end
       end
 
@@ -850,7 +794,7 @@ RSpec.describe ActionLinksHelper, type: :helper do
           before { allow(resource).to receive(:can_start_renewal?).and_return(false) }
 
           it "returns false" do
-            expect(helper.display_resend_renewal_reminder_link_for?(resource)).to eq(false)
+            expect(helper.display_ways_to_share_magic_link_for?(resource)).to eq(false)
           end
         end
 
@@ -858,7 +802,7 @@ RSpec.describe ActionLinksHelper, type: :helper do
           before { allow(resource).to receive(:can_start_renewal?).and_return(true) }
 
           it "returns true" do
-            expect(helper.display_resend_renewal_reminder_link_for?(resource)).to eq(true)
+            expect(helper.display_ways_to_share_magic_link_for?(resource)).to eq(true)
           end
         end
       end

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -780,7 +780,7 @@ RSpec.describe ActionLinksHelper, type: :helper do
       end
 
       context "and the user does not have permission" do
-        before { allow(helper).to receive(:can?).and_return(false) }
+        before { expect(helper).to receive(:can?).with(:renew, WasteCarriersEngine::Registration).and_return(false) }
 
         it "returns false" do
           expect(helper.display_ways_to_share_magic_link_for?(resource)).to eq(false)
@@ -788,18 +788,18 @@ RSpec.describe ActionLinksHelper, type: :helper do
       end
 
       context "and the user has permission" do
-        before { allow(helper).to receive(:can?).and_return(true) }
+        before { expect(helper).to receive(:can?).with(:renew, WasteCarriersEngine::Registration).and_return(true) }
 
-        context "and the resource cannot begin a renewal" do
-          before { allow(resource).to receive(:can_start_renewal?).and_return(false) }
+        context "and the resource cannot begin a renewal in the front office" do
+          before { expect(resource).to receive(:can_start_front_office_renewal?).and_return(false) }
 
           it "returns false" do
             expect(helper.display_ways_to_share_magic_link_for?(resource)).to eq(false)
           end
         end
 
-        context "and the resource can begin a renewal" do
-          before { allow(resource).to receive(:can_start_renewal?).and_return(true) }
+        context "and the resource can begin a renewal in the front office" do
+          before { expect(resource).to receive(:can_start_front_office_renewal?).and_return(true) }
 
           it "returns true" do
             expect(helper.display_ways_to_share_magic_link_for?(resource)).to eq(true)

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -812,6 +812,16 @@ RSpec.describe ActionLinksHelper, type: :helper do
   describe "#display_resend_renewal_reminder_link_for?" do
     let(:resource) { build(:registration) }
 
+    context "when the 'renewal_reminders' feature toggle is not enabled" do
+      before do
+        allow(WasteCarriersEngine::FeatureToggle).to receive(:active?).with(:renewal_reminders).and_return(false)
+      end
+
+      it "returns false" do
+        expect(helper.display_resend_renewal_reminder_link_for?(resource)).to eq(false)
+      end
+    end
+
     context "when the 'renewal_reminders' feature toggle is enabled" do
       before do
         allow(WasteCarriersEngine::FeatureToggle).to receive(:active?).with(:renewal_reminders).and_return(true)
@@ -851,16 +861,6 @@ RSpec.describe ActionLinksHelper, type: :helper do
             expect(helper.display_resend_renewal_reminder_link_for?(resource)).to eq(true)
           end
         end
-      end
-    end
-
-    context "when the 'renewal_reminders' feature toggle is not enabled" do
-      before do
-        allow(WasteCarriersEngine::FeatureToggle).to receive(:active?).with(:renewal_reminders).and_return(false)
-      end
-
-      it "returns false" do
-        expect(helper.display_resend_renewal_reminder_link_for?(resource)).to eq(false)
       end
     end
   end

--- a/spec/models/waste_carriers_engine/registration_spec.rb
+++ b/spec/models/waste_carriers_engine/registration_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteCarriersEngine
+  RSpec.describe Registration do
+
+    describe "#can_start_front_office_renewal?" do
+      let(:registration) { build(:registration) }
+
+      context "when the registration is lower tier" do
+        before { registration.tier = "LOWER" }
+
+        it "returns false" do
+          expect(registration.can_start_front_office_renewal?).to eq(false)
+        end
+      end
+
+      context "when the registration is upper tier" do
+        before { registration.tier = "UPPER" }
+
+        context "when the registration has been revoked or refused" do
+          before { registration.metaData.status = %w[REVOKED REFUSED].sample }
+
+          it "returns false" do
+            expect(registration.can_start_front_office_renewal?).to eq(false)
+          end
+        end
+
+        context "when the registration has not been revoked or refused" do
+          before { registration.metaData.status = "ACTIVE" }
+
+          context "when the registration is in the standard grace window" do
+            before { expect_any_instance_of(ExpiryCheckService).to receive(:in_standard_expiry_grace_window?).and_return(true) }
+
+            it "returns true" do
+              expect(registration.can_start_front_office_renewal?).to eq(true)
+            end
+          end
+
+          context "when the registration is not in the standard grace window" do
+            before { expect_any_instance_of(ExpiryCheckService).to receive(:in_standard_expiry_grace_window?).and_return(false) }
+
+            context "when the registration is past the expiry date" do
+              before { expect_any_instance_of(ExpiryCheckService).to receive(:expired?).and_return(true) }
+
+              it "returns false" do
+                expect(registration.can_start_front_office_renewal?).to eq(false)
+              end
+            end
+
+            context "when the registration is not past the expiry date" do
+              before { expect_any_instance_of(ExpiryCheckService).to receive(:expired?).and_return(false) }
+
+              context "when the registration is in the renewal window" do
+                before { expect_any_instance_of(ExpiryCheckService).to receive(:in_renewal_window?).and_return(true) }
+
+                it "returns true" do
+                  expect(registration.can_start_front_office_renewal?).to eq(true)
+                end
+              end
+
+              context "when the result is not in the renewal window" do
+                before { expect_any_instance_of(ExpiryCheckService).to receive(:in_renewal_window?).and_return(false) }
+
+                it "returns false" do
+                  expect(registration.can_start_front_office_renewal?).to eq(false)
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1175

All the checks for resending emails or otherwise sharing the renewal magic link are based off when NCCC can renew.

However, when NCCC can renew and when a front office user can renew may no longer be the same. In this case, the user could receive a link which would just tell them the registration was expired, and they could no longer use it.