### PR TITLE
Add reference to letters to aid understanding returns

### DIFF
--- a/app/services/notify/renewal_letter_service.rb
+++ b/app/services/notify/renewal_letter_service.rb
@@ -13,6 +13,7 @@ module Notify
       client = Notifications::Client.new(WasteCarriersEngine.configuration.notify_api_key)
 
       client.send_letter(template_id: template,
+                         reference: @registration.reg_identifier,
                          personalisation: personalisation)
     end
 

--- a/spec/cassettes/notify_ad_renewal_letter.yml
+++ b/spec/cassettes/notify_ad_renewal_letter.yml
@@ -5,8 +5,8 @@ http_interactions:
     uri: https://api.notifications.service.gov.uk/v2/notifications/letter
     body:
       encoding: UTF-8
-      string: '{"template_id":"1b56d3a7-f7fd-414d-a3ba-2b50f627cf40","personalisation":{"contact_name":"Jane
-        Doe","expiry_date":"30 May 2021","reg_identifier":"CBDU1","registration_cost":"154","renewal_cost":"105","renewal_url":"localhost:3002/fo/renew/9Z5AL9pDWbPwd5qahYSnQGUf","address_line_1":"Jane
+      string: '{"template_id":"1b56d3a7-f7fd-414d-a3ba-2b50f627cf40","reference":"CBDU8","personalisation":{"contact_name":"Jane
+        Doe","expiry_date":"17 May 2022","reg_identifier":"CBDU8","registration_cost":"154","renewal_cost":"105","renewal_url":"localhost:3002/fo/renew/U17FcPc5FJc46UKKPEqX8AVN","address_line_1":"Jane
         Doe","address_line_2":"42","address_line_3":"Foo Gardens","address_line_4":"Baz
         City","address_line_5":"BS1 1AA"}}'
     headers:
@@ -34,35 +34,35 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 30 Mar 2021 14:46:15 GMT
+      - Thu, 17 Mar 2022 12:59:56 GMT
       Server:
       - nginx
       Strict-Transport-Security:
       - max-age=31536000; includeSubdomains
       X-B3-Spanid:
-      - f1eab9a7fe57f234
+      - 575add09e43c7bb91438c125b8e6364b
       X-B3-Traceid:
-      - f1eab9a7fe57f234
+      - 575add09e43c7bb91438c125b8e6364b
       X-Vcap-Request-Id:
-      - 9c3d69af-6366-4eac-7d78-0dd38410eaf7
+      - 9df250ed-8eed-4db4-6391-574230017705
       Content-Length:
-      - '1291'
+      - '1241'
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
       string: '{"content":{"body":"Dear Jane Doe\r\n\r\nRenew online \u2013 you''ll
-        need an email address to use the service\r\n1. Go to the website:\r\nlocalhost:3002/fo/renew/9Z5AL9pDWbPwd5qahYSnQGUf\r\n2.
+        need an email address to use the service\r\n1. Go to the website:\r\nlocalhost:3002/fo/renew/U17FcPc5FJc46UKKPEqX8AVN\r\n2.
         Confirm details for your renewal\r\n3. Pay for your renewal\r\n\r\nIf you
         no longer carry out these waste operations, you can ignore this reminder.\r\n\r\nIf
         you do not renew in time you\u2019ll need to create a new registration, which
         will cost \u00a3154 instead.\r\n\r\nIf you need help completing the process
         online, or have specific access needs, you can give us a call.\r\n\r\n#Need
         help to renew?\r\nCall us on 03708 506 506 (Monday to Friday, 8am to 6pm).
-        \r\nYour waste carrier registration number is CBDU1.\r\n\r\nYours sincerely\r\nWaste
-        carrier renewal team","subject":"Renew your waste carrier registration CBDU1
-        by 30 May 2021. Renewal costs \u00a3105 and should take about 15 minutes."},"id":"29f9caaf-238e-4617-8337-1bf795146e87","reference":null,"scheduled_for":null,"template":{"id":"1b56d3a7-f7fd-414d-a3ba-2b50f627cf40","uri":"https://api.notifications.service.gov.uk/services/25cb6b94-8ce7-485b-918a-559f3b18f69c/templates/1b56d3a7-f7fd-414d-a3ba-2b50f627cf40","version":10},"uri":"https://api.notifications.service.gov.uk/v2/notifications/29f9caaf-238e-4617-8337-1bf795146e87"}
+        \r\nYour waste carrier registration number is CBDU8.","subject":"Renew your
+        waste carrier registration CBDU8 by 17 May 2022. Renewal costs \u00a3105 and
+        should take about 15 minutes."},"id":"2245b32a-0f56-4ce5-81f7-7e19264589f1","reference":"CBDU8","scheduled_for":null,"template":{"id":"1b56d3a7-f7fd-414d-a3ba-2b50f627cf40","uri":"https://api.notifications.service.gov.uk/services/25cb6b94-8ce7-485b-918a-559f3b18f69c/templates/1b56d3a7-f7fd-414d-a3ba-2b50f627cf40","version":11},"uri":"https://api.notifications.service.gov.uk/v2/notifications/2245b32a-0f56-4ce5-81f7-7e19264589f1"}
 
 '
