### PR TITLE
Feature/card order nil quantity

### DIFF
--- a/app/models/reports/card_orders_export_serializer.rb
+++ b/app/models/reports/card_orders_export_serializer.rb
@@ -49,7 +49,7 @@ module Reports
       )
 
       # Expand the results to one row per card
-      @order_item_logs.map { |oil| Array.new(oil.quantity, oil) }.flatten
+      @order_item_logs.map { |oil| Array.new(oil.quantity || 0, oil) }.flatten
     end
 
     def parse_object(order_item_log)

--- a/spec/models/reports/card_orders_export_serializer_spec.rb
+++ b/spec/models/reports/card_orders_export_serializer_spec.rb
@@ -9,7 +9,7 @@ module Reports
     let(:registration_2) { create(:registration) }
 
     let!(:order_item_log_1) do
-      create(:order_item_log, 
+      create(:order_item_log,
              type: "COPY_CARDS",
              registration_id: registration_1.id,
              quantity: 2,
@@ -66,7 +66,7 @@ module Reports
           expect(subject.scan(registration_1.reg_identifier).size).to eq 2
           expect(subject.scan(registration_2.reg_identifier).size).to eq 5
         end
-  
+
         # This is to ensure the export includes previously exported
         # items if run manually in addition to at the scheduled time.
         it "includes the same list of order items when run multiple times" do
@@ -77,7 +77,7 @@ module Reports
           expect(export2.scan(registration_1.reg_identifier).size).to eq 2
           expect(export2.scan(registration_2.reg_identifier).size).to eq 5
         end
-  
+
         it "excludes non-copy-card order items" do
           order_item_log_2.type = "NEW"
           order_item_log_2.save!
@@ -113,7 +113,7 @@ module Reports
         it "excludes order items for the earlier registration" do
           expect(subject).not_to include(registration.reg_identifier)
         end
-     end
+      end
 
       context "with no eligible order item logs" do
         before { WasteCarriersEngine::OrderItemLog.delete_all }
@@ -125,7 +125,7 @@ module Reports
 
       context "with a nil quantity card order item" do
         let!(:order_item_log_1) do
-          create(:order_item_log, 
+          create(:order_item_log,
                  type: "COPY_CARDS",
                  registration_id: registration_1.id,
                  quantity: nil,

--- a/spec/models/reports/card_orders_export_serializer_spec.rb
+++ b/spec/models/reports/card_orders_export_serializer_spec.rb
@@ -5,10 +5,23 @@ require "rails_helper"
 module Reports
   RSpec.describe CardOrdersExportSerializer do
 
-    let(:registration_1) { create(:registration, :has_orders_and_payments) }
-    let(:registration_2) { create(:registration, :has_orders_and_payments) }
-    let!(:order_item_log_1) { create(:order_item_log, type: "COPY_CARDS", registration_id: registration_1.id, quantity: 2) }
-    let!(:order_item_log_2) { create(:order_item_log, type: "COPY_CARDS", registration_id: registration_2.id, quantity: 5) }
+    let(:registration_1) { create(:registration) }
+    let(:registration_2) { create(:registration) }
+
+    let!(:order_item_log_1) do
+      create(:order_item_log, 
+             type: "COPY_CARDS",
+             registration_id: registration_1.id,
+             quantity: 2,
+             activated_at: start_time + 1.second)
+    end
+    let!(:order_item_log_2) do
+      create(:order_item_log,
+             type: "COPY_CARDS",
+             registration_id: registration_2.id,
+             quantity: 5,
+             activated_at: end_time - 1.second)
+    end
 
     let(:end_time) { DateTime.now + 3.days }
     let(:start_time) { end_time - 1.week }
@@ -47,42 +60,60 @@ module Reports
         expect(subject).to include(expected_columns.map { |title| "\"#{title}\"" }.join(","))
       end
 
-      it "includes one row per item ordered" do
-        expect(subject.scan(registration_1.reg_identifier).size).to eq 2
-        expect(subject.scan(registration_2.reg_identifier).size).to eq 5
-      end
+      context "with all registrations activated within the report window" do
 
-      # This is to ensure the export includes previously exported
-      # items if run manually in addition to at the scheduled time.
-      it "includes the same ist of order items when run multiple times" do
-        serializer = described_class.new(start_time, end_time)
-        serializer.to_csv
-        serializer.mark_exported
-        export2 = described_class.new(start_time, end_time).to_csv
-        expect(export2.scan(registration_1.reg_identifier).size).to eq 2
-        expect(export2.scan(registration_2.reg_identifier).size).to eq 5
-      end
-
-      it "excludes non-copy-card order items" do
-        order_item_log_2.type = "NEW"
-        order_item_log_2.save!
-        expect(subject).not_to include(order_item_log_2.registration_id)
-      end
-
-      it "excludes previously exported items" do
-        order_item_log_1.exported = true
-        order_item_log_1.save!
-        expect(subject).not_to include(order_item_log_1.registration_id)
-      end
-
-      context "with a registration activated outside the report window" do
-        let(:late_registration) { create(:registration, :has_orders_and_payments) }
-        let!(:late_order_item_log) { create(:order_item_log, type: "COPY_CARD", registration_id: late_registration.id, quantity: 2, activated_at: end_time + 1.hour) }
-
-        it "excludes orders outside the report date range" do
-          expect(subject).not_to include(late_registration.id)
+        it "includes one row per item ordered" do
+          expect(subject.scan(registration_1.reg_identifier).size).to eq 2
+          expect(subject.scan(registration_2.reg_identifier).size).to eq 5
+        end
+  
+        # This is to ensure the export includes previously exported
+        # items if run manually in addition to at the scheduled time.
+        it "includes the same list of order items when run multiple times" do
+          serializer = described_class.new(start_time, end_time)
+          serializer.to_csv
+          serializer.mark_exported
+          export2 = described_class.new(start_time, end_time).to_csv
+          expect(export2.scan(registration_1.reg_identifier).size).to eq 2
+          expect(export2.scan(registration_2.reg_identifier).size).to eq 5
+        end
+  
+        it "excludes non-copy-card order items" do
+          order_item_log_2.type = "NEW"
+          order_item_log_2.save!
+          expect(subject).not_to include(order_item_log_2.registration_id)
         end
       end
+
+      context "with a registration activated after the report window" do
+        let(:registration) { create(:registration) }
+        let!(:order_item_log) do
+          create(:order_item_log,
+                 type: "COPY_CARD",
+                 registration_id: registration.id,
+                 quantity: 2,
+                 activated_at: end_time + 1.hour)
+        end
+
+        it "excludes the late order items" do
+          expect(subject).not_to include(registration.reg_identifier)
+        end
+      end
+
+      context "with a registration activated before the report window" do
+        let(:registration) { create(:registration) }
+        let!(:order_item_log) do
+          create(:order_item_log,
+                 type: "COPY_CARD",
+                 registration_id: registration.id,
+                 quantity: 2,
+                 activated_at: start_time - 1.hour)
+        end
+
+        it "excludes order items for the earlier registration" do
+          expect(subject).not_to include(registration.reg_identifier)
+        end
+     end
 
       context "with no eligible order item logs" do
         before { WasteCarriersEngine::OrderItemLog.delete_all }
@@ -91,12 +122,26 @@ module Reports
           expect(subject).to include(expected_columns.map { |title| "\"#{title}\"" }.join(","))
         end
       end
+
+      context "with a nil quantity card order item" do
+        let!(:order_item_log_1) do
+          create(:order_item_log, 
+                 type: "COPY_CARDS",
+                 registration_id: registration_1.id,
+                 quantity: nil,
+                 activated_at: start_time + 1.second)
+        end
+
+        it "excludes the order item without raising an error" do
+          expect(subject).not_to include(registration_1.reg_identifier)
+        end
+      end
     end
 
     describe "#mark_exported" do
       serializer = nil
 
-      context "with an existing serialiazer which has created a CSV export" do
+      context "with an existing serializer which has created a CSV export" do
         before do
           serializer = described_class.new(start_time, end_time)
           serializer.to_csv


### PR DESCRIPTION
This change handles order_items with a quantity attribute of nil by treating it as a a quantity of zero, preventing "no implicit conversion from nil to integer" errors.