### PR TITLE
Temporarily lock Mongoid version to 7.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ ruby "2.7.1"
 gem "jquery-rails"
 # Use MongoDB as the database, and mongoid as our ORM for it. This version of
 # mongoid supports MongoDb 3.6
-gem "mongoid"
+gem "mongoid", "~> 7.1.5"
 # Bundle edge Rails instead: gem "rails", github: "rails/rails"
 gem "rails", ">= 6.0.3"
 # Use SCSS for stylesheets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -246,9 +246,9 @@ GEM
     minitest (5.14.2)
     mongo (2.14.0)
       bson (>= 4.8.2, < 5.0.0)
-    mongoid (7.2.0)
+    mongoid (7.1.6)
       activemodel (>= 5.1, < 6.1)
-      mongo (>= 2.10.5, < 3.0.0)
+      mongo (>= 2.7.0, < 3.0.0)
     mongoid-locker (2.0.0)
       mongoid (>= 5.0, < 8)
     multi_json (1.14.1)
@@ -454,7 +454,7 @@ DEPENDENCIES
   jquery-rails
   kaminari (~> 1.1)
   kaminari-mongoid (~> 1.0)
-  mongoid
+  mongoid (~> 7.1.5)
   passenger (~> 5.0, >= 5.0.30)
   pry-byebug
   rails (>= 6.0.3)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1241

When we upgraded the engine to 7.2, we ran into some test failures.

Until such time as we can fix this issue, locking to 7.1.