### PR TITLE
Add CSV export of user list

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -12,9 +12,16 @@ class UsersController < ApplicationController
   def all
     authorize! :manage_back_office_users, current_user
 
-    @users = User.all.order_by(email: :asc).page(params[:page]).per(100)
+    respond_to do |format|
+      format.html do
+        @users = User.all.order_by(email: :asc).page(params[:page]).per(100)
+        @show_all_users = true
+        render :index
+      end
 
-    @show_all_users = true
-    render :index
+      format.csv do
+        send_data Reports::UserExportSerializer.new.to_csv, filename: "users.csv"
+      end
+    end
   end
 end

--- a/app/models/reports/user_export_serializer.rb
+++ b/app/models/reports/user_export_serializer.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Reports
+  class UserExportSerializer < BaseSerializer
+    ATTRIBUTES = {
+      email: "Email Address",
+      status: "Status",
+      current_sign_in_at: "Last Logged In",
+      invitation_accepted_at: "Invitation Accepted"
+    }.freeze
+
+    private
+
+    def scope
+      User.all
+    end
+
+    def parse_object(user)
+      presenter = Reports::UserPresenter.new(user)
+
+      ATTRIBUTES.map do |key, _value|
+        presenter.public_send(key)
+      end
+    end
+  end
+end

--- a/app/presenters/reports/user_presenter.rb
+++ b/app/presenters/reports/user_presenter.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Reports
+  class UserPresenter < WasteCarriersEngine::BasePresenter
+    DATETIME_FORMAT = Time::DATE_FORMATS[:day_month_year_time_slashes]
+
+    def initialize(model)
+      @user = model
+      super(model)
+    end
+
+    def current_sign_in_at
+      @user.current_sign_in_at&.strftime(DATETIME_FORMAT)
+    end
+
+    def invitation_accepted_at
+      @user.invitation_accepted_at&.strftime(DATETIME_FORMAT)
+    end
+
+    def email
+      @user.email
+    end
+
+    def status
+      return "Active" if @user.active?
+      return "Invitation Sent" if @user.invitation_sent_at.present?
+
+      "Deactivated"
+    end
+  end
+end

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -15,6 +15,10 @@
         <%= link_to t(".options.show_all_users"), all_users_path %>
       <% end %>
     </p>
+
+    <p class="govuk-body">
+      <%= link_to t(".options.export_users_csv"), all_users_path(format: :csv) %>
+    </p>
   </div>
 </div>
 

--- a/config/locales/users.en.yml
+++ b/config/locales/users.en.yml
@@ -4,6 +4,7 @@ en:
       title: "Manage back office users"
       heading: "Manage back office users"
       options:
+        export_users_csv: "Export user list to CSV"
         invite_link: "Invite a new user"
         show_all_users: "Show all users"
         show_enabled_users_only: "Show enabled users only"

