### PR TITLE
Use correct govpay API in application config

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -130,9 +130,9 @@ module WasteCarriersBackOffice
     config.govpay_url = if ENV["WCRS_MOCK_ENABLED"].to_s.downcase == "true"
                           ENV.fetch("WCRS_MOCK_BO_GOVPAY_URL", nil)
                         else
-                          ENV["WCRS_GOVPAY_URL"] || "https://publicapi.payments.service.gov.uk/v1"
+                          ENV["WCRS_GOVPAY_BACK_OFFICE_URL"] || "https://publicapi.payments.service.gov.uk/v1"
                         end
-    config.govpay_api_token = ENV.fetch("WCRS_GOVPAY_API_TOKEN", nil)
+    config.govpay_api_token = ENV.fetch("WCRS_GOVPAY_BACK_OFFICE_API_TOKEN", nil)
 
     # Emails
     config.email_service_name = "Waste Carriers Registration Service"


### PR DESCRIPTION
We now use separate API keys for front-office and back-office. This commit changes the application configuration to use the new environment variable names to select correct API key.