### PR TITLE
Display `entity_display_name` in search results

### DIFF
--- a/app/presenters/search_result_presenter.rb
+++ b/app/presenters/search_result_presenter.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class SearchResultPresenter < WasteCarriersEngine::BasePresenter
+  include WasteCarriersEngine::CanPresentEntityDisplayName
+end

--- a/app/presenters/search_result_presenter.rb
+++ b/app/presenters/search_result_presenter.rb
@@ -2,4 +2,16 @@
 
 class SearchResultPresenter < WasteCarriersEngine::BasePresenter
   include WasteCarriersEngine::CanPresentEntityDisplayName
+
+  def initialize(model)
+    @original_model = model
+    super(model)
+  end
+
+  # ActionLinksHelper uses `is_a?(model-klass)` to make page display decisions.
+  # Here we enable that method to be called on the model that was passed to this
+  # class so we can continue to support that behaviour
+  def is_a?(klass)
+    @original_model.is_a?(klass)
+  end
 end

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -7,7 +7,7 @@ class SearchService < ::WasteCarriersEngine::BaseService
     @page = page
     @term = term.strip
 
-    response_hash(search_results)
+    response_hash(search_results.map { |result| SearchResultPresenter.new(result) })
   end
 
   private

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -80,7 +80,7 @@
                 <% end %>
               </td>
               <td class="govuk-table__cell">
-                <%= result.company_name %>
+                <%= result.entity_display_name %>
                 <% if result.registered_address.present? %>
                   <p class="address font-xsmall">
                     <%= inline_registered_address(result) %>

--- a/spec/presenters/search_result_presenter_spec.rb
+++ b/spec/presenters/search_result_presenter_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SearchResultPresenter do
+  let(:presenter) { described_class.new(model) }
+
+  describe "#entity_display_name" do
+    let(:model) { Object.new }
+
+    it { expect(presenter).to respond_to(:entity_display_name) }
+  end
+
+  describe "#is_a? WasteCarriersEngine::NewRegistration" do
+    subject { presenter.is_a?(WasteCarriersEngine::NewRegistration) }
+
+    context "when the model is a WasteCarriersEngine::NewRegistration" do
+      let(:model) { WasteCarriersEngine::NewRegistration.new }
+
+      it { expect(subject).to be_truthy }
+    end
+
+    context "when the model is not a WasteCarriersEngine::Registration" do
+      let(:model) { WasteCarriersEngine::RenewingRegistration.new }
+
+      it { expect(subject).to be_falsey }
+    end
+  end
+end

--- a/spec/services/search_service_spec.rb
+++ b/spec/services/search_service_spec.rb
@@ -44,6 +44,13 @@ RSpec.describe SearchService do
         expect(service[:count]).to eq(2)
       end
 
+      it "returns a presentation object that supports `entity_display_name`" do
+        result = service[:results].first
+
+        expect(result).to be_a(SearchResultPresenter)
+        expect(result).to respond_to(:entity_display_name)
+      end
+
       it "displays the matching transient_registration" do
         expect(service[:results]).to include(matching_renewal)
       end


### PR DESCRIPTION
Here we introduce a `SearchResultPresenter` that mixes in `CanPresentEntityDisplayName` so that the `entity_display_name` can be displayed in the search results.

Unfortunately, the ActionLinksHelper uses `is_a?(model-klass)` to
make page display decisions. To support this behaviouer, we enable that method to be called 
on the model that was passed to this class.

This is an unfortunate clash of design patterns - if there is a better solution, please let me know!

https://eaflood.atlassian.net/browse/RUBY-1794