### PR TITLE
Handle no account_email on registration transfer page

### DIFF
--- a/app/controllers/registration_transfers_controller.rb
+++ b/app/controllers/registration_transfers_controller.rb
@@ -40,7 +40,10 @@ class RegistrationTransfersController < ApplicationController
   end
 
   def find_registration(reg_identifier)
-    @registration = WasteCarriersEngine::Registration.where(reg_identifier: reg_identifier).first
+    @registration =
+      RegistrationTransferPresenter.new(
+        WasteCarriersEngine::Registration.where(reg_identifier: reg_identifier).first
+      )
   end
 
   def authorize_action

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -43,7 +43,7 @@ class Ability
 
     can :revert_to_payment_summary, :all
 
-    can :transfer_registration, WasteCarriersEngine::Registration
+    can :transfer_registration, [WasteCarriersEngine::Registration, RegistrationTransferPresenter]
   end
 
   def permissions_for_agency_user_with_refund

--- a/app/presenters/registration_transfer_presenter.rb
+++ b/app/presenters/registration_transfer_presenter.rb
@@ -7,16 +7,27 @@ class RegistrationTransferPresenter < WasteCarriersEngine::BasePresenter
     super
   end
 
-  def paragraph_1_message
+  def new_registration_transfer_message_lines
+    paragraph = []
     if @registration.account_email.present?
-      I18n.t(".registration_transfers.new.paragraph_1", email: @registration.account_email)
+      paragraph << to_yml(:paragraph_1, email: @registration.account_email)
+      paragraph << to_yml(:paragraph_2, reg_identifier: @registration.reg_identifier)
+      paragraph << to_yml(:paragraph_3, email: @registration.account_email)
+      paragraph << to_yml(:paragraph_4, email: @registration.account_email)
     else
-      I18n.t(".registration_transfers.new.paragraph_1_no_account_email")
+      paragraph << to_yml(:paragraph_1_no_account_email)
+      paragraph << to_yml(:paragraph_2, reg_identifier: @registration.reg_identifier)
     end
+    paragraph
   end
 
   def account_email_message
-    @registration.account_email.presence ||
-      I18n.t(".registration_transfers.new.registration_info.values.not_applicable")
+    @registration.account_email.presence || to_yml("registration_info.values.not_applicable")
+  end
+
+  private
+
+  def to_yml(key, options = {})
+    I18n.t(".registration_transfers.new.#{key}", options)
   end
 end

--- a/app/presenters/registration_transfer_presenter.rb
+++ b/app/presenters/registration_transfer_presenter.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class RegistrationTransferPresenter < WasteCarriersEngine::BasePresenter
+  def initialize(registration)
+    @registration = registration
+
+    super
+  end
+
+  def paragraph_1_message
+    if @registration.account_email.present?
+      I18n.t(".registration_transfers.new.paragraph_1", email: @registration.account_email)
+    else
+      I18n.t(".registration_transfers.new.paragraph_1_no_account_email")
+    end
+  end
+
+  def account_email_message
+    @registration.account_email.presence ||
+      I18n.t(".registration_transfers.new.registration_info.values.n_a")
+  end
+end

--- a/app/presenters/registration_transfer_presenter.rb
+++ b/app/presenters/registration_transfer_presenter.rb
@@ -17,6 +17,6 @@ class RegistrationTransferPresenter < WasteCarriersEngine::BasePresenter
 
   def account_email_message
     @registration.account_email.presence ||
-      I18n.t(".registration_transfers.new.registration_info.values.n_a")
+      I18n.t(".registration_transfers.new.registration_info.values.not_applicable")
   end
 end

--- a/app/views/registration_transfers/new.html.erb
+++ b/app/views/registration_transfers/new.html.erb
@@ -13,7 +13,7 @@
     </h1>
 
     <div class="form-group">
-      <p><%= t(".paragraph_1", email: @registration.account_email) %></p>
+      <p><%= @registration.paragraph_1_message %></p>
       <p><%= t(".paragraph_2", reg_identifier: @registration.reg_identifier) %></p>
       <p><%= t(".paragraph_3", email: @registration.account_email) %></p>
       <p><%= t(".paragraph_4", email: @registration.account_email) %></p>
@@ -28,7 +28,7 @@
               <%= t(".registration_info.labels.account_email") %>
             </td>
             <td>
-              <%= @registration.account_email %>
+              <%= @registration.account_email_message %>
             </td>
           </tr>
           <tr>

--- a/app/views/registration_transfers/new.html.erb
+++ b/app/views/registration_transfers/new.html.erb
@@ -13,11 +13,9 @@
     </h1>
 
     <div class="form-group">
