### PR TITLE
Add renewal stats to the monthly finance report

### DIFF
--- a/app/models/reports/daily_finance_report_serializer.rb
+++ b/app/models/reports/daily_finance_report_serializer.rb
@@ -4,7 +4,7 @@ module Reports
   # This class simply adds an entry for "day" in the correct position to the monthly report attributes.
   class DailyFinanceReportSerializer < MonthlyFinanceReportSerializer
     pre_day_attributes = MonthlyFinanceReportSerializer::ATTRIBUTES.slice(:period, :year, :month)
-    post_day_attributes = MonthlyFinanceReportSerializer::ATTRIBUTES.except(:period, :year, :month)
+    post_day_attributes = MonthlyFinanceReportSerializer::ATTRIBUTES.except(:period, :year, :month, :renewals_due, :renewal_percent)
     ATTRIBUTES = pre_day_attributes.merge(day: "day").merge(post_day_attributes).freeze
   end
 end

--- a/app/models/reports/daily_finance_report_serializer.rb
+++ b/app/models/reports/daily_finance_report_serializer.rb
@@ -3,8 +3,21 @@
 module Reports
   # This class simply adds an entry for "day" in the correct position to the monthly report attributes.
   class DailyFinanceReportSerializer < MonthlyFinanceReportSerializer
-    pre_day_attributes = MonthlyFinanceReportSerializer::ATTRIBUTES.slice(:period, :year, :month)
-    post_day_attributes = MonthlyFinanceReportSerializer::ATTRIBUTES.except(:period, :year, :month, :renewals_due, :renewal_percent)
+
+    pre_day_attributes = MonthlyFinanceReportSerializer::ATTRIBUTES.slice(
+      :period,
+      :year,
+      :month
+    )
+
+    post_day_attributes = MonthlyFinanceReportSerializer::ATTRIBUTES.except(
+      :period,
+      :year,
+      :month,
+      :renewals_due,
+      :renewal_percent
+    )
+
     ATTRIBUTES = pre_day_attributes.merge(day: "day").merge(post_day_attributes).freeze
   end
 end

--- a/app/models/reports/monthly_finance_report_serializer.rb
+++ b/app/models/reports/monthly_finance_report_serializer.rb
@@ -7,6 +7,8 @@ module Reports
       year: "year",
       month: "month",
       balance: "balance",
+      renewals_due: "renewals_due",
+      renewal_percent: "renewal_percent",
       pay_cnt: "pay_cnt",
       pay_bal: "pay_bal",
       pay_cash_cnt: "pay_cash_cnt",

--- a/app/presenters/reports/finance_report_presenter.rb
+++ b/app/presenters/reports/finance_report_presenter.rb
@@ -14,10 +14,15 @@ module Reports
       pence.zero? ? "0" : display_pence_as_pounds_and_cents(pence)
     end
 
+    def percent(ratio)
+      ratio.present? ? format("%<ratio>2.1f%%", ratio: ratio * 100.0) : "0.0"
+    end
+
     # These simple methods are easier to scan if defined on one line and without spaces between them.
     # rubocop:disable Style/SingleLineMethods
     # rubocop:disable Layout/EmptyLineBetweenDefs
     def balance()                pounds(@row[:balance]) end
+    def renewal_percent()        percent(@row[:renew_ratio]) end
     def pay_cnt()                @row[:payments][:count] end
     def pay_bal()                pounds(@row[:payments][:balance]) end
     def pay_cash_cnt()           @row[:payments][:cash][:count] end

--- a/spec/models/reports/monthly_finance_report_serializer_spec.rb
+++ b/spec/models/reports/monthly_finance_report_serializer_spec.rb
@@ -15,7 +15,7 @@ module Reports
       subject { MonthlyFinanceReportSerializer.new(finance_stats).to_csv }
 
       it "includes all expected columns only" do
