### PR TITLE
Upload EPR exports to EPR folder

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,7 @@ gem "whenever", "~> 1.0"
 gem "wicked_pdf"
 
 # Use the Defra Ruby Aws gem for loading files to AWS buckets
-gem "defra_ruby_aws", "~> 0.3.0"
+gem "defra_ruby_aws", "~> 0.4"
 
 # Use the waste carriers engine for the user journey
 gem "waste_carriers_engine",

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,20 +92,20 @@ GEM
     aws-eventstream (1.1.0)
     aws-healthcheck (1.0.1)
       rails (>= 3.0)
-    aws-partitions (1.341.0)
-    aws-sdk-core (3.103.0)
+    aws-partitions (1.402.0)
+    aws-sdk-core (3.110.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
-    aws-sdk-kms (1.36.0)
-      aws-sdk-core (~> 3, >= 3.99.0)
+    aws-sdk-kms (1.39.0)
+      aws-sdk-core (~> 3, >= 3.109.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.74.0)
-      aws-sdk-core (~> 3, >= 3.102.1)
+    aws-sdk-s3 (1.86.0)
+      aws-sdk-core (~> 3, >= 3.109.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)
-    aws-sigv4 (1.2.1)
+    aws-sigv4 (1.2.2)
       aws-eventstream (~> 1, >= 1.0.2)
     bcrypt (3.1.16)
     bindex (0.8.1)
@@ -127,7 +127,7 @@ GEM
       rest-client (~> 2.0)
     defra_ruby_alert (2.1.1)
       airbrake
-    defra_ruby_aws (0.3.1)
+    defra_ruby_aws (0.4.1)
       aws-sdk-s3
     defra_ruby_email (1.1.0)
       notifications-ruby-client
@@ -440,7 +440,7 @@ DEPENDENCIES
   aws-healthcheck
   cancancan (~> 1.10)
   database_cleaner
-  defra_ruby_aws (~> 0.3.0)
+  defra_ruby_aws (~> 0.4)
   defra_ruby_features (~> 0.1)
   defra_ruby_mocks
   defra_ruby_style

--- a/app/services/concerns/can_load_file_to_aws.rb
+++ b/app/services/concerns/can_load_file_to_aws.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 module CanLoadFileToAws
-  def load_file_to_aws_bucket
+  def load_file_to_aws_bucket(options = {})
     result = nil
 
     3.times do
-      result = bucket.load(File.new(file_path, "r"))
+      result = bucket.load(File.new(file_path, "r"), options)
 
       break if result.successful?
     end

--- a/app/services/reports/epr_export_service.rb
+++ b/app/services/reports/epr_export_service.rb
@@ -9,7 +9,9 @@ module Reports
     def run
       populate_temp_file
 
-      load_file_to_aws_bucket
+      options = { s3_directory: "EPR" }
+
+      load_file_to_aws_bucket(options)
     rescue StandardError => e
       Airbrake.notify e, file_name: file_name
       Rails.logger.error "Generate EPR export csv error for #{file_name}:\n#{e}"


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1239

This PR switches to an updated version of the defra-ruby-aws gem to enable us to upload to a subdirectory.

S3 doesn't really have subdirectories so it's actually just appending an "EPR/" prefix to the file on upload.

I also toned down the level of testing as the old tests were written before we moved all the export functionality into the defra-ruby-aws gem. We have much more specific testing in the gem so there is no need to test so heavily here.