### PR TITLE
Check registration for active status during copy card export

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: 9086e6250cac371536295ec973ca8379af54d833
+  revision: b7566f0311bbe4840b561bbc0c0bdf85bb32416b
   branch: main
   specs:
     waste_carriers_engine (0.0.1)

--- a/app/models/reports/card_orders_export_serializer.rb
+++ b/app/models/reports/card_orders_export_serializer.rb
@@ -43,13 +43,16 @@ module Reports
     private
 
     def scope
-      @order_item_logs = WasteCarriersEngine::OrderItemLog.where(
-        type: "COPY_CARDS",
-        activated_at: { "$gte": @start_time, "$lt": @end_time }
-      )
+      @order_item_logs =
+        WasteCarriersEngine::OrderItemLog.includes(:registration).where(
+          type: "COPY_CARDS",
+          activated_at: { "$gte": @start_time, "$lt": @end_time }
+        )
 
-      # Expand the results to one row per card
-      @order_item_logs.map { |oil| Array.new(oil.quantity || 0, oil) }.flatten
+      # Filter for active registrations and expand the results to one row per card
+      @order_item_logs
+        .select(&:active_registration?)
+        .map { |oil| Array.new(oil.quantity || 0, oil) }.flatten
     end
 
     def parse_object(order_item_log)

--- a/spec/models/reports/card_orders_export_serializer_spec.rb
+++ b/spec/models/reports/card_orders_export_serializer_spec.rb
@@ -115,6 +115,21 @@ module Reports
         end
       end
 
+      context "with an expired registration" do
+        let(:registration) { create(:registration, :expired) }
+        let!(:order_item_log) do
+          create(:order_item_log,
+                 type: "COPY_CARD",
+                 registration_id: registration.id,
+                 quantity: 2,
+                 activated_at: start_time + 1.second)
+        end
+
+        it "excludes order items for the expired registration" do
+          expect(subject).not_to include(registration.reg_identifier)
+        end
+      end
+
       context "with no eligible order item logs" do
         before { WasteCarriersEngine::OrderItemLog.delete_all }
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1787

- Here we filter the copy card export for copy_cards with an `active_registration?`
 