### PR TITLE
Update default letter config to allow more leeway

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -117,10 +117,10 @@ module WasteCarriersBackOffice
     config.second_renewal_email_reminder_days = ENV["SECOND_RENEWAL_EMAIL_REMINDER_DAYS"] || 28
 
     # Letters exports
-    config.digital_reminder_letters_exports_expires_in = ENV["DIGITAL_REMINDER_LETTERS_EXPORTS_EXPIRES_IN"] || 14
-    config.digital_reminder_letters_delete_records_in = ENV["DIGITAL_REMINDER_LETTERS_DELETE_RECORDS_IN"] || 7
+    config.digital_reminder_letters_exports_expires_in = ENV["DIGITAL_REMINDER_LETTERS_EXPORTS_EXPIRES_IN"] || 21
+    config.digital_reminder_letters_delete_records_in = ENV["DIGITAL_REMINDER_LETTERS_DELETE_RECORDS_IN"] || 28
     config.ad_reminder_letters_exports_expires_in = ENV["AD_REMINDER_LETTERS_EXPORTS_EXPIRES_IN"] || 35
-    config.ad_reminder_letters_delete_records_in = ENV["AD_REMINDER_LETTERS_DELETE_RECORDS_IN"] || 7
+    config.ad_reminder_letters_delete_records_in = ENV["AD_REMINDER_LETTERS_DELETE_RECORDS_IN"] || 28
 
     # Digital or assisted digital metaData.route value
     config.metadata_route = "ASSISTED_DIGITAL"


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1179

As our ability to print may be limited for a while, we're updating the following values:

- letter exports for digital renewals should be done 21 days in advance, not 14
- all letter exports should be deleted after 28 days, not 7