### PR TITLE
Add restart renewal action

### DIFF
--- a/app/controllers/renewing_registrations_controller.rb
+++ b/app/controllers/renewing_registrations_controller.rb
@@ -17,6 +17,14 @@ class RenewingRegistrationsController < ApplicationController
     @transient_registration = RenewingRegistrationPresenter.new(transient_registration, view_context)
   end
 
+  def restart_renewal
+    reg_identifier = params[:reg_identifier]
+
+    WasteCarriersEngine::RenewingRegistration.where(reg_identifier: reg_identifier).destroy
+
+    redirect_back(fallback_location: registration_path(reg_identifier))
+  end
+
   private
 
   def fetch_renewing_registration

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -103,6 +103,13 @@ module ActionLinksHelper
     resource.active? && resource.upper_tier?
   end
 
+  def display_restart_renewal_link_for?(resource)
+    return false unless display_registration_links?(resource)
+    return false unless can?(:edit, WasteCarriersEngine::Registration)
+
+    WasteCarriersEngine::RenewingRegistration.where(reg_identifier: resource.reg_identifier).count.positive?
+  end
+
   def display_refresh_registered_company_name_link_for?(resource)
     return false unless display_edit_link_for?(resource)
 

--- a/app/presenters/registration_transfer_presenter.rb
+++ b/app/presenters/registration_transfer_presenter.rb
@@ -28,6 +28,6 @@ class RegistrationTransferPresenter < WasteCarriersEngine::BasePresenter
   private
 
   def to_yml(key, options = {})
-    I18n.t(".registration_transfers.new.#{key}", options)
+    I18n.t(".registration_transfers.new.#{key}", **options)
   end
 end

--- a/app/views/shared/registrations/_action_links_panel.html.erb
+++ b/app/views/shared/registrations/_action_links_panel.html.erb
@@ -72,6 +72,14 @@
       </li>
     <% end %>
 
+    <% if display_restart_renewal_link_for?(resource) %>
+      <li>
+        <%= link_to t(".actions_box.links.restart_renewal"),
+                      renewing_registration_restart_renewal_path(resource.reg_identifier),
+                      method: :delete %>
+      </li>
+    <% end %>
+
     <% if display_refresh_registered_company_name_link_for?(resource) %>
       <li>
         <%= link_to t(".actions_box.links.refresh_companies_house"),

--- a/config/locales/shared/registrations.en.yml
+++ b/config/locales/shared/registrations.en.yml
@@ -80,6 +80,7 @@ en:
             payment_details: "Payment details"
             process_payment: "Process payment"
             revoke: "Cease or revoke"
+            restart_renewal: "Restart renewal"
             refresh_companies_house: "Refresh registered company name from Companies House"
       expired_panel:
         heading: "Expired on %{date}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -194,7 +194,7 @@ Rails.application.routes.draw do
       to: "convictions#begin_checks",
       as: :transient_registration_convictions_begin_checks
 
-  delete "/bo/renewing-registrations/:reg_identifier/restart_renewal",
+  delete "/bo/renewing-registrations/:reg_identifier/renewal",
          to: "renewing_registrations#restart_renewal",
          as: :renewing_registration_restart_renewal
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -194,6 +194,10 @@ Rails.application.routes.draw do
       to: "convictions#begin_checks",
       as: :transient_registration_convictions_begin_checks
 
+  delete "/bo/renewing-registrations/:reg_identifier/restart_renewal",
+         to: "renewing_registrations#restart_renewal",
+         as: :renewing_registration_restart_renewal
+
   get "/bo/users",
       to: "users#index",
       as: :users

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -721,6 +721,42 @@ RSpec.describe ActionLinksHelper, type: :helper do
     end
   end
 
+  describe "#display_restart_renewal_link_for?" do
+    let(:resource) { build(:registration) }
+
+    before do
+      allow(helper).to receive(:can?).with(:edit, WasteCarriersEngine::Registration).and_return(can)
+    end
+
+    context "when the user has permission for editing" do
+      let(:can) { true }
+
+      context "when a renewal is not in progress" do
+        it "returns false" do
+          expect(helper.display_restart_renewal_link_for?(resource)).to be_falsey
+        end
+      end
+
+      context "when a renewal is in progress" do
+        let(:renewing_registration) { create(:renewing_registration) }
+
+        before { resource.reg_identifier = renewing_registration.reg_identifier }
+
+        it "returns true" do
+          expect(helper.display_restart_renewal_link_for?(resource)).to be_truthy
+        end
+      end
+    end
+
+    context "when the user does not have permission for editing" do
+      let(:can) { false }
+
+      it "returns false" do
+        expect(helper.display_refresh_registered_company_name_link_for?(resource)).to be_falsey
+      end
+    end
+  end
+
   describe "#display_finance_details_link_for?" do
     let(:resource) { double(:resource) }
     let(:upper_tier) { true }

