### PR TITLE
Feature/card order export registration number

### DIFF
--- a/app/presenters/card_orders_export_presenter.rb
+++ b/app/presenters/card_orders_export_presenter.rb
@@ -23,7 +23,7 @@ class CardOrdersExportPresenter < WasteCarriersEngine::BasePresenter
   end
 
   def reg_identifier
-    @order_item_log.registration_id
+    @registration.reg_identifier
   end
 
   def date_of_issue

--- a/app/presenters/card_orders_export_presenter.rb
+++ b/app/presenters/card_orders_export_presenter.rb
@@ -10,11 +10,13 @@ class CardOrdersExportPresenter < WasteCarriersEngine::BasePresenter
     # so prepare them once for lookup on initialiation
     @registered_address = present_address(
       @registration.addresses.select { |a| a.addressType == "REGISTERED" }[0],
-      "registered"
+      "registered",
+      @registration.company_name
     )
     @contact_address = present_address(
       @registration.addresses.select { |a| a.addressType == "POSTAL" }[0],
-      "contact"
+      "contact",
+      @registration.company_name
     )
 
     super(model)
@@ -74,17 +76,17 @@ class CardOrdersExportPresenter < WasteCarriersEngine::BasePresenter
   end
 
   # Map an address from WCR database form to the presentation form.
-  def present_address(address, prefix)
+  def present_address(address, prefix, company_name)
     return "" unless address
 
     # These fields if present are to map to lines 1-5 in the output,
     # with any blanks between lines removed.
     address_values = [address.houseNumber,
-                      address.addressLine1,
+                      # Skip address line 1 if it matches the carrier name.
+                      address.addressLine1 == company_name ? "" : address.addressLine1,
                       address.addressLine2,
                       address.addressLine3,
                       address.addressLine4].reject(&:blank?)
-
     address_hash = {}
 
     address_values.each_with_index do |value, index|

--- a/app/presenters/card_orders_export_presenter.rb
+++ b/app/presenters/card_orders_export_presenter.rb
@@ -2,6 +2,8 @@
 
 class CardOrdersExportPresenter < WasteCarriersEngine::BasePresenter
 
+  DATE_FORMAT = "%-m/%-d/%y"
+
   def initialize(model)
     @order_item_log = model
     @registration = WasteCarriersEngine::Registration.find(model.registration_id)
@@ -27,7 +29,7 @@ class CardOrdersExportPresenter < WasteCarriersEngine::BasePresenter
   end
 
   def date_of_issue
-    @order_item_log.activated_at.strftime("%-m/%-d/%y")
+    @order_item_log.activated_at.strftime(DATE_FORMAT)
   end
 
   def carrier_name
@@ -55,11 +57,11 @@ class CardOrdersExportPresenter < WasteCarriersEngine::BasePresenter
   end
 
   def registration_date
-    @registration.metaData.dateRegistered.present? ? @registration.metaData.dateRegistered.strftime("%-m/%-d/%y") : ""
+    @registration.metaData.dateRegistered.present? ? @registration.metaData.dateRegistered.strftime(DATE_FORMAT) : ""
   end
 
   def expires_on
-    @registration.expires_on.present? ? @registration.expires_on.strftime("%-m/%-d/%y") : ""
+    @registration.expires_on.present? ? @registration.expires_on.strftime(DATE_FORMAT) : ""
   end
 
   def contact_phone_number

--- a/app/presenters/card_orders_export_presenter.rb
+++ b/app/presenters/card_orders_export_presenter.rb
@@ -27,7 +27,7 @@ class CardOrdersExportPresenter < WasteCarriersEngine::BasePresenter
   end
 
   def date_of_issue
-    @order_item_log.activated_at
+    @order_item_log.activated_at.strftime("%-m/%-d/%y")
   end
 
   def carrier_name
@@ -55,11 +55,11 @@ class CardOrdersExportPresenter < WasteCarriersEngine::BasePresenter
   end
 
   def registration_date
-    @registration.metaData.dateRegistered
+    @registration.metaData.dateRegistered.present? ? @registration.metaData.dateRegistered.strftime("%-m/%-d/%y") : ""
   end
 
   def expires_on
-    @registration.expires_on
+    @registration.expires_on.present? ? @registration.expires_on.strftime("%-m/%-d/%y") : ""
   end
 
   def contact_phone_number

--- a/spec/models/reports/card_orders_export_serializer_spec.rb
+++ b/spec/models/reports/card_orders_export_serializer_spec.rb
@@ -50,8 +50,8 @@ module Reports
       end
 
       it "includes one row per item ordered for the previously un-exported items" do
-        expect(subject.scan(order_item_log_1.registration_id).size).to eq 2
-        expect(subject.scan(order_item_log_2.registration_id).size).to eq 5
+        expect(subject.scan(registration_1.reg_identifier).size).to eq 2
+        expect(subject.scan(registration_2.reg_identifier).size).to eq 5
       end
 
       it "excludes non-copy-card order items" do

--- a/spec/presenters/reports/card_orders_export_presenter_spec.rb
+++ b/spec/presenters/reports/card_orders_export_presenter_spec.rb
@@ -53,8 +53,8 @@ module Reports
     before { registration.addresses = addresses }
 
     describe "#reg_identifier" do
-      it "returns the registration id" do
-        expect(subject.reg_identifier).to eq order_item_log.registration_id
+      it "returns the registration identifier" do
+        expect(subject.reg_identifier).to eq registration.reg_identifier
       end
     end
 

--- a/spec/presenters/reports/card_orders_export_presenter_spec.rb
+++ b/spec/presenters/reports/card_orders_export_presenter_spec.rb
@@ -46,7 +46,13 @@ module Reports
 
     let(:business_type) { "limitedCompany" }
     let(:company_name) { Faker::Company.name }
-    let(:registration) { create(:registration, :has_orders_and_payments, business_type: business_type, company_name: company_name) }
+    let(:registration) do
+      create(:registration,
+             :has_orders_and_payments,
+             business_type: business_type,
+             company_name: company_name,
+             expires_on: DateTime.now.next_year(3))
+    end
     let(:order) { registration.finance_details.orders[0] }
     let(:order_item_log) { create(:order_item_log, registration_id: registration.id, order_id: order.id) }
 
@@ -60,7 +66,7 @@ module Reports
 
     describe "#date_of_issue" do
       it "returns the date of the registration activation which activated the card order" do
-        expect(subject.date_of_issue).to eq order_item_log.activated_at
+        expect(subject.date_of_issue).to eq order_item_log.activated_at.strftime("%-m/%-d/%y")
       end
     end
 
@@ -96,8 +102,8 @@ module Reports
       it "returns the relevant registration attributes" do
         expect(subject.company_name).to eq registration.company_name
         expect(subject.registration_type).to eq registration.registration_type
-        expect(subject.registration_date.to_i).to eq registration.metaData.dateRegistered.to_i
-        expect(subject.expires_on).to eq registration.expires_on
+        expect(subject.registration_date).to eq registration.metaData.dateRegistered.strftime("%-m/%-d/%y")
+        expect(subject.expires_on).to eq registration.expires_on.strftime("%-m/%-d/%y")
         expect(subject.contact_phone_number).to eq registration.phone_number
       end
     end


### PR DESCRIPTION
This change resolves three issues with the content of the cards export CSV file:
1. If address line 1 in the database matches the business name, that address line should be skipped to avoid duplication of the business name on the card.
2. The value in the Registration Number column should be the registration identifier, not the registration (database) ID.
3. Dates should be presented in dd/mm/yy format, without the time element. (Note that the date format is to be confirmed with the stakeholders and may need to be updated).