### PR TITLE
Copy card fix telephone number issue

### DIFF
--- a/app/presenters/reports/card_order_presenter.rb
+++ b/app/presenters/reports/card_order_presenter.rb
@@ -66,7 +66,7 @@ module Reports
     end
 
     def contact_phone_number
-      @registration.phone_number
+      "=\"#{@registration.phone_number}\""
     end
 
     # Define address-level fields dynamically

--- a/spec/presenters/reports/card_order_presenter_spec.rb
+++ b/spec/presenters/reports/card_order_presenter_spec.rb
@@ -106,7 +106,7 @@ module Reports
         expect(subject.registration_type).to eq registration.registration_type
         expect(subject.registration_date).to eq registration.metaData.dateRegistered.strftime(export_date_format)
         expect(subject.expires_on).to eq registration.expires_on.strftime(export_date_format)
-        expect(subject.contact_phone_number).to eq registration.phone_number
+        expect(subject.contact_phone_number).to eq "=\"#{registration.phone_number}\""
       end
     end
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1802

NCCC have reported an issue with phone numbers whereby Excel formats
them as numbers and removes leading zeros.

Here we format the Contact Phone Number so that Excel will import it as a string:
```
"=""01234 567890"""
```