### PR TITLE
Feature/card orders page format

### DIFF
--- a/app/views/card_order_exports/index.html.erb
+++ b/app/views/card_order_exports/index.html.erb
@@ -15,7 +15,6 @@
   <div class="govuk-grid-column-three-quarters">
 
     <table class="govuk-table" aria-label="<%= t(".heading") %>" >
-      <caption class="govuk-table__caption"><%= t(".caption") %></caption>
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
           <th class="govuk-table__header" scope="col"><%= t(".file_name") %></th>

--- a/config/locales/card_order_exports.en.yml
+++ b/config/locales/card_order_exports.en.yml
@@ -2,8 +2,7 @@ en:
   card_order_exports:
     index:
       title: "Card order export history"
-      heading: "Copy Card Orders Weekly Exports"
-      caption: "Copy Card Orders Weekly Exports"
+      heading: "Copy card orders weekly exports"
       file_name: "Export File"
       exported_at: "Exported"
       first_downloaded_by: "Downloaded By"


### PR DESCRIPTION
This change adjusts the format of the copy card order export page:
- Uses sentence-case for the page title
- Drops the table caption