-        expect(subject).to include("period,year,month,balance,pay_cnt,pay_bal,pay_cash_cnt,pay_cash_tot,pay_reversal_cnt,pay_reversal_tot,pay_postalorder_cnt,pay_postalorder_tot,pay_refund_cnt,pay_refund_tot,pay_worldpay_cnt,pay_worldpay_tot,pay_worldpaymissed_cnt,pay_worldpaymissed_tot,pay_cheque_cnt,pay_cheque_tot,pay_banktransfer_cnt,pay_banktransfer_tot,pay_writeoffsmall_cnt,pay_writeoffsmall_tot,pay_writeofflarge_cnt,pay_writeofflarge_tot,chg_cnt,chg_bal,chg_chargeadjust_cnt,chg_chargeadjust_tot,chg_copycards_cnt,chg_copycards_tot,chg_new_cnt,chg_new_tot,chg_renew_cnt,chg_renew_tot,chg_edit_cnt,chg_edit_tot,chg_irimport_cnt,chg_irimport_tot")
+        expect(subject).to include("period,year,month,balance,renewals_due,renewal_percent,pay_cnt,pay_bal,pay_cash_cnt,pay_cash_tot,pay_reversal_cnt,pay_reversal_tot,pay_postalorder_cnt,pay_postalorder_tot,pay_refund_cnt,pay_refund_tot,pay_worldpay_cnt,pay_worldpay_tot,pay_worldpaymissed_cnt,pay_worldpaymissed_tot,pay_cheque_cnt,pay_cheque_tot,pay_banktransfer_cnt,pay_banktransfer_tot,pay_writeoffsmall_cnt,pay_writeoffsmall_tot,pay_writeofflarge_cnt,pay_writeofflarge_tot,chg_cnt,chg_bal,chg_chargeadjust_cnt,chg_chargeadjust_tot,chg_copycards_cnt,chg_copycards_tot,chg_new_cnt,chg_new_tot,chg_renew_cnt,chg_renew_tot,chg_edit_cnt,chg_edit_tot,chg_irimport_cnt,chg_irimport_tot")
       end
 
       it "includes registration payment amounts in pounds" do

--- a/spec/presenters/reports/finance_report_presenter_spec.rb
+++ b/spec/presenters/reports/finance_report_presenter_spec.rb
@@ -12,6 +12,8 @@ module Reports
         month: "09",
         day: "12",
         balance: Faker::Number.number(digits: 4),
+        renewals_due: Faker::Number.number(digits: 2),
+        renewal_percent: Faker::Number.between(from: 0.0, to: 1.0),
         payments: {
           count: Faker::Number.number(digits: 2),
           balance: Faker::Number.number(digits: 4),
@@ -109,6 +111,10 @@ module Reports
       expect(subject.chg_renew_tot).to eq format("%<val>.2f", val: row[:charges][:renew][:total] / 100.0)
       expect(subject.chg_edit_tot).to eq format("%<val>.2f", val: row[:charges][:edit][:total] / 100.0)
       expect(subject.chg_irimport_tot).to eq format("%<val>.2f", val: row[:charges][:irimport][:total] / 100.0)
+    end
+
+    it "presents percentage amounts in the correct format" do
+      expect(subject.renewal_percent).to eq format("%<val>2.1f", val: row[:renewal_percent] / 100.0)
     end
   end
 end

--- a/spec/support/shared_contexts/finance_stats_order_data.rb
+++ b/spec/support/shared_contexts/finance_stats_order_data.rb
@@ -5,9 +5,30 @@ RSpec.shared_context "Finance stats order data" do
 
   let(:order_data) do
     [
+      # Include values for 36 months prior to the core test period, to allow for exipiries
+      { date: 41.months.ago,
+        orders: [
+          { "NEW": 10_500 },
+          { "NEW": 10_500, "COPY_CARDS": 1500 },
+          { "COPY_CARDS": 1500 },
+          { "RENEW": 10_000, "COPY_CARDS": 2500 },
+          { "CHARGE_ADJUST": 1200 }
+        ] },
+      { date: 40.months.ago,
+        orders: [
+          { "NEW": 10_500 },
+          { "COPY_CARDS": 1500 },
+          { "RENEW": 10_000 },
+          { "EDIT": 2500 }
+        ] },
+      { date: 39.months.ago,
+        orders: [
+          { "NEW": 10_500 },
+          { "RENEW": 10_000 },
+          { "RENEW": 10_000 }
+        ] },
       { date: 5.months.ago,
         orders: [
-          # create one charge_adjust order for STG12, one new registration order with copy cards, etc.
           { "CHARGE_ADJUST": 1200 },
           { "NEW": 10_500, "COPY_CARDS": 1500 },
           { "NEW": 10_500 },


### PR DESCRIPTION
This change adds `renewals_due` and `renewal_percent` columns to the monthly form of the finance report.  The former represents the number of registrations and renewals completed 36 months previously; the latter represents the ratio of actual registrations in the month to the `renewals_due` value, as a percentage.
https://eaflood.atlassian.net/browse/RUBY-2021