### PR TITLE
Delete expired, ceased, revoked registrations after 7 years

### DIFF
--- a/app/presenters/base_registration_presenter.rb
+++ b/app/presenters/base_registration_presenter.rb
@@ -95,6 +95,10 @@ class BaseRegistrationPresenter < WasteCarriersEngine::BasePresenter
            reg_identifier: reg_identifier)
   end
 
+  def display_last_modifed
+    metaData.last_modified.to_datetime
+  end
+
   private
 
   def displayable_tier

--- a/app/services/remove_deletable_registrations_service.rb
+++ b/app/services/remove_deletable_registrations_service.rb
@@ -2,20 +2,16 @@
 
 class RemoveDeletableRegistrationsService < ::WasteCarriersEngine::BaseService
   def run
-    log "========================"
-    remove_registrations_expired_seven_years_ago
-    log "========================"
+    remove_deletable_registrations
   end
 
   private
 
-  # Registrations are expired when the `expires_on` date is reached
-  # Here we assume that the expiration happened on that date
-  def remove_registrations_expired_seven_years_ago
-    log "Starting removal of registrations expired < 7 years ago"
+  def remove_deletable_registrations
+    log "Starting removal of registrations last modified at least 7 years ago"
     counter = 0
 
-    registrations_expired_seven_years_ago.each do |registration|
+    deletable_registrations.each do |registration|
       remove_registration(registration)
       counter += 1
     end
@@ -23,10 +19,10 @@ class RemoveDeletableRegistrationsService < ::WasteCarriersEngine::BaseService
     log "Removed #{counter} registration(s)"
   end
 
-  def registrations_expired_seven_years_ago
+  def deletable_registrations
     WasteCarriersEngine::Registration
-      .where("metaData.status" => "EXPIRED")
-      .where(:expires_on.lte => 7.years.ago.end_of_day)
+      .where("metaData.status" => { '$in': %w[EXPIRED INACTIVE REVOKED] })
+      .where("metaData.lastModified" => { :$lte => 7.years.ago.end_of_day })
   end
 
   def remove_registration(registration)

--- a/app/services/remove_deletable_registrations_service.rb
+++ b/app/services/remove_deletable_registrations_service.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+class RemoveDeletableRegistrationsService < ::WasteCarriersEngine::BaseService
+  def run
+    log "========================"
+    remove_registrations_expired_seven_years_ago
+    log "========================"
+  end
+
+  private
+
+  # Registrations are expired when the `expires_on` date is reached
+  # Here we assume that the expiration happened on that date
+  def remove_registrations_expired_seven_years_ago
+    log "Starting removal of registrations expired < 7 years ago"
+    counter = 0
+
+    registrations_expired_seven_years_ago.each do |registration|
+      remove_registration(registration)
+      counter += 1
+    end
+
+    log "Removed #{counter} registration(s)"
+  end
+
+  def registrations_expired_seven_years_ago
+    WasteCarriersEngine::Registration
+      .where("metaData.status" => "EXPIRED")
+      .where(:expires_on.lte => 7.years.ago.end_of_day)
+  end
+
+  def remove_registration(registration)
+    registration.destroy
+    log "Removed registration: #{registration.reg_identifier}"
+  end
+
+  def log(msg)
+    # Avoid cluttering up the test logs
+    puts msg unless Rails.env.test?
+  end
+end

--- a/app/views/shared/registrations/_action_links_panel.html.erb
+++ b/app/views/shared/registrations/_action_links_panel.html.erb
@@ -2,6 +2,9 @@
   <h2 class="govuk-heading-m">
     <%= resource.display_action_links_heading %>
   </h2>
+  <div id="registration-last-modified" class="govuk-visually-hidden">
+    <%= resource.display_last_modifed %>
+  </div>
   <ul class="govuk-list govuk-list--spaced">
     <% if display_resume_link_for?(resource) %>
       <li>

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -66,3 +66,9 @@ end
 every :day, at: (ENV["CLEANUP_TRANSIENT_REGISTRATIONS_RUN_TIME"] || "00:35"), roles: [:db] do
   rake "cleanup:transient_registrations"
 end
+
+# This is job that removes all deletable registrations to support our data
+# retention policy
+every :day, at: (ENV["REMOVE_DELETABLE_REGISTRATIONS_RUN_TIME"] || "21:00"), roles: [:db] do
+  rake "remove_deletable_registrations:run"
+end

--- a/lib/tasks/remove_deletable_registrations.rake
+++ b/lib/tasks/remove_deletable_registrations.rake
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+namespace :remove_deletable_registrations do
+  desc "Remove deletable registrations"
+  task run: :environment do
+    RemoveDeletableRegistrationsService.run
+  end
+end

--- a/spec/factories/meta_data.rb
+++ b/spec/factories/meta_data.rb
@@ -15,6 +15,10 @@ FactoryBot.define do
       status { :INACTIVE }
     end
 
+    trait :ceased do
+      status { :INACTIVE }
+    end
+
     trait :expired do
       status { :EXPIRED }
     end
@@ -22,6 +26,10 @@ FactoryBot.define do
     trait :pending do
       date_activated { nil }
       status { :PENDING }
