### PR TITLE
Add user's role to user export CSV

### DIFF
--- a/app/models/reports/user_export_serializer.rb
+++ b/app/models/reports/user_export_serializer.rb
@@ -5,6 +5,7 @@ module Reports
     ATTRIBUTES = {
       email: "Email Address",
       status: "Status",
+      role: "Role",
       current_sign_in_at: "Last Logged In",
       invitation_accepted_at: "Invitation Accepted"
     }.freeze

--- a/app/presenters/reports/user_presenter.rb
+++ b/app/presenters/reports/user_presenter.rb
@@ -17,10 +17,6 @@ module Reports
       @user.invitation_accepted_at&.strftime(DATETIME_FORMAT)
     end
 
-    def email
-      @user.email
-    end
-
     def status
       return "Deactivated" if @user.deactivated?
       return "Invitation Sent" if @user.invitation_token.present?

--- a/spec/models/reports/user_export_serializer_spec.rb
+++ b/spec/models/reports/user_export_serializer_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe Reports::UserExportSerializer do
       [
         "Email Address",
         "Status",
+        "Role",
         "Last Logged In",
         "Invitation Accepted"
       ]
@@ -57,8 +58,9 @@ RSpec.describe Reports::UserExportSerializer do
       CSV.parse(subject).detect { |row| row.first == active_user.email }.tap do |row|
         expect(row[0]).to eq(active_user.email)
         expect(row[1]).to eq("Active")
-        expect(row[2]).to eq("01/01/1970 00:00")
+        expect(row[2]).to eq("agency")
         expect(row[3]).to eq("01/01/1970 00:00")
+        expect(row[4]).to eq("01/01/1970 00:00")
       end
     end
 
@@ -68,8 +70,9 @@ RSpec.describe Reports::UserExportSerializer do
       CSV.parse(subject).detect { |row| row.first == inactive_user.email }.tap do |row|
         expect(row[0]).to eq(inactive_user.email)
         expect(row[1]).to eq("Deactivated")
-        expect(row[2]).to eq("")
+        expect(row[2]).to eq("agency")
         expect(row[3]).to eq("")
+        expect(row[4]).to eq("")
       end
     end
 
@@ -79,8 +82,9 @@ RSpec.describe Reports::UserExportSerializer do
       CSV.parse(subject).detect { |row| row.first == invited_user.email }.tap do |row|
         expect(row[0]).to eq(invited_user.email)
         expect(row[1]).to eq("Invitation Sent")
-        expect(row[2]).to eq("")
-        expect(row[3]).to eq("01/01/1970 00:00")
+        expect(row[2]).to eq("agency")
+        expect(row[3]).to eq("")
+        expect(row[4]).to eq("01/01/1970 00:00")
       end
     end
   end

--- a/spec/presenters/reports/user_presenter_spec.rb
+++ b/spec/presenters/reports/user_presenter_spec.rb
@@ -5,14 +5,6 @@ require "rails_helper"
 RSpec.describe Reports::UserPresenter do
   subject { described_class.new(user) }
 
-  describe "#email" do
-    let(:user) { build(:user) }
-
-    it "returns the email address" do
-      expect(subject.email).to eq(user.email)
-    end
-  end
-
   describe "#status" do
     context "with an active user" do
       let(:user) { build(:user, active: true) }


### PR DESCRIPTION
This commit adds a new column to the user export CSV containing the user's current role.