### PR TITLE
Fix criteria for renewal reminders

### DIFF
--- a/app/services/ad_reminder_letters_export_service.rb
+++ b/app/services/ad_reminder_letters_export_service.rb
@@ -27,6 +27,8 @@ class AdReminderLettersExportService < ReminderLettersExportService
 
       WasteCarriersEngine::Registration
         .order_by(reg_identifier: "ASC")
+        .active
+        .upper_tier
         .in(contact_email: [WasteCarriersEngine.configuration.assisted_digital_email, nil, ""])
         .where(expires_on: { :$lte => to, :$gte => from })
     end.call

--- a/app/services/digital_reminder_letters_export_service.rb
+++ b/app/services/digital_reminder_letters_export_service.rb
@@ -27,6 +27,8 @@ class DigitalReminderLettersExportService < ReminderLettersExportService
 
       WasteCarriersEngine::Registration
         .order_by(reg_identifier: "ASC")
+        .active
+        .upper_tier
         .not_in(contact_email: [WasteCarriersEngine.configuration.assisted_digital_email, nil, ""])
         .where(expires_on: { :$lte => to, :$gte => from })
     end.call

--- a/app/services/renewal_reminder_service_base.rb
+++ b/app/services/renewal_reminder_service_base.rb
@@ -21,6 +21,7 @@ class RenewalReminderServiceBase < ::WasteCarriersEngine::BaseService
   def expiring_registrations
     WasteCarriersEngine::Registration
       .active
+      .upper_tier
       .where(
         expires_on:
         {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1203

We spotted that reminder letters were being generated for registrations that were ceased or had never been activated. These letters didn't have the proper renewal URL and it wouldn't have been possible to renew anyway.

This PR adds the `.active` scope when selecting registrations to contact. It also adds an additional `.upper_tier` check as an extra guard against legacy weirdness from the frontend.