--- a/spec/models/reports/user_export_serializer_spec.rb
+++ b/spec/models/reports/user_export_serializer_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Reports::UserExportSerializer do
+  let(:active_user) do
+    create(
+      :user,
+      active: true,
+      current_sign_in_at: Time.at(0).utc,
+      invitation_accepted_at: Time.at(0).utc
+    )
+  end
+
+  let(:invited_user) do
+    create(
+      :user,
+      active: false,
+      invitation_sent_at: Time.at(0).utc,
+      invitation_accepted_at: Time.at(0).utc
+    )
+  end
+
+  let(:inactive_user) do
+    create(:user, active: false)
+  end
+
+  describe "#to_csv" do
+    subject { described_class.new.to_csv }
+
+    let(:expected_columns) do
+      [
+        "Email Address",
+        "Status",
+        "Last Logged In",
+        "Invitation Accepted"
+      ]
+    end
+
+    before do
+      active_user
+      inactive_user
+      invited_user
+    end
+
+    it "includes the expected header" do
+      expect(subject).to include(expected_columns.map { |title| "\"#{title}\"" }.join(","))
+    end
+
+    it "includes the correct number of rows" do
+      expect(subject.split("\n").length).to eq(User.count + 1)
+    end
+
+    it "correctly includes active users" do
+      expect(subject.scan(active_user.email).size).to eq(1)
+
+      CSV.parse(subject).detect { |row| row.first == active_user.email }.tap do |row|
+        expect(row[0]).to eq(active_user.email)
+        expect(row[1]).to eq("Active")
+        expect(row[2]).to eq("01/01/1970 00:00")
+        expect(row[3]).to eq("01/01/1970 00:00")
+      end
+    end
+
+    it "correctly includes inactive users" do
+      expect(subject.scan(inactive_user.email).size).to eq(1)
+
+      CSV.parse(subject).detect { |row| row.first == inactive_user.email }.tap do |row|
+        expect(row[0]).to eq(inactive_user.email)
+        expect(row[1]).to eq("Deactivated")
+        expect(row[2]).to eq("")
+        expect(row[3]).to eq("")
+      end
+    end
+
+    it "correctly includes inactive users with a sent invitation" do
+      expect(subject.scan(invited_user.email).size).to eq(1)
+
+      CSV.parse(subject).detect { |row| row.first == invited_user.email }.tap do |row|
+        expect(row[0]).to eq(invited_user.email)
+        expect(row[1]).to eq("Invitation Sent")
+        expect(row[2]).to eq("")
+        expect(row[3]).to eq("01/01/1970 00:00")
+      end
+    end
+  end
+end

--- a/spec/presenters/reports/user_presenter_spec.rb
+++ b/spec/presenters/reports/user_presenter_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Reports::UserPresenter do
+  subject { described_class.new(user) }
+
+  describe "#email" do
+    let(:user) { build(:user) }
+
+    it "returns the email address" do
+      expect(subject.email).to eq(user.email)
+    end
+  end
+
+  describe "#status" do
+    context "with an active user" do
+      let(:user) { build(:user, active: true) }
+
+      it "returns 'Active'" do
+        expect(subject.status).to eq("Active")
+      end
+    end
+
+    context "with an invited user" do
+      let(:user) do
+        build(:user, active: false, invitation_sent_at: Time.at(0).utc)
+      end
+
+      it "returns 'Invitation Sent'" do
+        expect(subject.status).to eq("Invitation Sent")
+      end
+    end
+
+    context "with a deactivated user" do
+      let(:user) { build(:user, active: false) }
+
+      it "returns 'Deactivated'" do
+        expect(subject.status).to eq("Deactivated")
+      end
+    end
+  end
+
+  describe "#current_sign_in_at" do
+    context "with a previously signed in user" do
+      let(:user) do
+        build(:user, active: false, current_sign_in_at: Time.at(0).utc)
+      end
+
+      it "returns the date/time in the correct format" do
+        expect(subject.current_sign_in_at).to eq("01/01/1970 00:00")
+      end
+    end
+
+    context "with a user that never signed in" do
+      let(:user) do
+        build(:user, active: false, current_sign_in_at: nil)
+      end
+
+      it "returns the date/time in the correct format" do
+        expect(subject.current_sign_in_at).to be_nil
+      end
+    end
+  end
+
+  describe "#invitation_accepted_at" do
+    context "with an invited user" do
+      let(:user) do
+        build(:user, active: false, invitation_accepted_at: Time.at(0).utc)
+      end
+
+      it "returns the date/time in the correct format" do
+        expect(subject.invitation_accepted_at).to eq("01/01/1970 00:00")
+      end
+    end
+
+    context "with an uninvited user" do
+      let(:user) do
+        build(:user, active: false, invitation_accepted_at: nil)
+      end
+
+      it "returns the date/time in the correct format" do
+        expect(subject.invitation_accepted_at).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit adds a CSV export of all users including their active/deactivated and invitation status. The download is handled by the existing UsersController#all endpoint which already returns the identical resources (albeit with pagination) for text/html requests and has been extended to send the CSV using send_data when called with Content-Type/Accept headers set to text/csv.

This endpoint already has the correct access permissions, namely being accessible to agency and finance super users only.