### PR TITLE
Hide worldpay refunds if govpay active and vice-versa

### DIFF
--- a/app/controllers/refunds_controller.rb
+++ b/app/controllers/refunds_controller.rb
@@ -11,7 +11,10 @@ class RefundsController < ApplicationController
   before_action :fetch_payment, only: %i[new create]
 
   def index
-    payments = @resource.finance_details.payments.refundable
+    # Do not list worldpay payments if govpay is active, and vice-versa.
+    payments = @resource.finance_details.payments.refundable.reject do |payment|
+      payment.payment_type == (WasteCarriersEngine::FeatureToggle.active?(:govpay_payments) ? "WORLDPAY" : "GOVPAY")
+    end
     @payments = ::PaymentPresenter.create_from_collection(payments, view_context)
   end
 

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -56,6 +56,10 @@ module ActionLinksHelper
   def display_refund_link_for?(resource)
     return false if resource.balance >= 0
 
+    # Display the link only if there is at least one payment of the relevant type
+    refundable_type = WasteCarriersEngine::FeatureToggle.active?(:govpay_payments) ? "GOVPAY" : "WORLDPAY"
+    return false if resource.payments.find { |payment| payment.payment_type == refundable_type }.nil?
+
     can?(:refund, resource)
   end
 

--- a/spec/factories/finance_details.rb
+++ b/spec/factories/finance_details.rb
@@ -30,13 +30,11 @@ FactoryBot.define do
       after(:build, :create, &:update_balance)
     end
 
+    # TODO: When retiring worldpay code, retire this trait in favour of the _govpay version below.
     trait :has_overpaid_order_and_payment do
       orders { [build(:order, :has_required_data)] }
       payments do
-        [
-          build(:payment, payment_type, date_entered: payment_date_entered, amount: 100_500),
-          build(:payment, payment_type, date_entered: payment_date_entered, amount: 500)
-        ]
+        [build(:payment, :worldpay, date_entered: payment_date_entered, world_pay_payment_status: "AUTHORISED", amount: 100_500)]
       end
       after(:build, :create, &:update_balance)
     end
@@ -44,10 +42,7 @@ FactoryBot.define do
     trait :has_overpaid_order_and_payment_govpay do
       orders { [build(:order, :has_required_data)] }
       payments do
-        [
-          build(:payment, :bank_transfer, amount: 100_500),
-          build(:payment, :bank_transfer, amount: 500)
-        ]
+        [build(:payment, :govpay, date_entered: payment_date_entered, govpay_payment_status: "success", amount: 100_500)]
       end
       after(:build, :create, &:update_balance)
     end


### PR DESCRIPTION
This change prevents the display of worldpay payments for refunding if govpay is active, and vice-versa.
https://eaflood.atlassian.net/browse/RUBY-2031