### PR TITLE
Improve UX for back office user management

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,12 +5,16 @@ class UsersController < ApplicationController
 
   def index
     authorize! :manage_back_office_users, current_user
-    @users = list_of_users.page params[:page]
+
+    @users = User.where(active: true).order_by(email: :asc).page(params[:page]).per(100)
   end
 
-  private
+  def all
+    authorize! :manage_back_office_users, current_user
 
-  def list_of_users
-    User.all.order_by(email: :asc)
+    @users = User.all.order_by(email: :asc).page(params[:page]).per(100)
+
+    @show_all_users = true
+    render :index
   end
 end

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -7,6 +7,14 @@
     </h1>
 
     <p class="govuk-body"><%= link_to t(".options.invite_link"), new_user_invitation_path %></p>
+
+    <p class="govuk-body">
+      <% if @show_all_users %>
+        <%= link_to t(".options.show_enabled_users_only"), users_path %>
+      <% else %>
+        <%= link_to t(".options.show_all_users"), all_users_path %>
+      <% end %>
+    </p>
   </div>
 </div>
 

--- a/config/locales/users.en.yml
+++ b/config/locales/users.en.yml
@@ -5,6 +5,8 @@ en:
       heading: "Manage back office users"
       options:
         invite_link: "Invite a new user"
+        show_all_users: "Show all users"
+        show_enabled_users_only: "Show enabled users only"
       user_list:
         th:
           email: "User email"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -193,6 +193,10 @@ Rails.application.routes.draw do
   resources :users,
             only: [],
             path: "/bo/users" do
+              collection do
+                get :all
+              end
+
               resources :user_activations,
                         as: :activations,
                         only: %i[new create],

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -11,14 +11,17 @@ RSpec.describe "Users", type: :request do
       end
 
       it "renders the index template, returns a 200 response and includes the correct content" do
-        listed_user = create(:user, email: "aaaaaaaaaaa@example.com")
+        active_user = create(:user, email: "aaaaaaaaaaa@example.com")
+        deactivated_user = create(:user, email: "aaaaaaaaaaa2@example.com", active: false)
 
         get "/bo/users"
 
         expect(response).to render_template(:index)
         expect(response).to have_http_status(200)
         expect(response.body).to include("Manage back office users")
-        expect(response.body).to include(listed_user.email)
+        expect(response.body).to include("Show all users")
+        expect(response.body).to include(active_user.email)
+        expect(response.body).to_not include(deactivated_user.email)
       end
     end
 
@@ -38,6 +41,49 @@ RSpec.describe "Users", type: :request do
     context "when no user is signed in" do
       it "redirects the user to the sign in page" do
         get "/bo/users"
+
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  describe "/bo/users/all" do
+    context "when a super user is signed in" do
+      let(:user) { create(:user, :agency_super) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      it "renders the index template, returns a 200 response and includes the correct content" do
+        active_user = create(:user, email: "aaaaaaaaaaa@example.com")
+        deactivated_user = create(:user, email: "aaaaaaaaaaa2@example.com", active: false)
+
+        get "/bo/users/all"
+
+        expect(response).to render_template(:index)
+        expect(response).to have_http_status(200)
+        expect(response.body).to include("Show enabled users only")
+        expect(response.body).to include(active_user.email)
+        expect(response.body).to include(deactivated_user.email)
+      end
+    end
+
+    context "when a non-super user is signed in" do
+      let(:user) { create(:user, :agency) }
+      before(:each) do
+        sign_in(user)
+      end
+
+      it "redirects to the permissions error page" do
+        get "/bo/users/all"
+
+        expect(response).to redirect_to("/bo/pages/permission")
+      end
+    end
+
+    context "when no user is signed in" do
+      it "redirects the user to the sign in page" do
+        get "/bo/users/all"
 
         expect(response).to redirect_to(new_user_session_path)
       end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1662

This makes several changes to make the back office user management page more, well, manageable:

- list 100 users per page so the in-browser find feature can be used to search if needed
- only list active and invited users by default
- add a toggle to list deactivated users as well