### PR TITLE
Don't enforce expiry date uniqueness across exports

### DIFF
--- a/app/models/ad_reminder_letters_export.rb
+++ b/app/models/ad_reminder_letters_export.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class AdReminderLettersExport < ReminderLettersExport
+  validates :expires_on, uniqueness: true
+
   def export!
     AdReminderLettersExportService.run(self)
   end

--- a/app/models/digital_reminder_letters_export.rb
+++ b/app/models/digital_reminder_letters_export.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class DigitalReminderLettersExport < ReminderLettersExport
+  validates :expires_on, uniqueness: true
+
   def export!
     DigitalReminderLettersExportService.run(self)
   end

--- a/app/models/reminder_letters_export.rb
+++ b/app/models/reminder_letters_export.rb
@@ -10,8 +10,6 @@ class ReminderLettersExport
     DELETED = "deleted"
   ].freeze
 
-  validates :expires_on, uniqueness: true
-
   store_in collection: "reminder_letters_exports"
 
   scope :not_deleted, -> { where.not(status: DELETED) }

--- a/spec/models/ad_reminder_letters_export_spec.rb
+++ b/spec/models/ad_reminder_letters_export_spec.rb
@@ -11,6 +11,16 @@ RSpec.describe AdReminderLettersExport, type: :model do
 
       expect(invalid_record).to_not be_valid
     end
+
+    context "when there is a digital export with the same date" do
+      let(:digital_reminder_letters_export) { create(:digital_reminder_letters_export) }
+
+      it "is valid" do
+        valid_record = build(:ad_reminder_letters_export, expires_on: digital_reminder_letters_export.expires_on)
+
+        expect(valid_record).to be_valid
+      end
+    end
   end
 
   describe "#export!" do

--- a/spec/models/digital_reminder_letters_export_spec.rb
+++ b/spec/models/digital_reminder_letters_export_spec.rb
@@ -11,6 +11,16 @@ RSpec.describe DigitalReminderLettersExport, type: :model do
 
       expect(invalid_record).to_not be_valid
     end
+
+    context "when there is an AD export with the same date" do
+      let(:ad_reminder_letters_export) { create(:ad_reminder_letters_export) }
+
+      it "is valid" do
+        valid_record = build(:digital_reminder_letters_export, expires_on: ad_reminder_letters_export.expires_on)
+
+        expect(valid_record).to be_valid
+      end
+    end
   end
 
   describe "#export!" do


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-255

We spotted that a DigitalReminderLettersExport would fail if there was already an AdReminderLettersExport for that expiry date, and vice versa.

Moving the validation from the superclass to the individual export type classes should solve this issue.