### PR TITLE
Create bespoke user type to upload conviction data

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -21,6 +21,7 @@ class Ability
     permissions_for_agency_user_with_refund if agency_user_with_refund?(user)
     permissions_for_agency_super_user if agency_super_user?(user)
     permissions_for_developer_user if developer?(user)
+    permissions_for_import_conviction_data_user if import_conviction_data?(user)
   end
 
   def assign_finance_user_permissions(user)
@@ -122,6 +123,12 @@ class Ability
     can :import_conviction_data, :all
   end
 
+  def permissions_for_import_conviction_data_user
+    permissions_for_agency_user
+
+    can :import_conviction_data, :all
+  end
+
   # Checks to see if role matches
 
   def agency_user?(user)
@@ -150,6 +157,10 @@ class Ability
 
   def developer?(user)
     user.role == "developer"
+  end
+
+  def import_conviction_data?(user)
+    user.role == "import_conviction_data"
   end
 
   def write_off_agency_user_cap

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,6 +42,7 @@ class User
   # Roles
 
   AGENCY_ROLES = %w[agency
+                    import_conviction_data
                     agency_with_refund
                     agency_super
                     developer].freeze

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -52,6 +52,7 @@ en:
           agency_super: "Agency super user"
           finance_super: "Finance super user"
           developer: "Developer"
+          import_conviction_data: "Agency user who can import conviction data"
 
   # Kaminari overrides
   helpers:

--- a/config/locales/user_roles.en.yml
+++ b/config/locales/user_roles.en.yml
@@ -11,4 +11,5 @@ en:
         agency_super: "%{email} is currently an agency super user."
         finance_super: "%{email} is currently a finance super user."
         developer: "%{email} is currently a developer."
+        import_conviction_data: "%{email} is currently an agency user who can import conviction data."
       submit_button: "Change role"

--- a/config/locales/users.en.yml
+++ b/config/locales/users.en.yml
@@ -21,6 +21,7 @@ en:
           agency_super: "agency super"
           finance_super: "finance super"
           developer: "developer"
+          import_conviction_data: "agency user who can import conviction data"
         statuses:
           active: "active"
           deactivated: "deactivated"

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -41,5 +41,9 @@ FactoryBot.define do
     trait :developer do
       role { "developer" }
     end
+
+    trait :import_conviction_data do
+      role { "import_conviction_data" }
+    end
   end
 end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Ability, type: :model do
     include_examples "agency examples"
 
     include_examples "non-developer examples"
+    include_examples "non-import_conviction_data examples"
 
     include_examples "active and inactive examples"
   end
@@ -32,6 +33,7 @@ RSpec.describe Ability, type: :model do
     include_examples "agency examples"
 
     include_examples "non-developer examples"
+    include_examples "non-import_conviction_data examples"
 
     include_examples "active and inactive examples"
   end
@@ -44,6 +46,7 @@ RSpec.describe Ability, type: :model do
     include_examples "agency examples"
 
     include_examples "non-developer examples"
+    include_examples "non-import_conviction_data examples"
 
     include_examples "active and inactive examples"
   end
@@ -56,6 +59,20 @@ RSpec.describe Ability, type: :model do
     include_examples "agency examples"
 
     include_examples "developer examples"
+    include_examples "import_conviction_data examples"
+
+    include_examples "active and inactive examples"
+  end
+
+  context "when the user role is import_conviction_data" do
+    let(:role) { "import_conviction_data" }
+
+    include_examples "below agency_super examples"
+    include_examples "below agency_with_refund examples"
+    include_examples "agency examples"
+
+    include_examples "non-developer examples"
+    include_examples "import_conviction_data examples"
 
     include_examples "active and inactive examples"
   end
@@ -69,6 +86,7 @@ RSpec.describe Ability, type: :model do
     include_examples "finance_admin examples"
 
     include_examples "non-developer examples"
+    include_examples "non-import_conviction_data examples"
 
     include_examples "active and inactive examples"
   end
@@ -80,6 +98,7 @@ RSpec.describe Ability, type: :model do
     include_examples "finance_admin examples"
 
     include_examples "non-developer examples"
+    include_examples "non-import_conviction_data examples"
 
     include_examples "active and inactive examples"
   end
@@ -90,6 +109,7 @@ RSpec.describe Ability, type: :model do
     include_examples "finance examples"
 
     include_examples "non-developer examples"
+    include_examples "non-import_conviction_data examples"
 
     include_examples "active and inactive examples"
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -142,6 +142,14 @@ RSpec.describe User, type: :model do
       end
     end
 
+    context "when the role is import_conviction_data" do
+      let(:user) { build(:user, :import_conviction_data) }
+
+      it "is true" do
+        expect(user.in_agency_group?).to eq(true)
+      end
+    end
+
     context "when the role is finance" do
       let(:user) { build(:user, :finance) }
 

--- a/spec/support/shared_examples/abilities/developer_examples.rb
+++ b/spec/support/shared_examples/abilities/developer_examples.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples "developer examples" do
-  it "should be able to import conviction data" do
-    should be_able_to(:import_conviction_data, :all)
-  end
-
   it "should be able to toggle features" do
     should be_able_to(:manage, WasteCarriersEngine::FeatureToggle)
   end

--- a/spec/support/shared_examples/abilities/import_conviction_data_examples.rb
+++ b/spec/support/shared_examples/abilities/import_conviction_data_examples.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "import_conviction_data examples" do
+  it "should be able to import conviction data" do
+    should be_able_to(:import_conviction_data, :all)
+  end
+end

--- a/spec/support/shared_examples/abilities/non_developer_examples.rb
+++ b/spec/support/shared_examples/abilities/non_developer_examples.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples "non-developer examples" do
-  it "should not be able to import conviction data" do
-    should_not be_able_to(:import_conviction_data, :all)
-  end
-
   it "should not be able to toggle features" do
     should_not be_able_to(:manage, WasteCarriersEngine::FeatureToggle)
   end

--- a/spec/support/shared_examples/abilities/non_import_conviction_data_examples.rb
+++ b/spec/support/shared_examples/abilities/non_import_conviction_data_examples.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "non-import_conviction_data examples" do
+  it "should not be able to import conviction data" do
+    should_not be_able_to(:import_conviction_data, :all)
+  end
+end


### PR DESCRIPTION
Here we create a new user role in the back office called import_conviction_data.
This user can perform agency actions and import conviction data.

https://eaflood.atlassian.net/browse/RUBY-1756