-      <p><%= @registration.paragraph_1_message %></p>
-      <p><%= t(".paragraph_2", reg_identifier: @registration.reg_identifier) %></p>
-      <p><%= t(".paragraph_3", email: @registration.account_email) %></p>
-      <p><%= t(".paragraph_4", email: @registration.account_email) %></p>
-
+      <% @registration.new_registration_transfer_message_lines.each do |message_line| %>
+        <p><%= message_line %></p>
+      <% end %>
       <table>
         <caption class="heading-medium">
           <%= t(".registration_info.heading") %>

--- a/config/locales/registration_transfers.en.yml
+++ b/config/locales/registration_transfers.en.yml
@@ -15,7 +15,7 @@ en:
           reg_identifier: "Registration number"
           company_name: "Company name"
         values:
-          n_a: "n/a"
+          not_applicable: "n/a"
       subheading_1: "Transfer the registration"
       email_label: "Email address"
       confirm_email_label: "Confirm email address"

--- a/config/locales/registration_transfers.en.yml
+++ b/config/locales/registration_transfers.en.yml
@@ -4,6 +4,7 @@ en:
       title: "Transfer a registration to a different user account"
       heading: "Transfer registration %{reg_identifier} to a different user account"
       paragraph_1: "This registration currently belongs to %{email}."
+      paragraph_1_no_account_email: "This registration currently does not have an account associated with it."
       paragraph_2: "If you know that a different user should own %{reg_identifier}, you can transfer it to a different account."
       paragraph_3: "Once the registration is transferred, %{email} will no longer be able to view or manage it."
       paragraph_4: "Any other registrations owned by %{email} will not be affected."
@@ -13,6 +14,8 @@ en:
           account_email: "Current user account"
           reg_identifier: "Registration number"
           company_name: "Company name"
+        values:
+          n_a: "n/a"
       subheading_1: "Transfer the registration"
       email_label: "Email address"
       confirm_email_label: "Confirm email address"

--- a/spec/presenters/registration_transfer_presenter_spec.rb
+++ b/spec/presenters/registration_transfer_presenter_spec.rb
@@ -3,16 +3,26 @@
 require "rails_helper"
 
 RSpec.describe RegistrationTransferPresenter do
-  let(:registration) { double(:registration, account_email: account_email) }
+  let(:registration) do
+    double(:registration, account_email: account_email, reg_identifier: "ABC1")
+  end
+
   let(:presenter) { described_class.new(registration) }
 
   context "account_email messages" do
     context "with an account_email" do
       let(:account_email) { "alice@example.com" }
 
-      it "returns the paragraph_1 message" do
-        expect(presenter.paragraph_1_message)
-          .to eq("This registration currently belongs to alice@example.com.")
+      it "returns the new_registration_transfer_message_lines" do
+        expect(presenter.new_registration_transfer_message_lines)
+          .to eq(
+            [
+              message_for(:paragraph_1, email: account_email),
+              message_for(:paragraph_2, reg_identifier: registration.reg_identifier),
+              message_for(:paragraph_3, email: account_email),
+              message_for(:paragraph_4, email: account_email)
+            ]
+          )
       end
 
       it "returns the account_email" do
@@ -24,14 +34,22 @@ RSpec.describe RegistrationTransferPresenter do
       let(:account_email) { "" }
 
       it "returns the paragraph_1_no_email message" do
-        expect(presenter.paragraph_1_message)
-          .to eq("This registration currently does not have an account associated with it.")
+        expect(presenter.new_registration_transfer_message_lines)
+          .to eq(
+            [
+              message_for(:paragraph_1_no_account_email),
+              message_for(:paragraph_2, reg_identifier: registration.reg_identifier)
+            ]
+          )
       end
 
       it "returns n/a" do
-        expect(presenter.account_email_message)
-          .to eq("n/a")
+        expect(presenter.account_email_message).to eq("n/a")
       end
+    end
+
+    def message_for(key, options = {})
+      I18n.t(".registration_transfers.new.#{key}", options)
     end
   end
 end

--- a/spec/presenters/registration_transfer_presenter_spec.rb
+++ b/spec/presenters/registration_transfer_presenter_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RegistrationTransferPresenter do
+  let(:registration) { double(:registration, account_email: account_email) }
+  let(:presenter) { described_class.new(registration) }
+
+  context "account_email messages" do
+    context "with an account_email" do
+      let(:account_email) { "alice@example.com" }
+
+      it "returns the paragraph_1 message" do
+        expect(presenter.paragraph_1_message)
+          .to eq("This registration currently belongs to alice@example.com.")
+      end
+
+      it "returns the account_email" do
+        expect(presenter.account_email_message).to eq("alice@example.com")
+      end
+    end
+
+    context "without an account_email" do
+      let(:account_email) { "" }
+
+      it "returns the paragraph_1_no_email message" do
+        expect(presenter.paragraph_1_message)
+          .to eq("This registration currently does not have an account associated with it.")
+      end
+
+      it "returns n/a" do
+        expect(presenter.account_email_message)
+          .to eq("n/a")
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1429

- An edge case may arise whereby the account_email is blank,
so we need to display alternate text on the registration
transfer page