### PR TITLE
De-duplicate registered_company_name in copy cards export

### DIFF
--- a/app/presenters/reports/card_order_presenter.rb
+++ b/app/presenters/reports/card_order_presenter.rb
@@ -101,19 +101,20 @@ module Reports
     def parse_address(address, company_name)
       [
         # Skip house number and address line 1 if they match the company name.
-        address_line_unless_equal(company_name, address.houseNumber),
-        address_line_unless_equal(company_name, address.addressLine1),
+        address_line_unless_duplicate(@registration.registered_company_name, company_name, address.houseNumber),
+        address_line_unless_duplicate(@registration.registered_company_name, company_name, address.addressLine1),
         address.addressLine2,
         address.addressLine3,
         address.addressLine4
       ].reject(&:blank?)
     end
 
-    def address_line_unless_equal(company_name, address_line)
-      return "" if address_line.nil?
-      return address_line if company_name.nil?
+    def address_line_unless_duplicate(registered_company_name, company_name, address_line)
+      return "" if address_line.nil? ||
+                   registered_company_name.try(:downcase) == address_line.downcase ||
+                   company_name.try(:downcase) == address_line.downcase
 
-      address_line.downcase == company_name.downcase ? "" : address_line
+      address_line
     end
   end
 end


### PR DESCRIPTION
This change skips house number / address line 1 fields in the copy card export if they match the registered_company_name value of the registration.
It also DRYs up the company_card_presenter specs to avoid repetition of unit test logic.
https://eaflood.atlassian.net/browse/RUBY-1829