### PR TITLE
Add namespace to OrderPresenter to avoid intermittent CI failures

### DIFF
--- a/spec/models/reports/boxi/orders_serializer_spec.rb
+++ b/spec/models/reports/boxi/orders_serializer_spec.rb
@@ -43,7 +43,7 @@ module Reports
             "updated_by_user"
           ]
 
-          expect(OrderPresenter).to receive(:new).with(order, nil).and_return(presenter)
+          expect(Boxi::OrderPresenter).to receive(:new).with(order, nil).and_return(presenter)
 
           expect(presenter).to receive(:order_code).and_return("order_code")
           expect(presenter).to receive(:payment_method).and_return("payment_method")


### PR DESCRIPTION
This bug fixes resolves an intermittent unit test failure by adding the `Boxi` namespace when mocking `OrderPresenter` in an `OrderSerializer` unit test.
https://eaflood.atlassian.net/browse/RUBY-2037 