### PR TITLE
Don't hardcode EA email into digital reminder letter

### DIFF
--- a/app/presenters/reminder_letter_presenter.rb
+++ b/app/presenters/reminder_letter_presenter.rb
@@ -50,4 +50,8 @@ class ReminderLetterPresenter < WasteCarriersEngine::BasePresenter
      "/fo/renew/",
      renew_token].join
   end
+
+  def from_email
+    Rails.configuration.email_service_email
+  end
 end

--- a/app/views/digital_reminder_letters/_digital_reminder_letter_content.html.erb
+++ b/app/views/digital_reminder_letters/_digital_reminder_letter_content.html.erb
@@ -37,7 +37,10 @@
       </p>
 
       <ol>
-        <li><%= t(".section_2.instructions.line_1", email: presenter.contact_email, date: presenter.renewal_email_date) %></li>
+        <li><%= t(".section_2.instructions.line_1",
+                email: presenter.contact_email,
+                date: presenter.renewal_email_date,
+                from_email: presenter.from_email) %></li>
         <li><%= t(".section_2.instructions.line_2") %></li>
         <li><%= t(".section_2.instructions.line_3") %></li>
       </ol>

--- a/config/locales/digital_reminder_letters.en.yml
+++ b/config/locales/digital_reminder_letters.en.yml
@@ -8,7 +8,7 @@ en:
       section_2:
         subheading: "How to renew online"
         instructions:
-          line_1: "Search your email inbox and junk mail for the renewal email sent to %{email} on %{date}, from no‑reply@environment‑agency.gov.uk"
+          line_1: "Search your email inbox and junk mail for the renewal email sent to %{email} on %{date}, from %{from_email}"
           line_2: "Confirm details for your renewal"
           line_3: "Pay for your renewal"
       section_3:

--- a/spec/presenters/reminder_letter_presenter_spec.rb
+++ b/spec/presenters/reminder_letter_presenter_spec.rb
@@ -128,4 +128,13 @@ RSpec.describe ReminderLetterPresenter do
       expect(subject.renewal_url).to eq(expected_url)
     end
   end
+
+  describe "#from_email" do
+    let(:email_service_email) { "email_service_email@wcr.gov.uk" }
+
+    it "returns the email_service_email from the config" do
+      expect(Rails.configuration).to receive(:email_service_email).and_return(email_service_email)
+      expect(subject.from_email).to eq(email_service_email)
+    end
+  end
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-255

We want to make sure this email address is accurate and matches the one that we send emails from. So this change updates it to use the same config value that we use when sending out the emails.