### PR TITLE
Prefer bold text for labels on registration details page

### DIFF
--- a/app/presenters/base_registration_presenter.rb
+++ b/app/presenters/base_registration_presenter.rb
@@ -29,7 +29,7 @@ class BaseRegistrationPresenter < WasteCarriersEngine::BasePresenter
   def displayable_location
     location = show_translation_or_filler(:location)
 
-    I18n.t(".shared.registrations.business_information.labels.location", location: location)
+    I18n.t(".shared.registrations.business_information.labels.location_html", location: location).html_safe
   end
 
   def display_convictions_check_message
@@ -84,9 +84,9 @@ class BaseRegistrationPresenter < WasteCarriersEngine::BasePresenter
     return unless upper_tier?
 
     if expired?
-      I18n.t(".shared.registrations.labels.expired", formatted_date: display_expiry_date)
+      I18n.t(".shared.registrations.labels.expired_html", formatted_date: display_expiry_date).html_safe
     else
-      I18n.t(".shared.registrations.labels.expires", formatted_date: display_expiry_date)
+      I18n.t(".shared.registrations.labels.expires_html", formatted_date: display_expiry_date).html_safe
     end
   end
 

--- a/app/views/shared/registrations/_company_details_panel.html.erb
+++ b/app/views/shared/registrations/_company_details_panel.html.erb
@@ -16,7 +16,7 @@
         <br>
       <% end %>
       <% if resource.account_email.present? %>
-        <%= t(".labels.account", email: resource.account_email) %>
+        <%= t(".labels.account_html", email: resource.account_email).html_safe %>
       <% end %>
     </p>
   <% end %>

--- a/app/views/shared/registrations/_contact_and_business_details_panels.html.erb
+++ b/app/views/shared/registrations/_contact_and_business_details_panels.html.erb
@@ -42,7 +42,7 @@
 
       <% if resource.registered_address.present? %>
         <p class="govuk-body">
-          <%= t(".business_information.labels.registered_address") %> <br>
+          <%= t(".business_information.labels.registered_address_html").html_safe %> <br>
           <% displayable_address(resource.registered_address).each do |line| %>
             <%= line %><br>
           <% end %>

--- a/config/locales/shared/registrations.en.yml
+++ b/config/locales/shared/registrations.en.yml
@@ -36,7 +36,7 @@ en:
             business_type: "Business type"
             company_no: "Company number: %{number}"
             location: "Place of business: %{location}"
-            registered_address: "Registered address:"
+            registered_address_html: "<span class=\"govuk-!-font-weight-bold\">Registered address</span>:"
           no_business_information_available: "This registration application is still in progress, so there are no business details yet."
       pending_payment_panel:
         status:
@@ -54,7 +54,7 @@ en:
             pending_convictions_check: "A convictions check is required before this registration can be approved."
       company_details_panel:
         labels:
-          account: "Account: %{email}"
+          account_html: "<span class=\"govuk-!-font-weight-bold\">Account</span>: %{email}"
         attributes:
           registration_type:
             carrier_dealer: "Carrier and dealer"
@@ -86,8 +86,8 @@ en:
           renew: "Renew"
           new_registration: "Start new registration"
       labels:
-        expires: "Expires: %{formatted_date}"
-        expired: "Expired: %{formatted_date}"
+        expires_html: "<span class=\"govuk-!-font-weight-bold\">Expires</span>: %{formatted_date}"
+        expired_html: "<span class=\"govuk-!-font-weight-bold\">Expired</span>: %{formatted_date}"
       ceased_revoked_panel:
         heading:
           ceased: "Ceased"
@@ -137,7 +137,7 @@ en:
           lower: Lower tier
       business_information:
         labels:
-          location: "Place of business: %{location}"
+          location_html: "<span class=\"govuk-!-font-weight-bold\">Place of business</span>: %{location}"
       filler: "–"
       conviction_search_text:
         "true": "This registration has matching or declared convictions."

--- a/spec/presenters/base_registration_presenter_spec.rb
+++ b/spec/presenters/base_registration_presenter_spec.rb
@@ -198,7 +198,9 @@ RSpec.describe BaseRegistrationPresenter do
       let(:location) { nil }
 
       it "displays a placeholder" do
-        expect(subject.displayable_location).to eq("Place of business: –")
+        expect(subject.displayable_location).to eq(
+          "<span class=\"govuk-!-font-weight-bold\">Place of business</span>: –"
+        )
       end
     end
 
@@ -206,7 +208,9 @@ RSpec.describe BaseRegistrationPresenter do
       let(:location) { "england" }
 
       it "displays the location value" do
-        expect(subject.displayable_location).to eq("Place of business: England")
+        expect(subject.displayable_location).to eq(
+          "<span class=\"govuk-!-font-weight-bold\">Place of business</span>: England"
+        )
       end
     end
   end
@@ -333,7 +337,7 @@ RSpec.describe BaseRegistrationPresenter do
 
       context "when it is not expired" do
         it "displays the 'expires' message" do
-          message = "Expires: 1 January 2020"
+          message = "<span class=\"govuk-!-font-weight-bold\">Expires</span>: 1 January 2020"
 
           expect(subject.display_expiry_text).to eq(message)
         end
@@ -343,7 +347,7 @@ RSpec.describe BaseRegistrationPresenter do
         let(:expired) { true }
 
         it "displays the 'expired' message" do
-          message = "Expired: 1 January 2020"
+          message = "<span class=\"govuk-!-font-weight-bold\">Expired</span>: 1 January 2020"
 
           expect(subject.display_expiry_text).to eq(message)
         end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1542

This PR adds styling to some of the labels on the registration details page, and follows this pattern: https://guides.rubyonrails.org/i18n.html#using-safe-html-translations