-  recorded_at: Tue, 30 Mar 2021 14:46:14 GMT
-recorded_with: VCR 6.0.0
+  recorded_at: Thu, 17 Mar 2022 12:59:30 GMT
+recorded_with: VCR 6.1.0

--- a/spec/cassettes/notify_digital_renewal_letter.yml
+++ b/spec/cassettes/notify_digital_renewal_letter.yml
@@ -5,8 +5,8 @@ http_interactions:
     uri: https://api.notifications.service.gov.uk/v2/notifications/letter
     body:
       encoding: UTF-8
-      string: '{"template_id":"41ebbbc4-0d2f-425a-8d94-29e2beffd8ba","personalisation":{"contact_name":"Jane
-        Doe","expiry_date":"6 June 2021","reg_identifier":"CBDU1","registration_cost":"154","renewal_cost":"105","renewal_url":"localhost:3002/fo/renew/ePBEXbag1AMjrsUgfKEbNfYy","user_email":"whatever@example.com","email_date":"2021-04-25","from_email":"wcr-dev@example.com","address_line_1":"Jane
+      string: '{"template_id":"41ebbbc4-0d2f-425a-8d94-29e2beffd8ba","reference":"CBDU17","personalisation":{"contact_name":"Jane
+        Doe","expiry_date":"17 May 2022","reg_identifier":"CBDU17","registration_cost":"154","renewal_cost":"105","renewal_url":"localhost:3002/fo/renew/Ki3Mg315NiDrnM19tvjWMkfT","user_email":"whatever@example.com","email_date":"2022-04-05","address_line_1":"Jane
         Doe","address_line_2":"42","address_line_3":"Foo Gardens","address_line_4":"Baz
         City","address_line_5":"BS1 1AA"}}'
     headers:
@@ -34,19 +34,19 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 06 Apr 2021 14:20:09 GMT
+      - Thu, 17 Mar 2022 12:59:57 GMT
       Server:
       - nginx
       Strict-Transport-Security:
       - max-age=31536000; includeSubdomains
       X-B3-Spanid:
-      - 5a1f34325f84c13c
+      - 2cddc92e3ac25c4e6414e6bef33813b6
       X-B3-Traceid:
-      - 5a1f34325f84c13c
+      - 2cddc92e3ac25c4e6414e6bef33813b6
       X-Vcap-Request-Id:
-      - d28e5750-29e9-4642-5795-270d8bace2bc
+      - e9dd4d03-08ad-4e45-4355-8afaf7c18e66
       Content-Length:
-      - '1190'
+      - '1220'
       Connection:
       - keep-alive
     body:
@@ -54,14 +54,14 @@ http_interactions:
       string: '{"content":{"body":"Dear Jane Doe\r\n\r\nYou can renew online in a
         few minutes. It costs \u00a3105 and lasts for 3 years from the expiry date.\r\n\r\nHow
         to renew online:\r\n\r\n1. Search your email inbox and junk mail for the renewal
-        email sent to whatever@example.com on 2021-04-25, from wcr-dev@example.com\r\n2.
+        email sent to whatever@example.com on 2022-04-05, from nccc-carrierbroker@environment-agency.gov.uk\r\n2.
         Confirm details for your renewal\r\n3. Pay for your renewal\r\n\r\nIf you
         do not renew in time you\u2019ll need to create a new registration, which
         will instead cost \u00a3154.\r\n\r\nIf you\u2019re unable to find the renewal
-        email, begin your online renewal by using this unique link:\r\n\r\nlocalhost:3002/fo/renew/ePBEXbag1AMjrsUgfKEbNfYy\r\n\r\nYours
+        email, begin your online renewal by using this unique link:\r\n\r\nlocalhost:3002/fo/renew/Ki3Mg315NiDrnM19tvjWMkfT\r\n\r\nYours
         sincerely\r\nWaste carrier renewal team","subject":"You must renew your waste
