### PR TITLE
Copy card update

### DIFF
--- a/app/presenters/reports/card_order_presenter.rb
+++ b/app/presenters/reports/card_order_presenter.rb
@@ -38,7 +38,7 @@ module Reports
       when "soleTrader"
         "#{@registration.key_people[0].first_name} #{@registration.key_people[0].last_name}"
       else
-        @registration.company_name
+        @registration.registered_company_name.presence || @registration.company_name
       end
     end
 

--- a/app/presenters/reports/card_order_presenter.rb
+++ b/app/presenters/reports/card_order_presenter.rb
@@ -34,18 +34,11 @@ module Reports
     end
 
     def carrier_name
-      case @registration.tier
-      when "LOWER"
-        @registration.company_name
-      when "UPPER"
-        case @registration.business_type
-        when "soleTrader"
-          "#{@registration.key_people[0].first_name} #{@registration.key_people[0].last_name}"
-        else
-          @registration.company_name
-        end
+      case @registration.business_type
+      when "soleTrader"
+        "#{@registration.key_people[0].first_name} #{@registration.key_people[0].last_name}"
       else
-        ""
+        @registration.company_name
       end
     end
 

--- a/spec/presenters/reports/card_order_presenter_spec.rb
+++ b/spec/presenters/reports/card_order_presenter_spec.rb
@@ -43,8 +43,18 @@ module Reports
       end
 
       context "when the registration business type is NOT 'sole trader'" do
-        it "returns the company name" do
-          expect(subject.carrier_name).to eq(registration.company_name)
+        context "when the registration has a registered_company_name" do
+          before { registration.update(registered_company_name: "Acme Ltd") }
+
+          it "returns the registered_company_name" do
+            expect(subject.carrier_name).to eq("Acme Ltd")
+          end
+        end
+
+        context "when the registration does not have a registered_company_name" do
+          it "returns the company name" do
+            expect(subject.carrier_name).to eq(registration.company_name)
+          end
         end
       end
     end

--- a/spec/presenters/reports/card_order_presenter_spec.rb
+++ b/spec/presenters/reports/card_order_presenter_spec.rb
@@ -59,6 +59,16 @@ module Reports
       end
     end
 
+    describe "#company_name" do
+      context "when they registration does not have a company_name" do
+        let(:company_name) { nil }
+
+        it "is blank" do
+          expect(subject.company_name).to be_blank
+        end
+      end
+    end
+
     describe "base registration details" do
       it "returns the relevant registration attributes" do
         expect(subject.company_name).to eq registration.company_name

--- a/spec/presenters/reports/card_order_presenter_spec.rb
+++ b/spec/presenters/reports/card_order_presenter_spec.rb
@@ -33,29 +33,18 @@ module Reports
     end
 
     describe "#carrier_name" do
-      context "when the registration is lower tier" do
-        let(:lower_tier) { true }
-        let(:upper_tier) { false }
+      context "when the registration business type is 'soleTrader'" do
+        let(:business_type) { "soleTrader" }
 
-        it "returns the company name" do
-          expect(subject.carrier_name).to eq(registration.company_name)
+        it "returns the carrier's name" do
+          main_person = registration.key_people[0]
+          expect(subject.carrier_name).to eq("#{main_person.first_name} #{main_person.last_name}")
         end
       end
 
-      context "when the registration is upper tier" do
-        context "when the registration business type is 'soleTrader'" do
-          let(:business_type) { "soleTrader" }
-
-          it "returns the carrier's name" do
-            main_person = registration.key_people[0]
-            expect(subject.carrier_name).to eq("#{main_person.first_name} #{main_person.last_name}")
-          end
-        end
-
-        context "when the registration business type is NOT 'sole trader'" do
-          it "returns the company name" do
-            expect(subject.carrier_name).to eq(registration.company_name)
-          end
+      context "when the registration business type is NOT 'sole trader'" do
+        it "returns the company name" do
+          expect(subject.carrier_name).to eq(registration.company_name)
         end
       end
     end


### PR DESCRIPTION
Here we:
- enable the `registered_company_name` (if it exists) as the "Name of Registered Carrier"
- check that the "Business Name" will be blank if there is no `company_name`
- remove LOWER tier options (copy cards are only for UPPER tier registrations

https://eaflood.atlassian.net/browse/RUBY-1792