### PR TITLE
Redirect old frontend routes to back office pages

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -225,6 +225,12 @@ Rails.application.routes.draw do
             path: "/bo/import-convictions",
             path_names: { new: "" }
 
+  # Redirect old Devise routes
+  # rubocop:disable Style/FormatStringToken
+  get "/agency_users(*all)" => redirect("/bo/users%{all}")
+  get "/admins(*all)" => redirect("/bo/users%{all}")
+  # rubocop:enable Style/FormatStringToken
+
   mount DefraRubyMocks::Engine => "/bo/mocks"
 
   mount DefraRubyFeatures::Engine => "/bo/features", as: "features_engine"

--- a/spec/requests/routes_spec.rb
+++ b/spec/requests/routes_spec.rb
@@ -73,4 +73,44 @@ RSpec.describe "Root", type: :request do
       end
     end
   end
+
+  describe "GET /agency_users" do
+    context "when the user goes to an old Devise sign-in URL" do
+      it "returns a 301 and loads the new Devise URL" do
+        get "/agency_users/sign_in"
+
+        expect(response).to have_http_status(301)
+        expect(response).to redirect_to("/bo/users/sign_in")
+      end
+    end
+
+    context "when the user goes to an old Devise password URL" do
+      it "returns a 301 and loads the new Devise URL" do
+        get "/agency_users/password/edit"
+
+        expect(response).to have_http_status(301)
+        expect(response).to redirect_to("/bo/users/password/edit")
+      end
+    end
+  end
+
+  describe "GET /admins" do
+    context "when the user goes to an old Devise sign-in URL" do
+      it "returns a 301 and loads the new Devise URL" do
+        get "/admins/sign_in"
+
+        expect(response).to have_http_status(301)
+        expect(response).to redirect_to("/bo/users/sign_in")
+      end
+    end
+
+    context "when the user goes to an old Devise password URL" do
+      it "returns a 301 and loads the new Devise URL" do
+        get "/admins/password/edit"
+
+        expect(response).to have_http_status(301)
+        expect(response).to redirect_to("/bo/users/password/edit")
+      end
+    end
+  end
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1221

Since the frontend is being removed and the back office will be reached from the admin subdomain by default, we need to make some redirects.

Old Devise URLs (eg logging in) will redirect to the back front office URLs.