### PR TITLE
Page title matches H1 

### DIFF
--- a/spec/requests/routes_spec.rb
+++ b/spec/requests/routes_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe "Root", type: :request do
         get "/bo/#{registration.reg_identifier}/renew"
 
         expect(response).to have_http_status(200)
-        expect(response.body).to include("You are about to renew your registration")
+        expect(response.body).to match(/You are about to renew registration CBDU\d+/)
       end
     end
 


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/projects/RUBY/boards/374?selectedIssue=RUBY-1723

Updated one back office test that was failing due to the title changes in the engine. 

The test that has been updated is Root GET /fo/renew/[registration number] when the user is signed in returns a 200 response and loads the renewal start page
