### PR TITLE
Rename a Notify service that has been changed in the engine

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: c4435c9612cbf52a4d00a876179bb6fc687bd65c
+  revision: b407cd43e3c91ae02c33aec86ab91a2a4e3ce210
   branch: main
   specs:
     waste_carriers_engine (0.0.1)

--- a/app/controllers/resend_confirmation_email_controller.rb
+++ b/app/controllers/resend_confirmation_email_controller.rb
@@ -10,7 +10,7 @@ class ResendConfirmationEmailController < ApplicationController
     begin
       validate_contact_email(registration)
 
-      WasteCarriersEngine::Notify::RegistrationActivatedEmailService.run(registration: registration)
+      WasteCarriersEngine::Notify::RegistrationConfirmationEmailService.run(registration: registration)
 
       flash_success(
         I18n.t("resend_confirmation_email.messages.success", email: registration.contact_email)

--- a/spec/requests/resend_confirmation_email_spec.rb
+++ b/spec/requests/resend_confirmation_email_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe "ResendConfirmationEmail", type: :request do
 
       context "when an error happens", disable_bullet: true do
         before do
-          allow(WasteCarriersEngine::Notify::RegistrationActivatedEmailService)
+          allow(WasteCarriersEngine::Notify::RegistrationConfirmationEmailService)
             .to receive(:run)
             .and_raise(StandardError)
         end


### PR DESCRIPTION
Tests failed because 
`WasteCarriersEngine::Notify::RegistrationActivatedEmailService`
was changed to:
`WasteCarriersEngine::Notify::RegistrationConfirmationEmailService`

Includes a bump to the latest waste-carriers-engine gem