### PR TITLE
Fix spec that broke with Mongoid upgrade

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -293,7 +293,7 @@ GEM
     minitest (5.15.0)
     mongo (2.17.1)
       bson (>= 4.8.2, < 5.0.0)
-    mongoid (7.3.4)
+    mongoid (7.4.0)
       activemodel (>= 5.1, < 7.1, != 7.0.0)
       mongo (>= 2.10.5, < 3.0.0)
       ruby2_keywords (~> 0.0.5)

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -342,8 +342,8 @@ RSpec.describe ActionLinksHelper, type: :helper do
       let(:resource) { build(:registration) }
 
       before do
-        allow(helper).to receive(:can?).with(:revoke, resource).and_return(can)
-        allow(helper).to receive(:can?).with(:cease, resource).and_return(can)
+        allow(helper).to receive(:can?).with(:revoke, WasteCarriersEngine::Registration).and_return(can)
+        allow(helper).to receive(:can?).with(:cease, WasteCarriersEngine::Registration).and_return(can)
       end
 
       context "when the user has permission for revoking" do


### PR DESCRIPTION
- Upgrades mongoid to 7.4.0

- The stubbed methods in this spec were expecting an instance
of the resource, but the actual method expects a reference to
the object `WasteCarriersEngine::Registration`

- This appears to have broken now because mongoid has implemented
the `====` method:
https://www.mongodb.com/docs/mongoid/master/release-notes/mongoid-7.4/#change-operator-to-match-ruby-semantics

https://eaflood.atlassian.net/browse/RUBY-1850