### PR TITLE
Present sole trader / business name in registration details

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: e56bd0d1fbfd101483459e853b9dc2cd45eb77d2
+  revision: d7ebd864c525d293a6e90e3c02b9aaa18c775aec
   branch: main
   specs:
     waste_carriers_engine (0.0.1)

--- a/app/presenters/base_registration_presenter.rb
+++ b/app/presenters/base_registration_presenter.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class BaseRegistrationPresenter < WasteCarriersEngine::BasePresenter
+  include WasteCarriersEngine::CanPresentEntityDisplayName
+
   def display_company_details_panel?
     company_name.present? ||
       display_tier_and_registration_type.present? ||

--- a/app/views/shared/registrations/_company_details_panel.html.erb
+++ b/app/views/shared/registrations/_company_details_panel.html.erb
@@ -1,7 +1,7 @@
 <% if resource.display_company_details_panel? %>
-  <% if resource.company_name.present? %>
+  <% if resource.entity_display_name.present? %>
     <h2 class="govuk-heading-m">
-      <%= resource.company_name %>
+      <%= resource.entity_display_name %>
     </h2>
   <% end %>
   <% if resource.display_tier_and_registration_type.present? %>

--- a/app/views/shared/registrations/_contact_and_business_details_panels.html.erb
+++ b/app/views/shared/registrations/_contact_and_business_details_panels.html.erb
@@ -32,7 +32,7 @@
     </h2>
     <% if resource.display_business_information_panel? %>
       <p class="govuk-body">
-        <%= resource.company_name %>
+        <%= resource.entity_display_name %>
       </p>
       <% if resource.company_no.present? %>
         <p class="govuk-body">

--- a/spec/presenters/registration_presenter_spec.rb
+++ b/spec/presenters/registration_presenter_spec.rb
@@ -54,4 +54,53 @@ RSpec.describe RegistrationPresenter do
       expect(subject.display_registration_status).to eq("Pending")
     end
   end
+
+  describe "#entity_display_name" do
+    context "for a sole trader" do
+      let(:registration) do
+        build(:registration,
+              business_type: "soleTrader",
+              company_name: business_name,
+              key_people: [build(:key_person, :main)])
+      end
+      let(:key_person) { registration.key_people[0] }
+      let(:trader_name) { "#{key_person.first_name} #{key_person.last_name}" }
+
+      context "without a business name" do
+        let(:business_name) { nil }
+
+        it "returns the trader's name" do
+          expect(subject.entity_display_name).to eq trader_name
+        end
+      end
+
+      context "with a business name" do
+        let(:business_name) { Faker::Company.name }
+
+        it "returns the sole trader name and the business name" do
+          expect(subject.entity_display_name).to eq "#{trader_name} trading as #{business_name}"
+        end
+      end
+    end
+
+    context "for a limited company" do
+      let(:registration) { build(:registration, registered_company_name: reg_co_name) }
+
+      context "without a registered company name" do
+        let(:reg_co_name) { nil }
+
+        it "returns the business name" do
+          expect(subject.entity_display_name).to eq registration.company_name
+        end
+      end
+
+      context "with a registered_company_name and a business name" do
+        let(:reg_co_name) { Faker::Company.name }
+
+        it "returns the registered company name and the business name" do
+          expect(subject.entity_display_name).to eq "#{reg_co_name} trading as #{registration.company_name}"
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This change uses the engine's standard company presentation name logic to show sole trader name / business name in the registration details page.

https://eaflood.atlassian.net/browse/RUBY-1779