### PR TITLE
Track partially assisted digital

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: bb4d6b33e83caf88b018838e97dc2498f2e7bf1d
+  revision: b122002713a6309e1288df197b44922f7aad8896
   branch: main
   specs:
     waste_carriers_engine (0.0.1)
@@ -312,7 +312,7 @@ GEM
     nokogiri (1.13.8)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
-    notifications-ruby-client (5.3.0)
+    notifications-ruby-client (5.4.0)
       jwt (>= 1.5, < 3)
     octokit (4.21.0)
       faraday (>= 0.9)

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -13,6 +13,12 @@ module ActionLinksHelper
   end
 
   def resume_link_for(resource)
+    # If metaData.route is nil, the registration was started in the front-office
+    if resource.metaData.route.blank?
+      resource.metaData.route = "partial"
+      resource.save
+    end
+
     return ad_privacy_policy_path(token: resource.token) if a_new_registration?(resource)
 
     ad_privacy_policy_path(reg_identifier: resource.reg_identifier)

--- a/app/presenters/reports/boxi/registration_presenter.rb
+++ b/app/presenters/reports/boxi/registration_presenter.rb
@@ -34,7 +34,7 @@ module Reports
         case metaData&.route
         when "DIGITAL"
           "Unassisted"
-        when "ASSISTED_DIGITAL_FROM_TRANSIENT_REGISTRATION"
+        when "PARTIALLY_ASSISTED_DIGITAL"
           "Partially assisted"
         when "ASSISTED_DIGITAL"
           "Fully assisted"

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -100,12 +100,31 @@ RSpec.describe ActionLinksHelper, type: :helper do
   end
 
   describe "resume_link_for" do
+
+    shared_examples "metaData.route updates" do
+      context "when the registration was started in the back office" do
+        it "does not change metaData.route" do
+          expect { helper.resume_link_for(resource) }.not_to change { resource.metaData.route }
+        end
+      end
+
+      context "when the registration was started in the front office" do
+        before { resource.metaData.route = nil }
+
+        it "changes the assistance mode to partial" do
+          expect { helper.resume_link_for(resource) }.to change { resource.metaData.route }.to("partial")
+        end
+      end
+    end
+
     context "when the resource is a new_registration" do
       let(:resource) { build(:new_registration) }
 
       it "returns the correct path" do
         expect(helper.resume_link_for(resource)).to eq(ad_privacy_policy_path(token: resource.token))
       end
+
+      it_behaves_like "metaData.route updates"
     end
 
     context "when the resource is a renewing_registration" do
@@ -114,6 +133,8 @@ RSpec.describe ActionLinksHelper, type: :helper do
       it "returns the correct path" do
         expect(helper.resume_link_for(resource)).to eq(ad_privacy_policy_path(reg_identifier: resource.reg_identifier))
       end
+
+      it_behaves_like "metaData.route updates"
     end
   end
 

--- a/spec/presenters/reports/boxi/registration_presenter_spec.rb
+++ b/spec/presenters/reports/boxi/registration_presenter_spec.rb
@@ -77,7 +77,7 @@ module Reports
         end
 
         context "with a partially assisted registration" do
-          before { allow(metadata).to receive(:route).and_return("ASSISTED_DIGITAL_FROM_TRANSIENT_REGISTRATION") }
+          before { allow(metadata).to receive(:route).and_return("PARTIALLY_ASSISTED_DIGITAL") }
 
           it "returns 'Partially assisted'" do
             expect(subject.assistance_mode).to eq("Partially assisted")


### PR DESCRIPTION
This change updates metaData.route to track partial AD registrations/renewals, i.e. ones which are started in the front-office and completed in the back-office.
https://eaflood.atlassian.net/browse/RUBY-2001