### PR TITLE
Fix old frontend link in transferred account email

### DIFF
--- a/app/views/registration_transfer_mailer/transfer_to_existing_account_email.html.erb
+++ b/app/views/registration_transfer_mailer/transfer_to_existing_account_email.html.erb
@@ -69,7 +69,7 @@
               </p>
 
               <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 15px 0;">
-                <%= link_to t(".log_in_link"), "#{Rails.configuration.wcrs_frontend_url}/users/sign_in" %>
+                <%= link_to t(".log_in_link"), "#{Rails.configuration.wcrs_renewals_url}/fo/users/sign_in" %>
               </p>
 
               <ul>

--- a/spec/models/reports/epr_serializer_spec.rb
+++ b/spec/models/reports/epr_serializer_spec.rb
@@ -15,7 +15,7 @@ module Reports
 
         expect(result).to include("\"Registration number\",\"Organisation name\",\"UPRN\",\"Building\",\"Address line 1\",\"Address line 2\",\"Address line 3\",\"Address line 4\",\"Town\",\"Postcode\",\"Country\",\"Easting\",\"Northing\",\"Applicant type\",\"Registration tier\",\"Registration type\",\"Registration date\",\"Expiry date\",\"Company number\"")
         expect(result).to include(active.reg_identifier)
-        expect(result).to include(expired.reg_identifier)
+        expect(result).to_not include(expired.reg_identifier)
       end
     end
   end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1223

The email we send when a registration is transferred to an existing account had a link to log in via the frontend. This will no longer be valid so I've changed it to the front office.