### PR TITLE
Avoid pinning the Loofah gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,10 +40,6 @@ gem "govuk_design_system_formbuilder"
 gem "kaminari", "~> 1.1"
 gem "kaminari-mongoid", "~> 1.0"
 
-# Dependabot keeps trying to bump loofah for a version 2.13, which has
-# a security vulnerability: CVE-2018-8048
-gem "loofah", "~> 2.2"
-
 # Use Whenever to manage cron tasks
 gem "whenever", "~> 1.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -510,7 +510,6 @@ DEPENDENCIES
   jquery-rails
   kaminari (~> 1.1)
   kaminari-mongoid (~> 1.0)
-  loofah (~> 2.2)
   mongoid (~> 7.3)
   passenger (~> 5.0, >= 5.0.30)
   pry-byebug


### PR DESCRIPTION
- Dependabot has been trying to upgrade loofah to a version with secrurity
vulnerabilities.

- Pinning the gem version in the Gemfile is *not* the best way to tackle this,
instead we can suppress the Dependabot PR