### PR TITLE
Export metaData.route to boxi as 'assistance_mode' with mapping

### DIFF
--- a/app/models/reports/boxi/registrations_serializer.rb
+++ b/app/models/reports/boxi/registrations_serializer.rb
@@ -24,7 +24,7 @@ module Reports
         metadata_date_activated: "ActivationTimestamp",
         expires_on: "ExpiryTimestamp",
         metadata_date_last_modified: "LastModifiedTimestamp",
-        metadata_route: "Route",
+        assistance_mode: "AssistanceMode",
         other_businesses: "OtherBusinesses",
         is_main_service: "IsMainService",
         construction_waste: "ConstructionWaste",

--- a/app/presenters/reports/boxi/registration_presenter.rb
+++ b/app/presenters/reports/boxi/registration_presenter.rb
@@ -30,6 +30,19 @@ module Reports
         metadata&.last_modified&.to_datetime&.to_formatted_s(:calendar_date_and_local_time)
       end
 
+      def assistance_mode
+        case metaData&.route
+        when "DIGITAL"
+          "Unassisted"
+        when "ASSISTED_DIGITAL_FROM_TRANSIENT_REGISTRATION"
+          "Partially assisted"
+        when "ASSISTED_DIGITAL"
+          "Fully assisted"
+        else
+          ""
+        end
+      end
+
       def conviction_search_result_searched_at
         conviction_search_result&.searched_at&.to_datetime&.to_formatted_s(:calendar_date_and_local_time)
       end

--- a/spec/models/reports/boxi/registrations_serializer_spec.rb
+++ b/spec/models/reports/boxi/registrations_serializer_spec.rb
@@ -29,7 +29,7 @@ module Reports
           ActivationTimestamp
           ExpiryTimestamp
           LastModifiedTimestamp
-          Route
+          AssistanceMode
           OtherBusinesses
           IsMainService
           ConstructionWaste
@@ -69,7 +69,7 @@ module Reports
             "metadata_date_activated",
             "expires_on",
             "metadata_date_last_modified",
-            "metadata_route",
+            "assistance_mode",
             "other_businesses",
             "is_main_service",
             "construction_waste",
@@ -101,7 +101,7 @@ module Reports
           expect(presenter).to receive(:metadata_date_activated).and_return("metadata_date_activated")
           expect(presenter).to receive(:expires_on).and_return("expires_on")
           expect(presenter).to receive(:metadata_date_last_modified).and_return("metadata_date_last_modified")
-          expect(presenter).to receive(:metadata_route).and_return("metadata_route")
+          expect(presenter).to receive(:assistance_mode).and_return("assistance_mode")
           expect(presenter).to receive(:other_businesses).and_return("other_businesses")
           expect(presenter).to receive(:is_main_service).and_return("is_main_service")
           expect(presenter).to receive(:construction_waste).and_return("construction_waste")

--- a/spec/presenters/reports/boxi/registration_presenter_spec.rb
+++ b/spec/presenters/reports/boxi/registration_presenter_spec.rb
@@ -53,6 +53,38 @@ module Reports
         end
       end
 
+      describe "assistance_mode" do
+        let(:metadata) { double(:metadata) }
+
+        before do
+          allow(registration).to receive(:metaData).and_return(metadata)
+        end
+
+        context "for an unassisted registration" do
+          before { allow(metadata).to receive(:route).and_return("DIGITAL") }
+
+          it "returns 'Unassisted'" do
+            expect(subject.assistance_mode).to eq("Unassisted")
+          end
+        end
+
+        context "for a fully assisted registration" do
+          before { allow(metadata).to receive(:route).and_return("ASSISTED_DIGITAL") }
+
+          it "returns 'Fully assisted'" do
+            expect(subject.assistance_mode).to eq("Fully assisted")
+          end
+        end
+
+        context "for a partially assisted registration" do
+          before { allow(metadata).to receive(:route).and_return("ASSISTED_DIGITAL_FROM_TRANSIENT_REGISTRATION") }
+
+          it "returns 'Partially assisted'" do
+            expect(subject.assistance_mode).to eq("Partially assisted")
+          end
+        end
+      end
+
       describe "#conviction_search_result_searched_at" do
         it "returns a formatted date" do
           conviction_search_result = double(:conviction_search_result)


### PR DESCRIPTION
This change modifies the WCR BOXI export to map the internal metaData.route values to a new `assistance_mode` column in the registrations extract, with mapping ov values to align with WEX.
https://eaflood.atlassian.net/browse/RUBY-1988
