### PR TITLE
Display a registration's metaData

### DIFF
--- a/app/views/registrations/show.html.erb
+++ b/app/views/registrations/show.html.erb
@@ -57,11 +57,34 @@
         <% if display_ways_to_share_magic_link_for?(@registration) %>
           <%= render "shared/registrations/renewal_magic_link_panel", resource: @registration %>
         <% end %>
+
+        <details class="govuk-details" data-module="govuk-details">
+          <summary class="govuk-details__summary">
+            <span class="govuk-details__summary-text">
+              <%= t(".meta_data") %>
+            </span>
+          </summary>
+          <div class="govuk-details__text">
+            <dl class="govuk-summary-list">
+              <% @registration.metaData.attributes.each do |key, value| %>
+                <div class="govuk-summary-list__row">
+                  <dt class="govuk-summary-list__key">
+                    <%= key %>
+                  </dt>
+                  <dd class="govuk-summary-list__value">
+                    <%= value %>
+                  </dd>
+                </div>
+              <% end %>
+            </dl>
+          </div>
+        </details>
       </div>
 
       <div class="govuk-grid-column-one-third">
         <%= render "shared/registrations/action_links_panel", resource: @registration %>
       </div>
+
     </div>
   </div>
 </div>

--- a/config/locales/registrations.en.yml
+++ b/config/locales/registrations.en.yml
@@ -34,6 +34,7 @@ en:
         heading: "Registration cards (copy cards)"
         labels:
           temp_cards: "Number of cards ordered"
+      meta_data: "Meta data"
       attributes:
         declaration:
           "1": "Yes"


### PR DESCRIPTION
An adhoc requirement that enables NCCC users to view the metaData for a registration.

https://eaflood.atlassian.net/browse/RUBY-1766