### PR TITLE
Refactor worldpay card payments

### DIFF
--- a/app/controllers/online_missed_payment_forms_controller.rb
+++ b/app/controllers/online_missed_payment_forms_controller.rb
@@ -1,28 +1,28 @@
 # frozen_string_literal: true
 
-class WorldpayMissedPaymentFormsController < ResourceFormsController
+class OnlineMissedPaymentFormsController < ResourceFormsController
   include CanSetFlashMessages
 
   before_renew_or_complete :change_state_if_possible
 
   def new
-    super(WorldpayMissedPaymentForm, "worldpay_missed_payment_form")
+    super(OnlineMissedPaymentForm, "online_missed_payment_form")
   end
 
   def create
-    params[:worldpay_missed_payment_form][:updated_by_user] = current_user.email
+    params[:online_missed_payment_form][:updated_by_user] = current_user.email
 
-    return unless super(WorldpayMissedPaymentForm, "worldpay_missed_payment_form")
+    return unless super(OnlineMissedPaymentForm, "online_missed_payment_form")
 
     flash_success(
-      I18n.t("payments.messages.success", amount: @worldpay_missed_payment_form.amount)
+      I18n.t("payments.messages.success", amount: @online_missed_payment_form.amount)
     )
   end
 
   private
 
-  def worldpay_missed_payment_form_params
-    params.fetch(:worldpay_missed_payment_form, {}).permit(
+  def online_missed_payment_form_params
+    params.fetch(:online_missed_payment_form, {}).permit(
       :amount,
       :comment,
       :registration_reference,
@@ -34,7 +34,7 @@ class WorldpayMissedPaymentFormsController < ResourceFormsController
   end
 
   def authorize_user
-    authorize! :record_worldpay_missed_payment, @resource
+    authorize! :record_online_missed_payment, @resource
   end
 
   def change_state_if_possible

--- a/app/controllers/online_missed_payment_new_registrations_controller.rb
+++ b/app/controllers/online_missed_payment_new_registrations_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class WorldpayMissedPaymentNewRegistrationsController < ApplicationController
+class OnlineMissedPaymentNewRegistrationsController < ApplicationController
   include CanFetchResource
 
   prepend_before_action :authenticate_user!
@@ -9,7 +9,7 @@ class WorldpayMissedPaymentNewRegistrationsController < ApplicationController
   def new
     if ready_to_complete_and_add_missed_payment?
       complete_new_registration
-      redirect_to new_resource_worldpay_missed_payment_form_path(@registration._id)
+      redirect_to new_resource_online_missed_payment_form_path(@registration._id)
     else
       redirect_to new_registration_path(@resource.token)
     end
@@ -18,7 +18,7 @@ class WorldpayMissedPaymentNewRegistrationsController < ApplicationController
   private
 
   def authorize
-    authorize! :record_worldpay_missed_payment, @resource
+    authorize! :record_online_missed_payment, @resource
   end
 
   def ready_to_complete_and_add_missed_payment?

--- a/app/controllers/online_payment_escapes_controller.rb
+++ b/app/controllers/online_payment_escapes_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class WorldpayEscapesController < ApplicationController
+class OnlinePaymentEscapesController < ApplicationController
   include CanFetchResource
 
   prepend_before_action :authenticate_user!
@@ -9,7 +9,7 @@ class WorldpayEscapesController < ApplicationController
   def new
     if correct_workflow_state?
       change_state_to_payment_summary
-      log_worldpay_escape
+      log_online_payment_escape
       redirect_to continue_journey_path
     else
       redirect_to details_page_path
@@ -30,7 +30,7 @@ class WorldpayEscapesController < ApplicationController
     @resource.update_attributes(workflow_state: "payment_summary_form")
   end
 
-  def log_worldpay_escape
+  def log_online_payment_escape
     params = {
       user: current_user.email,
       class: @resource.class.name,

--- a/app/forms/base_payment_form.rb
+++ b/app/forms/base_payment_form.rb
@@ -73,7 +73,7 @@ class BasePaymentForm < WasteCarriersEngine::BaseForm
   def build_payment(params)
     params[:amount] = convert_amount_to_pence(params[:amount])
 
-    self.payment = WasteCarriersEngine::Payment.new_from_non_worldpay(params, order)
+    self.payment = WasteCarriersEngine::Payment.new_from_non_online_payment(params, order)
   end
 
   def update_finance_details

--- a/app/forms/online_missed_payment_form.rb
+++ b/app/forms/online_missed_payment_form.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class WorldpayMissedPaymentForm < BasePaymentForm
+class OnlineMissedPaymentForm < BasePaymentForm
   def submit(params)
     payment_type_value = "WORLDPAY_MISSED"
     super(params, payment_type_value)

--- a/app/forms/payment_form.rb
+++ b/app/forms/payment_form.rb
@@ -3,7 +3,7 @@
 class PaymentForm
   include ActiveModel::Model
 
-  PAYMENT_TYPES = %w[cash cheque postal_order bank_transfer worldpay_missed].freeze
+  PAYMENT_TYPES = %w[cash cheque postal_order bank_transfer online_missed].freeze
 
   attr_accessor :payment_type
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -88,7 +88,7 @@ class Ability
     can :view_payments, :all
 
     can :reverse, WasteCarriersEngine::Payment do |payment|
-      payment.worldpay? || payment.worldpay_missed?
+      payment.online? || payment.online_missed?
     end
   end
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -33,7 +33,7 @@ class Ability
   # Permissions for specific roles
 
   def permissions_for_agency_user
-    # This covers everything mounted in the engine and used for the assisted digital journey, including WorldPay
+    # This covers everything mounted in the engine and used for the assisted digital journey, including online payments
     can :update, WasteCarriersEngine::RenewingRegistration
     can :create, WasteCarriersEngine::Registration
     can :renew, :all
@@ -84,7 +84,7 @@ class Ability
     can :charge_adjust, :all
     can :write_off_large, WasteCarriersEngine::FinanceDetails
     can :view_certificate, WasteCarriersEngine::Registration
-    can :record_worldpay_missed_payment, :all
+    can :record_online_missed_payment, :all
     can :view_payments, :all
 
     can :reverse, WasteCarriersEngine::Payment do |payment|

--- a/app/presenters/payment_presenter.rb
+++ b/app/presenters/payment_presenter.rb
@@ -16,7 +16,7 @@ class PaymentPresenter < WasteCarriersEngine::BasePresenter
   end
 
   def refunded_message
-    if worldpay?
+    if online?
       I18n.t(".refunds.refunded_message.card", refund_status: refunded_payment.world_pay_payment_status)
     else
       I18n.t(".refunds.refunded_message.manual")

--- a/app/services/process_refund_service.rb
+++ b/app/services/process_refund_service.rb
@@ -60,7 +60,7 @@ class ProcessRefundService < WasteCarriersEngine::BaseService
   end
 
   def card_payment?
-    payment.worldpay?
+    payment.online?
   end
 
   def refund_comment

--- a/app/services/worldpay/refund_service.rb
+++ b/app/services/worldpay/refund_service.rb
@@ -6,7 +6,7 @@ module Worldpay
     include ::WasteCarriersEngine::CanBuildWorldpayXml
 
     def run(payment:, amount:, merchant_code:)
-      return false unless payment.worldpay? || payment.worldpay_missed?
+      return false unless payment.online? || payment.online_missed?
 
       @payment = payment
       @amount = amount

--- a/app/views/new_registrations/show.html.erb
+++ b/app/views/new_registrations/show.html.erb
@@ -13,21 +13,21 @@
             <%= t(".status.headings.in_progress") %>
           </h2>
 
-          <% if @transient_registration.workflow_state == "worldpay_form" %>
+          <% if @transient_registration.workflow_state == ".online._form" %>
             <p class="govuk-body">
-              <%= t(".status.messages.worldpay.paragraph_1") %>
+              <%= t(".status.messages.online.paragraph_1") %>
             </p>
 
             <% if can? :revert_to_payment_summary, @transient_registration %>
               <p class="govuk-body">
-                <%= t(".status.messages.worldpay.paragraph_2.revert") %>
+                <%= t(".status.messages.online.paragraph_2.revert") %>
               </p>
               <%= link_to t(".status.actions.revert_to_payment_summary_button"), new_resource_online_payment_escape_path(@transient_registration._id), class: 'button' %>
-            <% elsif can? :record_worldpay_missed_payment, @transient_registration %>
+            <% elsif can? :record_online_missed_payment, @transient_registration %>
               <p class="govuk-body">
-                <%= t(".status.messages.worldpay.paragraph_2.missed_payment") %>
+                <%= t(".status.messages.online.paragraph_2.missed_payment") %>
               </p>
-              <%= link_to t(".status.actions.missed_worldpay_payment_button"), new_resource_worldpay_missed_payment_new_registration_path(@transient_registration._id), class: 'button' %>
+              <%= link_to t(".status.actions.missed_online_payment_button"), new_resource_online_missed_payment_new_registration_path(@transient_registration._id), class: 'button' %>
             <% end %>
           <% else %>
             <p class="govuk-body">

--- a/app/views/new_registrations/show.html.erb
+++ b/app/views/new_registrations/show.html.erb
@@ -22,7 +22,7 @@
               <p class="govuk-body">
                 <%= t(".status.messages.worldpay.paragraph_2.revert") %>
               </p>
-              <%= link_to t(".status.actions.revert_to_payment_summary_button"), new_resource_worldpay_escape_path(@transient_registration._id), class: 'button' %>
+              <%= link_to t(".status.actions.revert_to_payment_summary_button"), new_resource_online_payment_escape_path(@transient_registration._id), class: 'button' %>
             <% elsif can? :record_worldpay_missed_payment, @transient_registration %>
               <p class="govuk-body">
                 <%= t(".status.messages.worldpay.paragraph_2.missed_payment") %>

--- a/app/views/online_missed_payment_forms/new.html.erb
+++ b/app/views/online_missed_payment_forms/new.html.erb
@@ -2,7 +2,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render("waste_carriers_engine/shared/back", back_path: new_resource_payment_form_path(@resource._id)) %>
 
-    <%= render("waste_carriers_engine/shared/errors", object: @worldpay_missed_payment_form) %>
+    <%= render("waste_carriers_engine/shared/errors", object: @online_missed_payment_form) %>
 
     <h1 class="govuk-heading-l">
       <%= t(".heading", reg_identifier: @resource.reg_identifier) %>
@@ -10,8 +10,8 @@
 
     <%= render(
       "shared/payment_form",
-      form: @worldpay_missed_payment_form,
-      path: resource_worldpay_missed_payment_forms_path(@resource._id),
+      form: @online_missed_payment_form,
+      path: resource_online_missed_payment_forms_path(@resource._id),
       resource: @resource
     ) %>
   </div>

--- a/app/views/renewing_registrations/show.html.erb
+++ b/app/views/renewing_registrations/show.html.erb
@@ -33,7 +33,7 @@
                 <p class="govuk-body">
                   <%= t(".status.messages.worldpay.paragraph_2.revert") %>
                 </p>
-                <%= link_to t(".status.actions.revert_to_payment_summary_button"), new_resource_worldpay_escape_path(@transient_registration._id), class: 'button' %>
+                <%= link_to t(".status.actions.revert_to_payment_summary_button"), new_resource_online_payment_escape_path(@transient_registration._id), class: 'button' %>
               <% elsif can? :record_worldpay_missed_payment, @transient_registration %>
                 <p class="govuk-body">
                   <%= t(".status.messages.worldpay.paragraph_2.missed_payment") %>

--- a/app/views/renewing_registrations/show.html.erb
+++ b/app/views/renewing_registrations/show.html.erb
@@ -26,19 +26,19 @@
 
             <% if @transient_registration.workflow_state == "worldpay_form" %>
               <p class="govuk-body">
-                <%= t(".status.messages.worldpay.paragraph_1") %>
+                <%= t(".status.messages.online.paragraph_1") %>
               </p>
 
               <% if can? :revert_to_payment_summary, @transient_registration %>
                 <p class="govuk-body">
-                  <%= t(".status.messages.worldpay.paragraph_2.revert") %>
+                  <%= t(".status.messages.online.paragraph_2.revert") %>
                 </p>
                 <%= link_to t(".status.actions.revert_to_payment_summary_button"), new_resource_online_payment_escape_path(@transient_registration._id), class: 'button' %>
-              <% elsif can? :record_worldpay_missed_payment, @transient_registration %>
+              <% elsif can? :record_online_missed_payment, @transient_registration %>
                 <p class="govuk-body">
-                  <%= t(".status.messages.worldpay.paragraph_2.missed_payment") %>
+                  <%= t(".status.messages.online.paragraph_2.missed_payment") %>
                 </p>
-                <%= link_to t(".status.actions.missed_worldpay_payment_button"), new_resource_worldpay_missed_payment_form_path(@transient_registration._id), class: 'button' %>
+                <%= link_to t(".status.actions.missed_online_payment_button"), new_resource_online_missed_payment_form_path(@transient_registration._id), class: 'button' %>
               <% end %>
             <% else %>
               <p class="govuk-body">

--- a/config/initializers/waste_carriers_engine.rb
+++ b/config/initializers/waste_carriers_engine.rb
@@ -32,10 +32,8 @@ WasteCarriersEngine.configure do |configuration|
 
   # By telling the engine it is hosted in the back-office it can make decisions
   # about any changes in behaviour needed. For example, the payment confirmation
-  # email from Worldpay is only applicable to users in the front-office. This is
-  # because Worldpay does not send one if the merchant code is MOTO. So the
-  # engine can use this flag to determine whether to show payment confirmation
-  # related content
+  # email is only applicable to users in the front-office. So the engine can use
+  # this flag to determine whether to show payment confirmation related content
   configuration.host_is_back_office = true
 end
 WasteCarriersEngine.start_airbrake

--- a/config/locales/new_registrations.en.yml
+++ b/config/locales/new_registrations.en.yml
@@ -19,7 +19,7 @@ en:
         actions:
           continue_button: "Continue as assisted digital"
           revert_to_payment_summary_button: "Send back to payment summary"
-          missed_worldpay_payment_button: "Add a missed WorldPay payment"
+          missed_online_payment_button: "Add a missed WorldPay payment"
       conviction_heading: "Convictions"
       conviction_link: "Conviction details"
       conviction_information:

--- a/config/locales/online_missed_payment_forms.en.yml
+++ b/config/locales/online_missed_payment_forms.en.yml
@@ -1,12 +1,12 @@
 en:
-  worldpay_missed_payment_forms:
+  online_missed_payment_forms:
     new:
       title: "Add a missed WorldPay payment"
       heading: "Add a missed WorldPay payment for %{reg_identifier}"
   activemodel:
     errors:
       models:
-        worldpay_missed_payment_form:
+        online_missed_payment_form:
           attributes:
             amount:
               not_a_number: "You must enter a valid number"

--- a/config/locales/payment_forms.en.yml
+++ b/config/locales/payment_forms.en.yml
@@ -8,7 +8,7 @@ en:
         cash: "Cash"
         cheque: "Cheque"
         postal_order: "Postal order"
-        worldpay_missed: "Missed WorldPay payment"
+        online_missed: "Missed WorldPay payment"
       no_permission: " – your account can't add this type of payment"
       submit_button: "Add payment details"
   activemodel:

--- a/config/locales/registrations.en.yml
+++ b/config/locales/registrations.en.yml
@@ -12,7 +12,7 @@ en:
         messages:
           in_progress: "The current form is"
           rejected: "This registration was rejected during a convictions check and cannot be completed."
-          worldpay:
+          online:
             paragraph_1: "The user is currently attempting to pay by WorldPay."
             paragraph_2:
               revert: "If an error has occurred and the user is stuck, you can send the registration back to the payment summary page. They can try to pay with WorldPay again, or select an alternative payment method."
@@ -21,7 +21,7 @@ en:
           continue_button: "Continue as assisted digital registration"
           convictions_check_button: "Check conviction matches"
           revert_to_payment_summary_button: "Send back to payment summary"
-          missed_worldpay_payment_button: "Add a missed WorldPay payment"
+          missed_online_payment_button: "Add a missed WorldPay payment"
       conviction_heading: "Convictions"
       conviction_link: "Conviction details"
       conviction_information:

--- a/config/locales/renewing_registrations.en.yml
+++ b/config/locales/renewing_registrations.en.yml
@@ -21,7 +21,7 @@ en:
           continue_button: "Continue as assisted digital"
           convictions_check_button: "Check conviction matches"
           revert_to_payment_summary_button: "Send back to payment summary"
-          missed_worldpay_payment_button: "Add a missed WorldPay payment"
+          missed_online_payment_button: "Add a missed WorldPay payment"
       conviction_heading: "Convictions"
       conviction_link: "Conviction details"
       conviction_information:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,9 +80,9 @@ Rails.application.routes.draw do
                         path: "payments/bank-transfer",
                         path_names: { new: "" }
 
-              resources :worldpay_missed_payment_forms,
+              resources :online_missed_payment_forms,
                         only: %i[new create],
-                        path: "payments/worldpay-missed",
+                        path: "payments/online-missed",
                         path_names: { new: "" }
 
               resources :online_payment_escapes,
@@ -90,9 +90,9 @@ Rails.application.routes.draw do
                         path: "revert-to-payment-summary",
                         path_names: { new: "" }
 
-              resources :worldpay_missed_payment_new_registrations,
+              resources :online_missed_payment_new_registrations,
                         only: :new,
-                        path: "missed-worldpay-payment-new-registration",
+                        path: "missed-online-payment-new-registration",
                         path_names: { new: "" }
 
               resource :finance_details,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -85,7 +85,7 @@ Rails.application.routes.draw do
                         path: "payments/worldpay-missed",
                         path_names: { new: "" }
 
-              resources :worldpay_escapes,
+              resources :online_payment_escapes,
                         only: :new,
                         path: "revert-to-payment-summary",
                         path_names: { new: "" }

--- a/lib/tasks/one_off/fix_renewal_received_form.rake
+++ b/lib/tasks/one_off/fix_renewal_received_form.rake
@@ -8,8 +8,8 @@ namespace :fix do
     puts "#{renewals.count} renewals to update"
 
     renewals.each do |renewal|
-      updated_state = if renewal.pending_worldpay_payment?
-                        "renewal_received_pending_worldpay_payment_form"
+      updated_state = if renewal.pending_online_payment?
+                        "renewal_received_pending_online_payment_form"
                       elsif renewal.unpaid_balance?
                         "renewal_received_pending_payment_form"
                       else

--- a/spec/factories/payment.rb
+++ b/spec/factories/payment.rb
@@ -26,7 +26,7 @@ FactoryBot.define do
       payment_type { WasteCarriersEngine::Payment::WORLDPAY }
     end
 
-    trait :worldpay_missed do
+    trait :online_missed do
       payment_type { WasteCarriersEngine::Payment::WORLDPAY_MISSED }
     end
   end

--- a/spec/presenters/payment_presenter_spec.rb
+++ b/spec/presenters/payment_presenter_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe PaymentPresenter do
       allow(finance_details).to receive(:payments).and_return(scope)
       allow(scope).to receive(:where).with(order_key: "123_REFUNDED").and_return([refunded_payment])
 
-      allow(payment).to receive(:worldpay?).and_return(worldpay)
+      allow(payment).to receive(:online?).and_return(worldpay)
       allow(refunded_payment).to receive(:world_pay_payment_status).and_return(world_pay_payment_status)
     end
 

--- a/spec/requests/online_missed_payment_forms_spec.rb
+++ b/spec/requests/online_missed_payment_forms_spec.rb
@@ -2,13 +2,13 @@
 
 require "rails_helper"
 
-RSpec.describe "WorldpayMissedPaymentForms", type: :request do
+RSpec.describe "OnlineMissedPaymentForms", type: :request do
   let(:transient_registration) do
     create(:renewing_registration, :has_finance_details, :does_not_require_conviction_check)
   end
   let(:registration) { transient_registration.registration }
 
-  describe "GET /bo/resources/:_id/payments/worldpay-missed" do
+  describe "GET /bo/resources/:_id/payments/online-missed" do
     context "when a valid user is signed in" do
       let(:user) { create(:user, :finance_admin) }
       before(:each) do
@@ -16,7 +16,7 @@ RSpec.describe "WorldpayMissedPaymentForms", type: :request do
       end
 
       it "renders the new template, returns a 200 response and includes the reg identifier" do
-        get "/bo/resources/#{transient_registration._id}/payments/worldpay-missed"
+        get "/bo/resources/#{transient_registration._id}/payments/online-missed"
 
         expect(response).to render_template(:new)
         expect(response).to have_http_status(200)
@@ -27,7 +27,7 @@ RSpec.describe "WorldpayMissedPaymentForms", type: :request do
         let(:registration) { create(:registration) }
 
         it "renders the new template, returns a 200 response and includes the reg identifier" do
-          get "/bo/resources/#{registration._id}/payments/worldpay-missed"
+          get "/bo/resources/#{registration._id}/payments/online-missed"
 
           expect(response).to render_template(:new)
           expect(response).to have_http_status(200)
@@ -43,14 +43,14 @@ RSpec.describe "WorldpayMissedPaymentForms", type: :request do
       end
 
       it "redirects to the permissions error page" do
-        get "/bo/resources/#{transient_registration._id}/payments/worldpay-missed"
+        get "/bo/resources/#{transient_registration._id}/payments/online-missed"
 
         expect(response).to redirect_to("/bo/pages/permission")
       end
     end
   end
 
-  describe "POST /bo/resources/:_id/payments/worldpay-missed" do
+  describe "POST /bo/resources/:_id/payments/online-missed" do
     let(:params) do
       {
         amount: transient_registration.finance_details.balance,
@@ -73,7 +73,7 @@ RSpec.describe "WorldpayMissedPaymentForms", type: :request do
         old_payments_count = registration.finance_details.payments.count
         expected_expiry_date = registration.expires_on.to_date + 3.years
 
-        post "/bo/resources/#{transient_registration._id}/payments/worldpay-missed", params: { worldpay_missed_payment_form: params }
+        post "/bo/resources/#{transient_registration._id}/payments/online-missed", params: { online_missed_payment_form: params }
 
         registration.reload
         actual_expiry_date = registration.expires_on.to_date
@@ -88,7 +88,7 @@ RSpec.describe "WorldpayMissedPaymentForms", type: :request do
         it "redirects to the registration's finance details page, creates a new payment and assigns the correct updated_by_user to the payment" do
           old_payments_count = registration.finance_details.payments.count
 
-          post "/bo/resources/#{registration._id}/payments/worldpay-missed", params: { worldpay_missed_payment_form: params }
+          post "/bo/resources/#{registration._id}/payments/online-missed", params: { online_missed_payment_form: params }
 
           registration.reload
 
@@ -106,7 +106,7 @@ RSpec.describe "WorldpayMissedPaymentForms", type: :request do
         it "does not renew the registration and redirects to the transient registration's finance details page" do
           old_renewal_date = registration.expires_on
 
-          post "/bo/resources/#{transient_registration._id}/payments/worldpay-missed", params: { worldpay_missed_payment_form: params }
+          post "/bo/resources/#{transient_registration._id}/payments/online-missed", params: { online_missed_payment_form: params }
 
           expect(registration.reload.expires_on).to eq(old_renewal_date)
           expect(response).to redirect_to(resource_finance_details_path(transient_registration._id))
@@ -123,7 +123,7 @@ RSpec.describe "WorldpayMissedPaymentForms", type: :request do
         it "renders the new template and does not create a new payment" do
           old_payments_count = transient_registration.finance_details.payments.count
 
-          post "/bo/resources/#{transient_registration._id}/payments/worldpay-missed", params: { worldpay_missed_payment_form: params }
+          post "/bo/resources/#{transient_registration._id}/payments/online-missed", params: { online_missed_payment_form: params }
 
           expect(response).to render_template(:new)
           expect(transient_registration.reload.finance_details.payments.count).to eq(old_payments_count)
@@ -140,7 +140,7 @@ RSpec.describe "WorldpayMissedPaymentForms", type: :request do
       it "redirects to the permissions error page and does not create a new payment" do
         old_payments_count = transient_registration.finance_details.payments.count
 
-        post "/bo/resources/#{transient_registration._id}/payments/worldpay-missed", params: { worldpay_missed_payment_form: params }
+        post "/bo/resources/#{transient_registration._id}/payments/online-missed", params: { online_missed_payment_form: params }
 
         expect(response).to redirect_to("/bo/pages/permission")
         expect(transient_registration.reload.finance_details.payments.count).to eq(old_payments_count)

--- a/spec/requests/online_missed_payment_new_registrations_controller_spec.rb
+++ b/spec/requests/online_missed_payment_new_registrations_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "WorldpayMissedPaymentNewRegistrations", type: :request do
   let(:transient_registration) { create(:new_registration, :has_required_data) }
   let(:_id) { transient_registration._id }
 
-  describe "GET /bo/resources/:_id/missed-worldpay-payment-new-registration" do
+  describe "GET /bo/resources/:_id/missed-online-payment-new-registration" do
     let(:user) { create(:user) }
     before(:each) do
       sign_in(user)
@@ -25,13 +25,13 @@ RSpec.describe "WorldpayMissedPaymentNewRegistrations", type: :request do
           old_new_registration_count = WasteCarriersEngine::NewRegistration.count
           expected_reg_identifier = transient_registration.reg_identifier
 
-          get "/bo/resources/#{_id}/missed-worldpay-payment-new-registration"
+          get "/bo/resources/#{_id}/missed-online-payment-new-registration"
 
           expect(WasteCarriersEngine::Registration.count).to eq(old_registration_count + 1)
           expect(WasteCarriersEngine::NewRegistration.count).to eq(old_new_registration_count - 1)
 
           registration = WasteCarriersEngine::Registration.where(reg_identifier: expected_reg_identifier).first
-          expect(response).to redirect_to new_resource_worldpay_missed_payment_form_path(registration._id)
+          expect(response).to redirect_to new_resource_online_missed_payment_form_path(registration._id)
         end
       end
 
@@ -41,7 +41,7 @@ RSpec.describe "WorldpayMissedPaymentNewRegistrations", type: :request do
         end
 
         it "renders the new registration details page" do
-          get "/bo/resources/#{_id}/missed-worldpay-payment-new-registration"
+          get "/bo/resources/#{_id}/missed-online-payment-new-registration"
 
           expect(response).to redirect_to new_registration_path(transient_registration.token)
         end
@@ -52,7 +52,7 @@ RSpec.describe "WorldpayMissedPaymentNewRegistrations", type: :request do
       let(:user) { create(:user, :agency) }
 
       it "renders the permissions error page" do
-        get "/bo/resources/#{_id}/missed-worldpay-payment-new-registration"
+        get "/bo/resources/#{_id}/missed-online-payment-new-registration"
 
         expect(response).to redirect_to "/bo/pages/permission"
       end

--- a/spec/requests/online_payment_escapes_spec.rb
+++ b/spec/requests/online_payment_escapes_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "WorldpayEscapes", type: :request do
+RSpec.describe "OnlinePaymentEscapes", type: :request do
   let(:transient_registration) { create(:renewing_registration) }
   let(:_id) { transient_registration._id }
 

--- a/spec/requests/payment_forms_spec.rb
+++ b/spec/requests/payment_forms_spec.rb
@@ -94,15 +94,15 @@ RSpec.describe "PaymentForms", type: :request do
         end
       end
 
-      context "when the payment_type is worldpay_missed" do
+      context "when the payment_type is online_missed" do
         before do
-          params[:payment_type] = "worldpay_missed"
+          params[:payment_type] = "online_missed"
         end
 
-        it "redirects to the worldpay_missed payment form" do
+        it "redirects to the online_missed payment form" do
           post "/bo/resources/#{transient_registration._id}/payments", params: { payment_form: params }
 
-          expect(response).to redirect_to(new_resource_worldpay_missed_payment_form_path(transient_registration._id))
+          expect(response).to redirect_to(new_resource_online_missed_payment_form_path(transient_registration._id))
         end
       end
 

--- a/spec/services/process_refund_service_spec.rb
+++ b/spec/services/process_refund_service_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ProcessRefundService do
     let(:worldpay) { true }
 
     before do
-      allow(payment).to receive(:worldpay?).and_return(worldpay)
+      allow(payment).to receive(:online?).and_return(worldpay)
       allow(orders).to receive(:find_by).and_return(order)
     end
 
@@ -70,7 +70,7 @@ RSpec.describe ProcessRefundService do
       let(:worldpay) { false }
 
       before do
-        allow(payment).to receive(:worldpay_missed?).and_return(false)
+        allow(payment).to receive(:online_missed?).and_return(false)
       end
 
       it "generates a new refund payment and associate it with the right finance details" do

--- a/spec/services/worldpay/refund_service_spec.rb
+++ b/spec/services/worldpay/refund_service_spec.rb
@@ -9,8 +9,8 @@ module Worldpay
     describe ".run" do
       context "when the payment is not a worldpay payment nor a worldpay_missed payment" do
         it "returns false" do
-          expect(payment).to receive(:worldpay?).and_return(false)
-          expect(payment).to receive(:worldpay_missed?).and_return(false)
+          expect(payment).to receive(:online?).and_return(false)
+          expect(payment).to receive(:online_missed?).and_return(false)
 
           expect(result).to be_falsey
         end
@@ -26,7 +26,7 @@ module Worldpay
         let(:worldpay_url) { "worldpay_url" }
 
         before do
-          allow(payment).to receive(:worldpay?).and_return(true)
+          allow(payment).to receive(:online?).and_return(true)
           allow(payment).to receive(:order_key).and_return("foo")
 
           allow(Rails.configuration).to receive(:worldpay_ecom_merchantcode).and_return(worldpay_ecom_merchantcode)

--- a/spec/services/worldpay/refund_service_spec.rb
+++ b/spec/services/worldpay/refund_service_spec.rb
@@ -7,7 +7,7 @@ module Worldpay
     let(:result) { described_class.run(payment: payment, amount: 100, merchant_code: merchant_code) }
 
     describe ".run" do
-      context "when the payment is not a worldpay payment nor a worldpay_missed payment" do
+      context "when the payment is not a worldpay payment nor a online_missed payment" do
         it "returns false" do
           expect(payment).to receive(:online?).and_return(false)
           expect(payment).to receive(:online_missed?).and_return(false)

--- a/spec/support/shared_examples/abilities/finance_admin_examples.rb
+++ b/spec/support/shared_examples/abilities/finance_admin_examples.rb
@@ -4,7 +4,7 @@ RSpec.shared_examples "finance_admin examples" do
   # finance_admin and finance_super users should be able to do this:
 
   it "should be able to record a worldpay payment" do
-    should be_able_to(:record_worldpay_missed_payment, WasteCarriersEngine::RenewingRegistration)
+    should be_able_to(:record_online_missed_payment, WasteCarriersEngine::RenewingRegistration)
   end
 
   it "should be able to view the certificate" do
@@ -24,8 +24,8 @@ RSpec.shared_examples "finance_admin examples" do
       end
     end
 
-    context "when the payment is a worldpay_missed" do
-      let(:payment) { build(:payment, :worldpay_missed) }
+    context "when the payment is a online_missed" do
+      let(:payment) { build(:payment, :online_missed) }
 
       it "should be able to reverse the payment" do
         should be_able_to(:reverse, payment)

--- a/spec/support/shared_examples/abilities/finance_examples.rb
+++ b/spec/support/shared_examples/abilities/finance_examples.rb
@@ -93,7 +93,7 @@ RSpec.shared_examples "finance examples" do
   end
 
   it "should not be able to record a worldpay payment" do
-    should_not be_able_to(:record_worldpay_missed_payment, WasteCarriersEngine::RenewingRegistration)
+    should_not be_able_to(:record_online_missed_payment, WasteCarriersEngine::RenewingRegistration)
   end
 
   it "should not be able to review convictions" do


### PR DESCRIPTION
These changes are a preparatory step for migration from Worldpay to GovPay. The aim is to separate general online-payments logic from Worldpay-specific logic.
Changes include:
- Rename classes referencing “worldpay” which are about online payments in general and not worldpay specifically.
- Rename keys (not values) which reference worldpay in locale files.
- Changes to the following are specifically avoided:
- Names of worldpay-specific classes.
- Database schema (implied) or contents - i.e. the database still has contents such as payment_status: "WORLDPAY_MISSED".
- Environment settings
- Locale file values (as opposed to keys)
- Anticipatory refactoring based on assumptions about how GovPay integration will be implemented.

https://eaflood.atlassian.net/browse/RUBY-1848