### PR TITLE
Show correct user status in user export CSV

### DIFF
--- a/app/presenters/reports/user_presenter.rb
+++ b/app/presenters/reports/user_presenter.rb
@@ -22,10 +22,10 @@ module Reports
     end
 
     def status
-      return "Active" if @user.active?
-      return "Invitation Sent" if @user.invitation_sent_at.present?
+      return "Deactivated" if @user.deactivated?
+      return "Invitation Sent" if @user.invitation_token.present?
 
-      "Deactivated"
+      "Active"
     end
   end
 end

--- a/spec/models/reports/user_export_serializer_spec.rb
+++ b/spec/models/reports/user_export_serializer_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe Reports::UserExportSerializer do
   let(:invited_user) do
     create(
       :user,
-      active: false,
-      invitation_sent_at: Time.at(0).utc,
+      active: true,
+      invitation_token: "foobar",
       invitation_accepted_at: Time.at(0).utc
     )
   end

--- a/spec/presenters/reports/user_presenter_spec.rb
+++ b/spec/presenters/reports/user_presenter_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Reports::UserPresenter do
 
     context "with an invited user" do
       let(:user) do
-        build(:user, active: false, invitation_sent_at: Time.at(0).utc)
+        build(:user, active: true, invitation_token: "foobar")
       end
 
       it "returns 'Invitation Sent'" do
@@ -34,6 +34,14 @@ RSpec.describe Reports::UserPresenter do
 
     context "with a deactivated user" do
       let(:user) { build(:user, active: false) }
+
+      it "returns 'Deactivated'" do
+        expect(subject.status).to eq("Deactivated")
+      end
+    end
+
+    context "with a deactivated user with invitation token" do
+      let(:user) { build(:user, active: false, invitation_token: "foobar") }
 
       it "returns 'Deactivated'" do
         expect(subject.status).to eq("Deactivated")


### PR DESCRIPTION
The status precedence has been incorrect in #1482. With this commit we now correctly shows the active/deactivated status as well as uses the presence of an invitation token to determine if an active user's invitation is still pending, being now in line with what's shown on the users index page.