-        carrier registration CBDU1 by 6 June 2021"},"id":"b6628d5c-5869-433e-9096-22ad759d447b","reference":null,"scheduled_for":null,"template":{"id":"41ebbbc4-0d2f-425a-8d94-29e2beffd8ba","uri":"https://api.notifications.service.gov.uk/services/25cb6b94-8ce7-485b-918a-559f3b18f69c/templates/41ebbbc4-0d2f-425a-8d94-29e2beffd8ba","version":5},"uri":"https://api.notifications.service.gov.uk/v2/notifications/b6628d5c-5869-433e-9096-22ad759d447b"}
+        carrier registration CBDU17 by 17 May 2022"},"id":"7c1bf4d4-93ad-492e-a6a6-80ebac653037","reference":"CBDU17","scheduled_for":null,"template":{"id":"41ebbbc4-0d2f-425a-8d94-29e2beffd8ba","uri":"https://api.notifications.service.gov.uk/services/25cb6b94-8ce7-485b-918a-559f3b18f69c/templates/41ebbbc4-0d2f-425a-8d94-29e2beffd8ba","version":6},"uri":"https://api.notifications.service.gov.uk/v2/notifications/7c1bf4d4-93ad-492e-a6a6-80ebac653037"}
 
 '
-  recorded_at: Tue, 06 Apr 2021 14:20:09 GMT
-recorded_with: VCR 6.0.0
+  recorded_at: Thu, 17 Mar 2022 12:59:31 GMT
+recorded_with: VCR 6.1.0

--- a/spec/factories/address.rb
+++ b/spec/factories/address.rb
@@ -20,4 +20,14 @@ FactoryBot.define do
       address_type { "REGISTERED" }
     end
   end
+
+  # This is to support legacy tests (notify letters) that broke
+  # when the address factory was changed.
+  factory :simple_address, class: WasteCarriersEngine::Address do
+    house_number { "42" }
+    address_line_1 { "Foo Gardens" }
+    town_city { "Baz City" }
+    postcode { "FA1 1KE" }
+    address_type { "POSTAL" }
+  end
 end

--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -23,6 +23,10 @@ FactoryBot.define do
 
     metaData { build(:metaData) }
 
+    trait :simple_address do
+      addresses { [build(:simple_address)] }
+    end
+
     trait :ad_registration do
       account_email { ENV["WCRS_ASSISTED_DIGITAL_EMAIL"] }
       contact_email { ENV["WCRS_ASSISTED_DIGITAL_EMAIL"] }

--- a/spec/services/notify/ad_renewal_letter_service_spec.rb
+++ b/spec/services/notify/ad_renewal_letter_service_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe Notify::AdRenewalLetterService do
   describe "run" do
-    let(:registration) { create(:registration, :expires_soon) }
+    let(:registration) { create(:registration, :expires_soon, :simple_address) }
     let(:service) do
       Notify::AdRenewalLetterService.run(registration: registration)
     end
@@ -20,6 +20,7 @@ RSpec.describe Notify::AdRenewalLetterService do
 
         expect(response).to be_a(Notifications::Client::ResponseNotification)
         expect(response.template["id"]).to eq("1b56d3a7-f7fd-414d-a3ba-2b50f627cf40")
+        expect(response.reference).to match(/CBDU*/)
         expect(response.content["subject"]).to include("Renew your waste carrier registration")
       end
     end

--- a/spec/services/notify/digital_renewal_letter_service_spec.rb
+++ b/spec/services/notify/digital_renewal_letter_service_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe Notify::DigitalRenewalLetterService do
   describe "run" do
-    let(:registration) { create(:registration, :expires_soon) }
+    let(:registration) { create(:registration, :expires_soon, :simple_address) }
     let(:service) do
       Notify::DigitalRenewalLetterService.run(registration: registration)
     end
@@ -20,6 +20,7 @@ RSpec.describe Notify::DigitalRenewalLetterService do
 
         expect(response).to be_a(Notifications::Client::ResponseNotification)
         expect(response.template["id"]).to eq("41ebbbc4-0d2f-425a-8d94-29e2beffd8ba")
+        expect(response.reference).to match(/CBDU*/)
         expect(response.content["subject"]).to include("You must renew your waste carrier registration")
       end
     end


### PR DESCRIPTION
- Here we add the reg_identifier as a `reference` to the API
request to send Notify letters

- Unfortunately, recent changes to the address factory introduced
breaking changes so we also add a new `simple_address` factory
that will generate an address that Notify is happy to validate

https://eaflood.atlassian.net/browse/RUBY-1755