### PR TITLE
Copy cards - remove duplicate business name from house number

### DIFF
--- a/app/presenters/reports/card_order_presenter.rb
+++ b/app/presenters/reports/card_order_presenter.rb
@@ -84,12 +84,7 @@ module Reports
 
       # These fields if present are to map to lines 1-5 in the output,
       # with any blanks between lines removed.
-      address_values = [address.houseNumber,
-                        # Skip address line 1 if it matches the carrier name.
-                        address.addressLine1 == company_name ? "" : address.addressLine1,
-                        address.addressLine2,
-                        address.addressLine3,
-                        address.addressLine4].reject(&:blank?)
+      address_values = parse_address(address, company_name)
       address_hash = {}
 
       address_values.each_with_index do |value, index|
@@ -108,6 +103,17 @@ module Reports
       )
 
       address_hash
+    end
+
+    def parse_address(address, company_name)
+      [
+        # Skip house number and address line 1 if they match the company name.
+        address.houseNumber.downcase == company_name.downcase ? "" : address.houseNumber,
+        address.addressLine1.downcase == company_name.downcase ? "" : address.addressLine1,
+        address.addressLine2,
+        address.addressLine3,
+        address.addressLine4
+      ].reject(&:blank?)
     end
   end
 end

--- a/spec/presenters/reports/card_order_presenter_spec.rb
+++ b/spec/presenters/reports/card_order_presenter_spec.rb
@@ -8,14 +8,15 @@ module Reports
 
     export_date_format = "%d/%m/%Y"
 
-    # Allow this to be overridden to test company name on line 1
+    # Allow these to be overridden to test company name on house number and address line 1
     let(:reg_address_line_1) { Faker::Address.street_name }
+    let(:reg_house_number) { "" }
 
     # Use different address structures for registered and contact addresses
     # to test handling of blank fields.
     let(:registered_address) do
       {
-        house_number: "",
+        house_number: reg_house_number,
         address_line_1: reg_address_line_1,
         address_line_2: Faker::Address.secondary_address,
         address_line_3: nil,
@@ -140,15 +141,45 @@ module Reports
       end
     end
 
-    context "with company name in address line 1" do
-      let(:reg_address_line_1) { company_name }
+    context "checking for company name in the address fields" do
+      let(:registered_addr) { registration.addresses.select { |a| a.addressType == "REGISTERED" }[0] }
 
-      it "does not present the company name in address line 1" do
-        registered_addr = registration.addresses.select { |a| a.addressType == "REGISTERED" }[0]
-        expect(subject.registered_address_line_1).not_to eq registered_addr.address_line_1
-        expect(subject.registered_address_line_1).to eq registered_addr.address_line_2
+      context "with company name in address line 1" do
+        context "and the company name is a case sensitive match" do
+          let(:reg_address_line_1) { company_name }
+
+          it "does not present the company name in the subject's address line 1" do
+            expect(subject.registered_address_line_1).not_to eq registered_addr.address_line_1
+            expect(subject.registered_address_line_1).to eq registered_addr.address_line_2
+          end
+        end
+
+        context "and the company_name is in a different case" do
+          let(:reg_address_line_1) { company_name.upcase }
+
+          it "still does not present the company name in the subject's address line 1" do
+            expect(subject.registered_address_line_1).not_to eq registered_addr.address_line_1
+          end
+        end
       end
 
+      context "with company name in house number" do
+        context "and the company name is a case sensitive match" do
+          let(:reg_house_number) { company_name }
+
+          it "does not present the company name in the subject's address line 1" do
+            expect(subject.registered_address_line_1).not_to eq registered_addr.house_number
+          end
+        end
+
+        context "and the company_name is in a different case" do
+          let(:reg_house_number) { company_name.upcase }
+
+          it "still does not present the company name in the subject's address line 1" do
+            expect(subject.registered_address_line_1).not_to eq registered_addr.house_number
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1786

If a registration has a company_name duplicated in the house_number
field, we don't want to display it on the copy cards export.

We also want this to be a case insensitive match, and have updated the
existing filter for company_name in address_line_1 to also  be case
insensitive.