+    end
+
+    trait :revoked do
+      status { :REVOKED }
     end
   end
 end

--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -48,8 +48,16 @@ FactoryBot.define do
       metaData { build(:metaData, :active) }
     end
 
+    trait :ceased do
+      metaData { build(:metaData, :ceased) }
+    end
+
     trait :expired do
       metaData { build(:metaData, :expired) }
+    end
+
+    trait :revoked do
+      metaData { build(:metaData, :revoked) }
     end
 
     trait :has_orders_and_payments do

--- a/spec/schedule_spec.rb
+++ b/spec/schedule_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Whenever schedule" do
 
   it "makes sure 'rake' statements exist" do
     rake_jobs = schedule.jobs[:rake]
-    expect(rake_jobs.count).to eq(8)
+    expect(rake_jobs.count).to eq(9)
   end
 
   it "picks up the EPR export run frequency and time" do
@@ -72,5 +72,12 @@ RSpec.describe "Whenever schedule" do
 
     expect(job_details[:every][0]).to eq(:day)
     expect(job_details[:every][1][:at]).to eq("00:35")
+  end
+
+  it "takes the remove_deletable_registrations execution time from the appropriate ENV variable" do
+    job_details = schedule.jobs[:rake].find { |h| h[:task] == "remove_deletable_registrations:run" }
+
+    expect(job_details[:every][0]).to eq(:day)
+    expect(job_details[:every][1][:at]).to eq("21:00")
   end
 end

--- a/spec/services/remove_deletable_registrations_service_spec.rb
+++ b/spec/services/remove_deletable_registrations_service_spec.rb
@@ -3,21 +3,30 @@
 require "rails_helper"
 
 RSpec.describe RemoveDeletableRegistrationsService do
-  let!(:expired_8_years_ago) { create(:registration, :expired, expires_on: 8.years.ago) }
-  let!(:expired_7_years_ago) { create(:registration, :expired, expires_on: 7.years.ago) }
-  let!(:expired_6_years_ago) { create(:registration, :expired, expires_on: 6.years.ago) }
-  let!(:not_expired) { create(:registration) }
+  let!(:ceased_8_years_ago) { Timecop.freeze(8.years.ago) { create(:registration, :ceased) } }
+  let!(:expired_8_years_ago) { Timecop.freeze(8.years.ago) { create(:registration, :expired) } }
+  let!(:revoked_8_years_ago) { Timecop.freeze(8.years.ago) { create(:registration, :revoked) } }
+  let!(:ceased) { create(:registration, :ceased) }
+  let!(:expired) { create(:registration, :expired) }
+  let!(:revoked) { create(:registration, :revoked) }
 
   describe ".run" do
-    it "removes the expired registrations" do
+    it "removes registrations expired/revoked/ceased > 7 years ago" do
       expect(WasteCarriersEngine::Registration.all).to eq(
-        [expired_8_years_ago, expired_7_years_ago, expired_6_years_ago, not_expired]
+        [
+          ceased_8_years_ago,
+          expired_8_years_ago,
+          revoked_8_years_ago,
+          ceased,
+          expired,
+          revoked
+        ]
       )
 
       described_class.run
 
       expect(WasteCarriersEngine::Registration.all).to eq(
-        [expired_6_years_ago, not_expired]
+        [ceased, expired, revoked]
       )
     end
   end

--- a/spec/services/remove_deletable_registrations_service_spec.rb
+++ b/spec/services/remove_deletable_registrations_service_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RemoveDeletableRegistrationsService do
+  let!(:expired_8_years_ago) { create(:registration, :expired, expires_on: 8.years.ago) }
+  let!(:expired_7_years_ago) { create(:registration, :expired, expires_on: 7.years.ago) }
+  let!(:expired_6_years_ago) { create(:registration, :expired, expires_on: 6.years.ago) }
+  let!(:not_expired) { create(:registration) }
+
+  describe ".run" do
+    it "removes the expired registrations" do
+      expect(WasteCarriersEngine::Registration.all).to eq(
+        [expired_8_years_ago, expired_7_years_ago, expired_6_years_ago, not_expired]
+      )
+
+      described_class.run
+
+      expect(WasteCarriersEngine::Registration.all).to eq(
+        [expired_6_years_ago, not_expired]
+      )
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1683

We have a requirement to delete old registrations that been ceased, revoked or expired more than seven years ago. 

There are several components to this task:
- [x] An overnight job is scheduled to run this task
- [x] The task removes all registrations from the database which expired more than 7 years ago
- [x] Removes all registration from the database which ceased or revoked more than 7 years ago
- [x]  Support testing with some [registrations that can be deleted ](https://github.com/DEFRA/waste-carriers-front-office/pull/745) to support testing
- [x] This [job can be run through Jenkins](https://wcr-jenkins.aws-int.defra.cloud/job/DEV_77_RUN_REMOVE_DELETABLE_REGISTRATIONS_JOB/) on non-prod environments for test purposes
- [x] Update the relevant documentation: https://github.com/DEFRA/ruby-services-team/blob/main/services/wcr/background_jobs.md
