### PR TITLE
Send digital reminder letters via Notify

### DIFF
--- a/app/presenters/notify_renewal_letter_presenter.rb
+++ b/app/presenters/notify_renewal_letter_presenter.rb
@@ -27,4 +27,9 @@ class NotifyRenewalLetterPresenter < WasteCarriersEngine::BasePresenter
      "/fo/renew/",
      renew_token].join
   end
+
+  def renewal_email_date
+    first_reminder_days = Rails.configuration.first_renewal_email_reminder_days.to_i
+    (expires_on - first_reminder_days.days).to_date
+  end
 end

--- a/app/services/notify_ad_renewal_letter_service.rb
+++ b/app/services/notify_ad_renewal_letter_service.rb
@@ -1,20 +1,6 @@
 # frozen_string_literal: true
 
-require "notifications/client"
-
-class NotifyAdRenewalLetterService < ::WasteCarriersEngine::BaseService
-  # So we can use displayable_address()
-  include ::WasteCarriersEngine::ApplicationHelper
-
-  def run(registration:)
-    @registration = NotifyRenewalLetterPresenter.new(registration)
-
-    client = Notifications::Client.new(WasteCarriersEngine.configuration.notify_api_key)
-
-    client.send_letter(template_id: template,
-                       personalisation: personalisation)
-  end
-
+class NotifyAdRenewalLetterService < NotifyRenewalLetterService
   private
 
   def template
@@ -30,21 +16,5 @@ class NotifyAdRenewalLetterService < ::WasteCarriersEngine::BaseService
       renewal_cost: @registration.renewal_cost,
       renewal_url: @registration.renewal_url
     }.merge(address_lines)
-  end
-
-  def address_lines
-    address_values = [
-      @registration.contact_name,
-      displayable_address(@registration.contact_address)
-    ].flatten
-
-    address_hash = {}
-
-    address_values.each_with_index do |value, index|
-      line_number = index + 1
-      address_hash["address_line_#{line_number}"] = value
-    end
-
-    address_hash
   end
 end

--- a/app/services/notify_digital_renewal_letter_service.rb
+++ b/app/services/notify_digital_renewal_letter_service.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class NotifyDigitalRenewalLetterService < NotifyRenewalLetterService
+  private
+
+  def template
+    "41ebbbc4-0d2f-425a-8d94-29e2beffd8ba"
+  end
+
+  def personalisation
+    {
+      contact_name: @registration.contact_name,
+      expiry_date: @registration.expiry_date,
+      reg_identifier: @registration.reg_identifier,
+      registration_cost: @registration.registration_cost,
+      renewal_cost: @registration.renewal_cost,
+      renewal_url: @registration.renewal_url,
+      user_email: @registration.contact_email,
+      email_date: @registration.renewal_email_date
+    }.merge(address_lines)
+  end
+end

--- a/app/services/notify_renewal_letter_service.rb
+++ b/app/services/notify_renewal_letter_service.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "notifications/client"
+
+class NotifyRenewalLetterService < ::WasteCarriersEngine::BaseService
+  # So we can use displayable_address()
+  include ::WasteCarriersEngine::ApplicationHelper
+
+  def run(registration:)
+    @registration = NotifyRenewalLetterPresenter.new(registration)
+
+    client = Notifications::Client.new(WasteCarriersEngine.configuration.notify_api_key)
+
+    client.send_letter(template_id: template,
+                       personalisation: personalisation)
+  end
+
+  private
+
+  def address_lines
+    address_values = [
+      @registration.contact_name,
+      displayable_address(@registration.contact_address)
+    ].flatten
+
+    address_hash = {}
+
+    address_values.each_with_index do |value, index|
+      line_number = index + 1
+      address_hash["address_line_#{line_number}"] = value
+    end
+
+    address_hash
+  end
+end

