### PR TITLE
Restrict action for refreshing registered company name

### DIFF
--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -103,6 +103,12 @@ module ActionLinksHelper
     resource.active? && resource.upper_tier?
   end
 
+  def display_refresh_registered_company_name_link_for?(resource)
+    return false unless display_edit_link_for?(resource)
+
+    resource.active? && resource.company_no_required? && resource.upper_tier?
+  end
+
   def display_cancel_link_for?(resource)
     return false unless display_registration_links?(resource)
     return false unless can?(:cancel, WasteCarriersEngine::Registration)

--- a/app/views/shared/registrations/_action_links_panel.html.erb
+++ b/app/views/shared/registrations/_action_links_panel.html.erb
@@ -72,7 +72,7 @@
       </li>
     <% end %>
 
-    <% if display_edit_link_for?(resource) %>
+    <% if display_refresh_registered_company_name_link_for?(resource) %>
       <li>
         <%= link_to t(".actions_box.links.refresh_companies_house"),
                       registration_companies_house_details_path(resource.reg_identifier),

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -649,6 +649,78 @@ RSpec.describe ActionLinksHelper, type: :helper do
     end
   end
 
+  describe "#display_refresh_registered_company_name_link_for?" do
+    let(:resource) { build(:registration) }
+
+    before do
+      allow(helper).to receive(:can?).with(:edit, WasteCarriersEngine::Registration).and_return(can)
+    end
+
+    context "when the user has permission for editing" do
+      let(:can) { true }
+
+      before do
+        allow(resource).to receive(:active?).and_return(active)
+      end
+
+      context "when the resource is active" do
+        let(:active) { true }
+
+        before do
+          allow(resource).to receive(:upper_tier?).and_return(upper_tier)
+        end
+
+        context "when the resource is an upper tier" do
+          let(:upper_tier) { true }
+
+          context "when the resource is a limited company or a limited liability partnership" do
+            before do
+              allow(resource).to receive(:company_no_required?).and_return(true)
+            end
+
+            it "returns true" do
+              expect(helper.display_refresh_registered_company_name_link_for?(resource)).to be_truthy
+            end
+          end
+
+          context "when the resource is neither a limited company nor a limited liability partnership" do
+            before do
+              allow(resource).to receive(:company_no_required?).and_return(false)
+            end
+
+            it "returns false" do
+              expect(helper.display_refresh_registered_company_name_link_for?(resource)).to be_falsey
+            end
+          end
+        end
+
+        context "when the resource is not an upper tier" do
+          let(:upper_tier) { false }
+
+          it "returns false" do
+            expect(helper.display_refresh_registered_company_name_link_for?(resource)).to be_falsey
+          end
+        end
+      end
+
+      context "when the resource is not active" do
+        let(:active) { false }
+
+        it "returns false" do
+          expect(helper.display_refresh_registered_company_name_link_for?(resource)).to be_falsey
+        end
+      end
+    end
+
+    context "when the user does not have permission for editing" do
+      let(:can) { false }
+
+      it "returns false" do
+        expect(helper.display_refresh_registered_company_name_link_for?(resource)).to be_falsey
+      end
+    end
+  end
+
   describe "#display_finance_details_link_for?" do
     let(:resource) { double(:resource) }
     let(:upper_tier) { true }


### PR DESCRIPTION
Restrict the action for refreshing registered company name to apply only to upper tier LTD and LLP entities.
https://eaflood.atlassian.net/browse/RUBY-1780 - additional a/c.