--- a/spec/presenters/registration_transfer_presenter_spec.rb
+++ b/spec/presenters/registration_transfer_presenter_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe RegistrationTransferPresenter do
     end
 
     def message_for(key, options = {})
-      I18n.t(".registration_transfers.new.#{key}", options)
+      I18n.t(".registration_transfers.new.#{key}", **options)
     end
   end
 end

--- a/spec/requests/refresh_companies_house_spec.rb
+++ b/spec/requests/refresh_companies_house_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Refunds", type: :request do
+RSpec.describe "Refresh companies house", type: :request do
   describe "PATCH /bo/registrations/:reg_identifier/companies_house_details" do
 
     subject { patch registration_companies_house_details_path(registration.reg_identifier) }

--- a/spec/requests/restart_renewal_spec.rb
+++ b/spec/requests/restart_renewal_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Restart renewal", type: :request do
+  describe "DELETE /bo/renewing-registrations/:reg_identifier/restart_renewal" do
+
+    subject { delete renewing_registration_restart_renewal_path(registration.reg_identifier) }
+
+    RSpec.shared_examples "all restart renewal requests" do
+
+      it "redirects to the same page" do
+        subject
+        expect(response.status).to eq 302
+        expect(response.location).to end_with registration_path(registration.reg_identifier)
+      end
+    end
+
+    let(:user) { create(:user) }
+    # Force creation of the registration before calling subject so that the check for changes to Registration.count is valid
+    let!(:registration) { create(:registration) }
+
+    before { sign_in(user) }
+
+    context "with no renewal in progress" do
+      it_behaves_like "all restart renewal requests"
+
+      it "does not delete any registrations or transient_registrations" do
+        expect { subject }.not_to change { WasteCarriersEngine::Registration.count }
+        expect { subject }.not_to change { WasteCarriersEngine::TransientRegistration.count }
+      end
+    end
+
+    context "with a renewal in progress" do
+      let(:renewing_registration) { create(:renewing_registration) }
+
+      before { registration.reg_identifier = renewing_registration.reg_identifier }
+
+      it_behaves_like "all restart renewal requests"
+
+      it "deletes the renewing registration" do
+        expect { subject }.to change { WasteCarriersEngine::RenewingRegistration.count }.from(1).to(0)
+      end
+    end
+  end
+end

--- a/spec/requests/restart_renewal_spec.rb
+++ b/spec/requests/restart_renewal_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "Restart renewal", type: :request do
-  describe "DELETE /bo/renewing-registrations/:reg_identifier/restart_renewal" do
+  describe "DELETE /bo/renewing-registrations/:reg_identifier/renewal" do
 
     subject { delete renewing_registration_restart_renewal_path(registration.reg_identifier) }
 

--- a/spec/services/conviction_import_service_spec.rb
+++ b/spec/services/conviction_import_service_spec.rb
@@ -76,7 +76,11 @@ Apex Limited,,11111111,ABC,99999999
     end
 
     context "when valid CSV data is not provided" do
-      let(:csv) { :not_a_csv }
+      # Use an object with a close method so that forwardable does not complain about forwarding to a private method.
+      class NotCsv
+        def close; end
+      end
+      let(:csv) { NotCsv.new }
 
       it "raises an InvalidCSVError and doesn't update any conviction data" do
         old_conviction = WasteCarriersEngine::ConvictionsCheck::Entity.where(name: old_conviction_name)

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -7,7 +7,7 @@ RSpec.configure do |config|
   # Clean the registrations and users databases before running tests
   config.before(:suite) do
     DatabaseCleaner[:mongoid].strategy = :deletion
-    DatabaseCleaner[:mongoid, { db: :users }].strategy = :deletion
+    DatabaseCleaner[:mongoid, **{ db: :users }].strategy = :deletion
 
     DatabaseCleaner.clean
   end


### PR DESCRIPTION
This change adds a new action for back-office users with the `agency_user` role to restart an in-progress renewal. An example of when this might need to be done is where an in-progress renewal gets stuck in an invalid state, for example after deploying a change which renders the `renewing_registration`'s existing workflow_state invalid.
The action item is displayed in the registration details view, only for registrations which have a renewal in progress, i.e. `registrations` with an associated `renewing_registration`.
The implementation deletes any existing `renewing_registration` for the current registration.
https://eaflood.atlassian.net/browse/RUBY-1867