--- a/spec/cassettes/notify_digital_renewal_letter.yml
+++ b/spec/cassettes/notify_digital_renewal_letter.yml
@@ -1,0 +1,67 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.notifications.service.gov.uk/v2/notifications/letter
+    body:
+      encoding: UTF-8
+      string: '{"template_id":"41ebbbc4-0d2f-425a-8d94-29e2beffd8ba","personalisation":{"contact_name":"Jane
+        Doe","expiry_date":"6 June 2021","reg_identifier":"CBDU1","registration_cost":"154","renewal_cost":"105","renewal_url":"localhost:3002/fo/renew/ePBEXbag1AMjrsUgfKEbNfYy","user_email":"whatever@example.com","email_date":"2021-04-25","from_email":"wcr-dev@example.com","address_line_1":"Jane
+        Doe","address_line_2":"42","address_line_3":"Foo Gardens","address_line_4":"Baz
+        City","address_line_5":"BS1 1AA"}}'
+    headers:
+      User-Agent:
+      - NOTIFY-API-RUBY-CLIENT/5.3.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic <API_KEY>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type,Authorization
+      Access-Control-Allow-Methods:
+      - GET,PUT,POST,DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 06 Apr 2021 14:20:09 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains
+      X-B3-Spanid:
+      - 5a1f34325f84c13c
+      X-B3-Traceid:
+      - 5a1f34325f84c13c
+      X-Vcap-Request-Id:
+      - d28e5750-29e9-4642-5795-270d8bace2bc
+      Content-Length:
+      - '1190'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"content":{"body":"Dear Jane Doe\r\n\r\nYou can renew online in a
+        few minutes. It costs \u00a3105 and lasts for 3 years from the expiry date.\r\n\r\nHow
+        to renew online:\r\n\r\n1. Search your email inbox and junk mail for the renewal
+        email sent to whatever@example.com on 2021-04-25, from wcr-dev@example.com\r\n2.
+        Confirm details for your renewal\r\n3. Pay for your renewal\r\n\r\nIf you
+        do not renew in time you\u2019ll need to create a new registration, which
+        will instead cost \u00a3154.\r\n\r\nIf you\u2019re unable to find the renewal
+        email, begin your online renewal by using this unique link:\r\n\r\nlocalhost:3002/fo/renew/ePBEXbag1AMjrsUgfKEbNfYy\r\n\r\nYours
+        sincerely\r\nWaste carrier renewal team","subject":"You must renew your waste
+        carrier registration CBDU1 by 6 June 2021"},"id":"b6628d5c-5869-433e-9096-22ad759d447b","reference":null,"scheduled_for":null,"template":{"id":"41ebbbc4-0d2f-425a-8d94-29e2beffd8ba","uri":"https://api.notifications.service.gov.uk/services/25cb6b94-8ce7-485b-918a-559f3b18f69c/templates/41ebbbc4-0d2f-425a-8d94-29e2beffd8ba","version":5},"uri":"https://api.notifications.service.gov.uk/v2/notifications/b6628d5c-5869-433e-9096-22ad759d447b"}
+
+'
+  recorded_at: Tue, 06 Apr 2021 14:20:09 GMT
+recorded_with: VCR 6.0.0

--- a/spec/presenters/notify_renewal_letter_presenter_spec.rb
+++ b/spec/presenters/notify_renewal_letter_presenter_spec.rb
@@ -54,4 +54,17 @@ RSpec.describe NotifyRenewalLetterPresenter do
       expect(subject.renewal_url).to eq(expected_url)
     end
   end
+
+  describe "#renewal_email_date" do
+    let(:first_renewal_email_reminder_days) { 30 }
+    let(:expires_on) { Time.now }
+    let(:registration) { double(:registration, expires_on: expires_on) }
+
+    it "returns a date object" do
+      expected_date = first_renewal_email_reminder_days.days.ago.to_date
+
+      expect(Rails.configuration).to receive(:first_renewal_email_reminder_days).and_return(first_renewal_email_reminder_days)
+      expect(subject.renewal_email_date).to eq(expected_date)
+    end
+  end
 end

--- a/spec/services/notify_digital_renewal_letter_service_spec.rb
+++ b/spec/services/notify_digital_renewal_letter_service_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe NotifyDigitalRenewalLetterService do
+  describe "run" do
+    let(:registration) { create(:registration, :expires_soon) }
+    let(:service) do
+      NotifyDigitalRenewalLetterService.run(registration: registration)
+    end
+
+    it "sends a letter" do
+      VCR.use_cassette("notify_digital_renewal_letter") do
+        # Make sure it's a real postcode for Notify validation purposes
+        allow_any_instance_of(WasteCarriersEngine::Address).to receive(:postcode).and_return("BS1 1AA")
+
+        expect_any_instance_of(Notifications::Client).to receive(:send_letter).and_call_original
+
+        response = service
+
+        expect(response).to be_a(Notifications::Client::ResponseNotification)
+        expect(response.template["id"]).to eq("41ebbbc4-0d2f-425a-8d94-29e2beffd8ba")
+        expect(response.content["subject"]).to include("You must renew your waste carrier registration")
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1362

This PR adds a service that sends reminder letters for non-AD registrations via GOV.UK Notify.

These users receive multiple emails before this point, but the letter acts as a fallback in case they did not receive the email.