### PR TITLE
Add correct grace period to COVID extension regs in EPR

### DIFF
--- a/app/presenters/reports/registration_epr_presenter.rb
+++ b/app/presenters/reports/registration_epr_presenter.rb
@@ -48,7 +48,7 @@ module Reports
     end
 
     def extended_covid_expiry_date(original_expires_on)
-      (original_expires_on + Rails.configuration.grace_window.days).to_formatted_s(:year_month_day_hyphens)
+      (original_expires_on + Rails.configuration.covid_grace_window.days).to_formatted_s(:year_month_day_hyphens)
     end
   end
 end

--- a/spec/presenters/reports/registration_epr_presenter_spec.rb
+++ b/spec/presenters/reports/registration_epr_presenter_spec.rb
@@ -58,8 +58,8 @@ module Reports
             expect(Rails.configuration).to receive(:end_of_covid_extension).and_return(Date.new(2020, 10, 1))
           end
 
-          it "returns the object expires_on formatted plus grace window days" do
-            allow(Rails.configuration).to receive(:grace_window).and_return(3)
+          it "returns the object expires_on formatted plus COVID grace window days" do
+            allow(Rails.configuration).to receive(:covid_grace_window).and_return(3)
 
             allow(registration).to receive(:expires_on).and_return(Time.new(2015, 1, 1))
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1210

We need to add the COVID grace period to the expiry date for regs which received the extension, not the standard grace period.