### PR TITLE
Fix the Registration Transfer email validation

### DIFF
--- a/app/forms/registration_transfer_form.rb
+++ b/app/forms/registration_transfer_form.rb
@@ -12,21 +12,22 @@ class RegistrationTransferForm < WasteCarriersEngine::BaseForm
     self.email = params[:email]&.downcase
     self.confirm_email = params[:confirm_email]&.downcase
 
-    attributes = {}
+    return false unless valid?
 
-    super(attributes)
+    transfer_registration!
   end
 
   validates :email, :confirm_email, "defra_ruby/validators/email": true
   validates :confirm_email, "waste_carriers_engine/matching_email": { compare_to: :email }
-  validate :registration_transferred_successfully?
 
-  def registration_transferred_successfully?
+  def transfer_registration!
     result = RegistrationTransferService.run(registration: registration, email: email)
 
-    return true if %i[success_existing_user
-                      success_new_user].include?(result)
+    return true if %i[success_existing_user success_new_user].include?(result)
 
+    # This is to handle a `no_matching_user` return code.
+    # Currently, the service only checks for the presence of an email, and
+    # as the email already been validated, this scenario shouldn't happen.
     errors[:email] << I18n.t("activemodel.errors.models.registration_transfer_form.attributes.email.#{result}")
     false
   end

--- a/spec/forms/registration_transfer_form_spec.rb
+++ b/spec/forms/registration_transfer_form_spec.rb
@@ -82,42 +82,16 @@ RSpec.describe RegistrationTransferForm, type: :model do
 
   describe "#confirm_email" do
     context "when it doesn't match the email" do
+      let(:original_account_email) { registration_transfer_form.registration.account_email }
+
       before { registration_transfer_form.confirm_email = "no_matchy@example.com" }
 
       it "is not valid" do
         expect(registration_transfer_form).to_not be_valid
       end
-    end
-  end
 
-  describe "#registration_transferred_successfully?" do
-    context "when the RegistrationTransferService returns :success_existing_user" do
-      before do
-        allow(RegistrationTransferService).to receive(:run).and_return(:success_existing_user)
-      end
-
-      it "is valid" do
-        expect(registration_transfer_form).to be_valid
-      end
-    end
-
-    context "when the RegistrationTransferService returns :success_new_user" do
-      before do
-        allow(RegistrationTransferService).to receive(:run).and_return(:success_new_user)
-      end
-
-      it "is valid" do
-        expect(registration_transfer_form).to be_valid
-      end
-    end
-
-    context "when the RegistrationTransferService returns :no_matching_user" do
-      before do
-        allow(RegistrationTransferService).to receive(:run).and_return(:no_matching_user)
-      end
-
-      it "is not valid" do
-        expect(registration_transfer_form).to_not be_valid
+      it "does not update the account_email" do
+        expect(registration_transfer_form.registration.account_email).to eq(original_account_email)
       end
     end
   end

--- a/spec/requests/registration_transfers_spec.rb
+++ b/spec/requests/registration_transfers_spec.rb
@@ -67,11 +67,27 @@ RSpec.describe "RegistrationTransfers", type: :request do
         end
       end
 
-      context "when the params are invalid" do
+      context "when the email addresses are blank" do
         let(:params) do
           {
             email: nil,
             confirm_email: nil
+          }
+        end
+
+        it "renders the new template and does not change the account_email" do
+          old_email = registration.account_email
+          post "/bo/registrations/#{registration.reg_identifier}/transfer/", params: { registration_transfer_form: params }
+
+          expect(response).to render_template(:new)
+          expect(registration.reload.account_email).to eq(old_email)
+        end
+      end
+      context "when the email addresses do not match" do
+        let(:params) do
+          {
+            email: "alice@example.com",
+            confirm_email: "bob@example.com"
           }
         end
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1431

- When a user entered an invalid email/confirmation email pair, the web page
returned the expected error (emails do not match), but the input email 
was saved to the account_email and the registration transfer emails would have been sent.

- This happened because the RegistrationTransferService was invoked as part of
the validation chain. When the email validation failed, there was nothing
to stop the RegistrationTransferService running.

- This PR refactors the RegistrationTransferForm to only call the service if the
model validations are successful. In the `submit` method there was also a call to
`super` with empty attributes, but it's not clear what this was meant to do.