### PR TITLE
Refresh registered company name from companies house

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: 5bae77378ee158ce732bf59a6eac4e0e55ebc7a5
+  revision: 7cf5730b2562cf9ffa469abd12c3620d8be837ed
   branch: develop
   specs:
     waste_carriers_engine (0.0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: e52138036db84560eb85f1f6e296fc3ca085759a
+  revision: 5bae77378ee158ce732bf59a6eac4e0e55ebc7a5
   branch: develop
   specs:
     waste_carriers_engine (0.0.1)

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -12,4 +12,11 @@ class RegistrationsController < ApplicationController
 
     @registration = RegistrationPresenter.new(registration, view_context)
   end
+
+  def update_companies_house_details
+    reg_identifier = params[:registration_reg_identifier]
+    WasteCarriersEngine::RefreshCompaniesHouseNameService.run(reg_identifier: reg_identifier)
+
+    redirect_back(fallback_location: registration_path(reg_identifier))
+  end
 end

--- a/app/presenters/base_registration_presenter.rb
+++ b/app/presenters/base_registration_presenter.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class BaseRegistrationPresenter < WasteCarriersEngine::BasePresenter
+  include WasteCarriersEngine::CanPresentEntityDisplayName
+
   def display_company_details_panel?
     company_name.present? ||
       display_tier_and_registration_type.present? ||

--- a/app/views/shared/registrations/_action_links_panel.html.erb
+++ b/app/views/shared/registrations/_action_links_panel.html.erb
@@ -71,5 +71,13 @@
         <%= link_to t(".actions_box.links.cancel"), new_resource_cancel_path(resource._id) %>
       </li>
     <% end %>
+
+    <% if display_edit_link_for?(resource) %>
+      <li>
+        <%= link_to t(".actions_box.links.refresh_companies_house"),
+                      registration_companies_house_details_path(resource.reg_identifier),
+                      method: :patch %>
+      </li>
+    <% end %>
   </ul>
 </div>

--- a/app/views/shared/registrations/_company_details_panel.html.erb
+++ b/app/views/shared/registrations/_company_details_panel.html.erb
@@ -1,7 +1,7 @@
 <% if resource.display_company_details_panel? %>
   <% if resource.company_name.present? %>
     <h2 class="govuk-heading-m">
-      <%= resource.company_name %>
+      <%= resource.entity_display_name %>
     </h2>
   <% end %>
   <% if resource.display_tier_and_registration_type.present? %>

--- a/app/views/shared/registrations/_contact_and_business_details_panels.html.erb
+++ b/app/views/shared/registrations/_contact_and_business_details_panels.html.erb
@@ -32,7 +32,7 @@
     </h2>
     <% if resource.display_business_information_panel? %>
       <p class="govuk-body">
-        <%= resource.company_name %>
+        <%= resource.entity_display_name %>
       </p>
       <% if resource.company_no.present? %>
         <p class="govuk-body">

--- a/config/locales/shared/registrations.en.yml
+++ b/config/locales/shared/registrations.en.yml
@@ -80,6 +80,7 @@ en:
             payment_details: "Payment details"
             process_payment: "Process payment"
             revoke: "Cease or revoke"
+            refresh_companies_house: "Refresh registered company name from Companies House"
       expired_panel:
         heading: "Expired on %{date}"
         links:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -186,6 +186,10 @@ Rails.application.routes.draw do
       to: "convictions#begin_checks",
       as: :registration_convictions_begin_checks
 
+  patch "/bo/registrations/:registration_reg_identifier/companies_house_details",
+        to: "registrations#update_companies_house_details",
+        as: :registration_companies_house_details
+
   get "/bo/transient-registrations/:transient_registration_reg_identifier/convictions/begin-checks",
       to: "convictions#begin_checks",
       as: :transient_registration_convictions_begin_checks

--- a/spec/requests/refresh_companies_house_spec.rb
+++ b/spec/requests/refresh_companies_house_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Refunds", type: :request do
+  describe "PATCH /bo/registrations/:reg_identifier/companies_house_details" do
+
+    subject { patch registration_companies_house_details_path(registration.reg_identifier) }
+
+    RSpec.shared_examples "all companies house details requests" do
+
+      it "redirects to the same page" do
+        subject
+        expect(response.status).to eq 302
+        expect(response.location).to end_with registration_path(registration.reg_identifier)
+      end
+    end
+
+    let(:user) { create(:user) }
+    let(:new_registered_name) { Faker::Company.name }
+    let(:registration) { create(:registration, registered_company_name: old_registered_name) }
+
+    before do
+      sign_in(user)
+      stub_request(:get, "#{Rails.configuration.companies_house_host}#{registration.company_no}").to_return(
+        status: 200,
+        body: { company_name: new_registered_name }.to_json
+      )
+    end
+
+    context "with no previous companies house name" do
+      let(:old_registered_name) { nil }
+
+      it_behaves_like "all companies house details requests"
+    end
+
+    context "with an existing registered company name" do
+      let(:old_registered_name) { Faker::Company.name }
+
+      context "when the new company name is the same as the old one" do
+        let(:new_registered_name) { old_registered_name }
+
+        it_behaves_like "all companies house details requests"
+      end
+
+      context "when the new company name is different to the old one" do
+        it_behaves_like "all companies house details requests"
+      end
+    end
+  end
+end

--- a/spec/requests/registrations_spec.rb
+++ b/spec/requests/registrations_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "RenewingRegistrations", type: :request do
+RSpec.describe "Registrations", type: :request do
   let(:registration) { create(:registration) }
 
   describe "/bo/registrations/:reg_identifier" do


### PR DESCRIPTION
This change uses the new service in waste_carriers_engine to allow a back-office user to refresh the registered company name.
It also displays the registered company name (if defined) as well as the business name on the registration details page.