### PR TITLE
Handle nil company name / address line 1 in copy cards export

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: aa664837e236dbb776c55ff65b9cecd6e4193034
+  revision: e56bd0d1fbfd101483459e853b9dc2cd45eb77d2
   branch: main
   specs:
     waste_carriers_engine (0.0.1)
@@ -278,7 +278,7 @@ GEM
     kaminari-mongoid (1.0.2)
       kaminari-core (~> 1.0)
       mongoid
-    loofah (2.14.0)
+    loofah (2.15.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)

--- a/app/presenters/reports/card_order_presenter.rb
+++ b/app/presenters/reports/card_order_presenter.rb
@@ -108,12 +108,19 @@ module Reports
     def parse_address(address, company_name)
       [
         # Skip house number and address line 1 if they match the company name.
-        address.houseNumber.downcase == company_name.downcase ? "" : address.houseNumber,
-        address.addressLine1.downcase == company_name.downcase ? "" : address.addressLine1,
+        address_line_unless_equal(company_name, address.houseNumber),
+        address_line_unless_equal(company_name, address.addressLine1),
         address.addressLine2,
         address.addressLine3,
         address.addressLine4
       ].reject(&:blank?)
+    end
+
+    def address_line_unless_equal(company_name, address_line)
+      return "" if address_line.nil?
+      return address_line if company_name.nil?
+
+      address_line.downcase == company_name.downcase ? "" : address_line
     end
   end
 end

--- a/spec/factories/address.rb
+++ b/spec/factories/address.rb
@@ -2,10 +2,14 @@
 
 FactoryBot.define do
   factory :address, class: WasteCarriersEngine::Address do
-    house_number { "42" }
-    address_line_1 { "Foo Gardens" }
-    town_city { "Baz City" }
+    house_number { Faker::Number.number(digits: 2) }
+    address_line_1 { Faker::Address.street_name }
+    address_line_2 { Faker::Address.secondary_address }
+    address_line_3 { Faker::Address.community }
+    address_line_4 { Faker::Address.community }
+    town_city { Faker::Address.city }
     postcode { "FA1 1KE" }
+    country { Faker::Address.country }
     uprn { "340116" }
 
     trait :contact do

--- a/spec/helpers/dashboards_helper_spec.rb
+++ b/spec/helpers/dashboards_helper_spec.rb
@@ -18,7 +18,12 @@ RSpec.describe DashboardsHelper, type: :helper do
 
     context "when the address is present" do
       it "returns the correct value" do
-        expect(helper.inline_registered_address(result)).to eq("42, Foo Gardens, Baz City, FA1 1KE")
+        reg_address = result.addresses.select { |a| a.address_type == "REGISTERED" }.first
+        expect(helper.inline_registered_address(result).split(/\s*,\s*/))
+          .to include(reg_address.house_number,
+                      reg_address.address_line_1,
+                      reg_address.town_city,
+                      reg_address.postcode)
       end
     end
   end


### PR DESCRIPTION
This change fixes an issue where address line 1 and/or company name are nil during a copy cards export.
It also refactors the CardOrderPresenter unit tests for clarity and for more complete coverage.

https://eaflood.atlassian.net/browse/RUBY-1815