### PR TITLE
Use main engine branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ gem "defra_ruby_aws", "~> 0.5"
 # Use the waste carriers engine for the user journey
 gem "waste_carriers_engine",
     git: "https://github.com/DEFRA/waste-carriers-engine",
-    branch: "govpay"
+    branch: "main"
 
 # Use the Defra Ruby Features gem to allow users with the correct permissions to
 # manage feature toggle (create / update / delete) from the back-office.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: f1776b30a4ec717aa22069d7d1ee3c174945b38f
-  branch: govpay
+  revision: d814858d4dfda03a2fae7994d924af329a65cdba
+  branch: main
   specs:
     waste_carriers_engine (0.0.1)
       aasm (~> 4.12)


### PR DESCRIPTION
This corrects the engine branch to `main` instead of `govpay`.
https://eaflood.atlassian.net/browse/RUBY-2117