### PR TITLE
Check metaData.route DIGITAL as part of partial AD logic

### DIFF
--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -13,8 +13,8 @@ module ActionLinksHelper
   end
 
   def resume_link_for(resource)
-    # If metaData.route is nil, the registration was started in the front-office
-    if resource.metaData.route.blank?
+    # If metaData.route is nil or DIGITAL, the registration was started in the front-office
+    if resource.metaData.route.blank? || resource.metaData.route == "DIGITAL"
       resource.metaData.route = "partial"
       resource.save
     end

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -108,8 +108,16 @@ RSpec.describe ActionLinksHelper, type: :helper do
         end
       end
 
-      context "when the registration was started in the front office" do
+      context "when the registration was started in the front office with a nil route" do
         before { resource.metaData.route = nil }
+
+        it "changes the assistance mode to partial" do
+          expect { helper.resume_link_for(resource) }.to change { resource.metaData.route }.to("partial")
+        end
+      end
+
+      context "when the registration was started in the front office with route = DIGITAL" do
+        before { resource.metaData.route = "DIGITAL" }
 
         it "changes the assistance mode to partial" do
           expect { helper.resume_link_for(resource) }.to change { resource.metaData.route }.to("partial")


### PR DESCRIPTION
The default metaData.route is set in some FO environments and not others. This change checks whether the route is either nil or "DIGITAL" when a registration is resumed, and if so, changes it to "partial".
https://eaflood.atlassian.net/browse/RUBY-2001