### PR TITLE
Refactor search services and add email search

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: 36bd51ec486321ed31f16dc76054aadd9ad8641c
+  revision: 186a2c77672a1b256a58be16eb3e6c8a64f849f8
   branch: main
   specs:
     waste_carriers_engine (0.0.1)
@@ -140,8 +140,8 @@ GEM
     concurrent-ruby (1.1.10)
     console (1.13.1)
       fiber-local
-    countries (5.1.2)
-      sixarm_ruby_unaccent (~> 1.1)
+    countries (5.2.0)
+      unaccent (~> 0.3)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -149,6 +149,7 @@ GEM
     database_cleaner-mongoid (2.0.1)
       database_cleaner-core (~> 2.0.0)
       mongoid
+    date (3.3.1)
     defra_ruby_address (0.1.0)
       rest-client (~> 2.0)
     defra_ruby_alert (2.1.1)
@@ -278,8 +279,11 @@ GEM
     loofah (2.19.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.7.1)
+    mail (2.8.0)
       mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
@@ -299,17 +303,18 @@ GEM
       mongoid (>= 5.0, < 8)
     multi_json (1.15.0)
     multipart-post (2.1.1)
-    net-imap (0.3.1)
+    net-imap (0.3.2)
+      date
       net-protocol
     net-pop (0.1.2)
       net-protocol
-    net-protocol (0.1.3)
+    net-protocol (0.2.1)
       timeout
     net-smtp (0.3.3)
       net-protocol
     netrc (0.11.0)
     nio4r (2.5.8)
-    nokogiri (1.13.9)
+    nokogiri (1.13.10)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     notifications-ruby-client (5.4.0)
@@ -325,7 +330,7 @@ GEM
     passenger (5.3.7)
       rack
       rake (>= 0.8.1)
-    phonelib (0.7.4)
+    phonelib (0.7.5)
     protocol-hpack (1.4.2)
     protocol-http (0.22.5)
     protocol-http1 (0.14.1)
@@ -340,7 +345,7 @@ GEM
       byebug (~> 11.0)
       pry (>= 0.13, < 0.15)
     public_suffix (5.0.0)
-    racc (1.6.0)
+    racc (1.6.1)
     rack (2.2.4)
     rack-test (2.0.2)
       rack (>= 1.3)
@@ -448,7 +453,6 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    sixarm_ruby_unaccent (1.2.0)
     spring (4.1.0)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
@@ -460,7 +464,7 @@ GEM
     thor (1.2.1)
     tilt (2.0.11)
     timecop (0.9.6)
-    timeout (0.3.0)
+    timeout (0.3.1)
     timers (4.3.3)
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
@@ -470,6 +474,7 @@ GEM
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
     uk_postcode (2.1.8)
+    unaccent (0.4.0)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8.2)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -24,3 +24,10 @@ input.button-link {
   padding: 0;
   text-decoration: underline;
 }
+
+.inline-checkboxes {
+  .govuk-checkboxes__item {
+    padding-right: 1em;
+    clear: none;
+  }
+}

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -14,7 +14,7 @@ class DashboardsController < ApplicationController
     @results = []
 
     if params[:search_fullname] == "1" && params[:search_email] == "1"
-      flash_error(I18n.t(".dashboards.index.search.search_type_error"), nil)
+      flash.now[:error] = I18n.t(".dashboards.index.search.search_type_error")
     else
       @search_type = search_type(params)
     end
@@ -29,7 +29,7 @@ class DashboardsController < ApplicationController
       :fullname
     elsif params[:search_email] == "1"
       if ValidatesEmailFormatOf.validate_email_format(@term)
-        flash_error(I18n.t(".dashboards.index.search.invalid_email_error"), nil)
+        flash.now[:error] = I18n.t(".dashboards.index.search.invalid_email_error")
         nil
       else
         :email

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -1,24 +1,54 @@
 # frozen_string_literal: true
 
 class DashboardsController < ApplicationController
+  include CanSetFlashMessages
+
   helper ActionLinksHelper
 
   before_action :authenticate_user!
 
   def index
     @term = params[:term]
-    @search_type = params[:search_fullname] == "1" ? :fullname : :general
+    @search_type = nil
+    @result_count = 0
+    @results = []
+
+    if params[:search_fullname] == "1" && params[:search_email] == "1"
+      flash_error(I18n.t(".dashboards.index.search.search_type_error"), nil)
+    else
+      @search_type = search_type(params)
+    end
+
     search_and_count_results(params[:page])
   end
 
   private
 
+  def search_type(params)
+    if params[:search_fullname] == "1"
+      :fullname
+    elsif params[:search_email] == "1"
+      if ValidatesEmailFormatOf.validate_email_format(@term)
+        flash_error(I18n.t(".dashboards.index.search.invalid_email_error"), nil)
+        nil
+      else
+        :email
+      end
+    else
+      :general
+    end
+  end
+
   def search_and_count_results(page)
     result_data = case @search_type
                   when :fullname
                     SearchFullnameService.run(page: page, term: @term)
-                  else
+                  when :email
+                    SearchEmailService.run(page: page, term: @term)
+                  when :general
                     SearchService.run(page: page, term: @term)
+                  else
+                    { count: 0, results: [] }
                   end
     @result_count = result_data[:count]
     @results = result_data[:results]

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -8,7 +8,7 @@ class DashboardsController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @term = params[:term]
+    @term = params[:term]&.strip
     @search_type = nil
     @result_count = 0
     @results = []

--- a/app/services/base_search_service.rb
+++ b/app/services/base_search_service.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class BaseSearchService < ::WasteCarriersEngine::BaseService
+  def run(page:, term:)
+    return response_hash([]) if term.blank?
+
+    @page = page
+    @term = term.strip.downcase
+
+    response_hash(search_results)
+  end
+
+  private
+
+  def response_hash(results)
+    {
+      count: results.count,
+      results: Kaminari.paginate_array(results).page(@page)
+    }
+  end
+
+  def search_results
+    @_search_results ||= matching_resources.sort_by do |resource|
+      resource.reg_identifier || ""
+    end
+  end
+
+  def matching_resources
+    # De-duplicate Registration results by reg_identifier
+    # and TransientRegistration results by reg_identifier and classname.
+    search(WasteCarriersEngine::Registration).uniq(&:reg_identifier) +
+      search(WasteCarriersEngine::TransientRegistration).uniq { |reg| "#{reg.reg_identifier}_#{reg.class}" }
+  end
+
+  # Implement this in the subclasses
+  def search(model)
+    raise NotImplementedError
+  end
+end

--- a/app/services/base_search_service.rb
+++ b/app/services/base_search_service.rb
@@ -31,9 +31,4 @@ class BaseSearchService < ::WasteCarriersEngine::BaseService
     search(WasteCarriersEngine::Registration).uniq(&:reg_identifier) +
       search(WasteCarriersEngine::TransientRegistration).uniq { |reg| "#{reg.reg_identifier}_#{reg.class}" }
   end
-
-  # Implement this in the subclasses
-  def search(_model)
-    raise NotImplementedError
-  end
 end

--- a/app/services/base_search_service.rb
+++ b/app/services/base_search_service.rb
@@ -33,7 +33,7 @@ class BaseSearchService < ::WasteCarriersEngine::BaseService
   end
 
   # Implement this in the subclasses
-  def search(model)
+  def search(_model)
     raise NotImplementedError
   end
 end

--- a/app/services/base_search_service.rb
+++ b/app/services/base_search_service.rb
@@ -26,9 +26,8 @@ class BaseSearchService < ::WasteCarriersEngine::BaseService
   end
 
   def matching_resources
-    # De-duplicate Registration results by reg_identifier
-    # and TransientRegistration results by reg_identifier and classname.
+    # De-duplicate results for each class by reg_identifier
     search(WasteCarriersEngine::Registration).uniq(&:reg_identifier) +
-      search(WasteCarriersEngine::TransientRegistration).uniq { |reg| "#{reg.reg_identifier}_#{reg.class}" }
+      search(WasteCarriersEngine::RenewingRegistration).uniq(&:reg_identifier)
   end
 end

--- a/app/services/search_email_service.rb
+++ b/app/services/search_email_service.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-class SearchService < ::BaseSearchService
+class SearchEmailService < BaseSearchService
 
   private
 
   def search(model)
-    model.search_term(@term)
+    model.where("$or": [{ contact_email: @term }, { account_email: @term }])
          .limit(100)
          .read(mode: :secondary)
   end

--- a/app/services/search_fullname_service.rb
+++ b/app/services/search_fullname_service.rb
@@ -1,36 +1,8 @@
 # frozen_string_literal: true
 
-class SearchFullnameService < ::WasteCarriersEngine::BaseService
-  def run(page:, term:)
-    return response_hash([]) if term.blank?
-
-    @page = page
-    @term = term.strip.downcase
-
-    response_hash(search_results)
-  end
+class SearchFullnameService < BaseSearchService
 
   private
-
-  def response_hash(results)
-    {
-      count: results.count,
-      results: Kaminari.paginate_array(results).page(@page)
-    }
-  end
-
-  def search_results
-    @_search_results ||= matching_resources.sort_by do |resource|
-      resource.reg_identifier || ""
-    end
-  end
-
-  def matching_resources
-    # De-duplicate Registration results by reg_identifier
-    # and TransientRegistration results by reg_identifier and classname.
-    search(WasteCarriersEngine::Registration).uniq(&:reg_identifier) +
-      search(WasteCarriersEngine::TransientRegistration).uniq { |reg| "#{reg.reg_identifier}_#{reg.class}" }
-  end
 
   def search(model)
     search_registered_name(model) + search_key_people(model)

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -34,11 +34,20 @@
           <span class="govuk-hint"><%= t(".search.hint") %></span>
         <% end %>
 
-        <div class="govuk-checkboxes__item">
-          <input id="search-fullname-field" class="govuk-checkboxes__input" type="checkbox" value="1" name="search_fullname" />
-          <label for="search-fullname-field" class="govuk-label govuk-checkboxes__label">
-            <%= t(".search.fullname_search_label") %>
-          </label>
+        <div class="govuk-checkboxes govuk-checkboxes--small inline-checkboxes" data-module="govuk-checkboxes">
+          <span class="govuk-checkboxes__item">
+            <input id="search-fullname-field" class="govuk-checkboxes__input" type="checkbox" value="1" name="search_fullname" />
+            <label for="search-fullname-field" class="govuk-label govuk-checkboxes__label">
+              <%= t(".search.fullname_search_label") %>
+            </label>
+          </span>
+
+          <span class="govuk-checkboxes__item">
+            <input id="search-email-field" class="govuk-checkboxes__input" type="checkbox" value="1" name="search_email" />
+            <label for="search-email-field" class="govuk-label govuk-checkboxes__label">
+              <%= t(".search.email_search_label") %>
+            </label>
+          </span>
         </div>
         <br>
         <%= text_field_tag :term, @term, class: "govuk-input govuk-!-width-one-half", type: "search" %>
@@ -64,7 +73,7 @@
   <% end %>
 </div>
 
-<% if @results.any? %>
+<% if @results&.any? %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <table class="govuk-table">

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -58,7 +58,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   # config.log_tags = [ :subdomain, :uuid ]

--- a/config/locales/dashboard.en.yml
+++ b/config/locales/dashboard.en.yml
@@ -8,9 +8,12 @@ en:
         new_registration: Create new registration
       search:
         label: Search for a registration
-        hint: Search using registration number, business or contact last name, postcode or telephone number. Use the checkbox to do a full name search across all names.
+        hint: Search using registration number, business or contact last name, postcode or telephone number. Use the checkboxes to do a full name search or contact and account email search.
         fullname_search_label: Search full name
+        email_search_label: Email address
         submit: Search
+        search_type_error: You cannot search by full name and by email address at the same time. Only use one of the search checkboxes at a time.
+        invalid_email_error: Enter a valid email address
       results:
         caption:
           one: Found 1 registration

--- a/spec/factories/edit_registration.rb
+++ b/spec/factories/edit_registration.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :edit_registration, class: "WasteCarriersEngine::EditRegistration" do
+    initialize_with { new(reg_identifier: create(:registration, :active).reg_identifier) }
+  end
+end

--- a/spec/requests/dashboards_spec.rb
+++ b/spec/requests/dashboards_spec.rb
@@ -33,7 +33,13 @@ RSpec.describe "Dashboards" do
         expect(response).to have_http_status(:ok)
       end
 
-      context "when a search term is included" do
+      context "when no search term is provided" do
+        it "does not raise an error" do
+          expect { get "/bo", params: { term: nil } }.not_to raise_error
+        end
+      end
+
+      context "when a search term is provided" do
 
         context "when there are no matches" do
           it "says there are no results" do
@@ -100,6 +106,16 @@ RSpec.describe "Dashboards" do
 
           context "with a valid email search term matching contact_email" do
             let(:search_term) { matching_registration.contact_email }
+
+            it "includes links to the matched registrations" do
+              subject
+
+              expect(response.body).to include(registration_path(matching_registration.reg_identifier))
+            end
+          end
+
+          context "with a valid email search term with whitespace otherwise matching contact_email" do
+            let(:search_term) { " #{matching_registration.contact_email}   " }
 
             it "includes links to the matched registrations" do
               subject

--- a/spec/requests/dashboards_spec.rb
+++ b/spec/requests/dashboards_spec.rb
@@ -4,12 +4,27 @@ require "rails_helper"
 
 RSpec.describe "Dashboards" do
   describe "/bo" do
-    context "when a valid user is signed in" do
-      let(:user) { create(:user) }
 
-      before do
-        sign_in(user)
+    context "when a user is not signed in" do
+      it "redirects to the sign-in page" do
+        get "/bo"
+
+        expect(response).to redirect_to(new_user_session_path)
       end
+    end
+
+    context "when a deactivated user is signed in" do
+      before { sign_in(create(:user, :inactive)) }
+
+      it "redirects to the deactivated page" do
+        get "/bo"
+
+        expect(response).to redirect_to("/bo/pages/deactivated")
+      end
+    end
+
+    context "when a valid user is signed in" do
+      before { sign_in(create(:user)) }
 
       it "renders the index template and returns a 200 response" do
         get "/bo"
@@ -19,6 +34,15 @@ RSpec.describe "Dashboards" do
       end
 
       context "when a search term is included" do
+
+        context "when there are no matches" do
+          it "says there are no results" do
+            get "/bo", params: { term: "foobarbaz" }
+
+            expect(response.body).to include("No results")
+          end
+        end
+
         context "when there are matches" do
           it "links to renewal details pages" do
             last_modified_renewal = create(:renewing_registration)
@@ -43,39 +67,47 @@ RSpec.describe "Dashboards" do
           end
 
           it "links to renewal details pages" do
-            link_to_renewal = renewing_registration_path(matching_renewal.reg_identifier)
-
             get "/bo", params: { term: "#{first_name} #{last_name}", search_fullname: "1" }
 
-            expect(response.body).to include(link_to_renewal)
+            expect(response.body).to include(renewing_registration_path(matching_renewal.reg_identifier))
           end
         end
 
-        context "when there are no matches" do
-          it "says there are no results" do
-            get "/bo", params: { term: "foobarbaz" }
+        context "when email search is selected" do
 
-            expect(response.body).to include("No results")
+          subject(:search_request) {  get "/bo", params: { term: search_term, search_email: "1" } }
+
+          let!(:matching_renewal) { create(:renewing_registration, contact_email: Faker::Internet.email) }
+          let!(:matching_registration) { WasteCarriersEngine::Registration.where(reg_identifier: matching_renewal.reg_identifier).first }
+
+          context "when both full name search and email search are selected" do
+            it "returns a form validation error" do
+              get "/bo", params: { term: "summat", search_fullname: "1", search_email: "1" }
+
+              expect(request.flash[:error]).to be_present
+            end
+          end
+
+          context "with an invalid email search term" do
+            let(:search_term) { "foo_at_bar.com" }
+
+            it "displays a validation error" do
+              subject
+
+              expect(request.flash[:error]).to eq("Enter a valid email address")
+            end
+          end
+
+          context "with a valid email search term matching contact_email" do
+            let(:search_term) { matching_registration.contact_email }
+
+            it "includes links to the matched registrations" do
+              subject
+
+              expect(response.body).to include(registration_path(matching_registration.reg_identifier))
+            end
           end
         end
-      end
-    end
-
-    context "when a deactivated user is signed in" do
-      before { sign_in(create(:user, :inactive)) }
-
-      it "redirects to the deactivated page" do
-        get "/bo"
-
-        expect(response).to redirect_to("/bo/pages/deactivated")
-      end
-    end
-
-    context "when a user is not signed in" do
-      it "redirects to the sign-in page" do
-        get "/bo"
-
-        expect(response).to redirect_to(new_user_session_path)
       end
     end
   end

--- a/spec/services/base_search_service_spec.rb
+++ b/spec/services/base_search_service_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BaseSearchService do
+
+  subject(:run_service) { test_service.run(page: page, term: search_term) }
+
+  let(:test_class) do
+    Class.new(described_class) do
+      def run(page:, term:); end
+    end
+  end
+  let(:page) { 1 }
+  let(:search_term) { "search for me" }
+  let(:non_matching_renewal) { create(:renewing_registration) }
+  let(:non_matching_registration) { WasteCarriersEngine::Registration.find_by(reg_identifier: non_matching_renewal.reg_identifier) }
+  let(:matching_renewal1) { create(:renewing_registration) }
+  let(:matching_registration1) { WasteCarriersEngine::Registration.find_by(reg_identifier: matching_renewal1.reg_identifier) }
+  let(:matching_renewal2) { create(:renewing_registration) }
+  let(:matching_registration2) { WasteCarriersEngine::Registration.find_by(reg_identifier: matching_renewal2.reg_identifier) }
+  let(:test_service) { instance_double(test_class) }
+
+  def expected_result_for(entities)
+    {
+      count: entities.count,
+      results: entities
+    }
+  end
+
+  before do
+    allow(test_class).to receive(:new).and_return(test_service)
+    allow(test_service).to receive(:run).with(any_args).and_return(count: 0, results: [])
+  end
+
+  context "when there is no search term" do
+    let(:search_term) { nil }
+
+    it "returns no results" do
+      expect(run_service).to eq(count: 0, results: [])
+    end
+  end
+
+  context "when there is a search term" do
+
+    context "with no matches" do
+      it "returns no results" do
+        expect(run_service).to eq(count: 0, results: [])
+      end
+    end
+
+    context "with matches on a single collection" do
+      before { allow(test_service).to receive(:run).with(any_args).and_return(expected_result_for([matching_renewal1, matching_renewal2])) }
+
+      it "returns the expected count" do
+        expect(run_service[:count]).to eq 2
+      end
+
+      it "returns all matches from the collection" do
+        expect(run_service[:results]).to contain_exactly(matching_renewal1, matching_renewal2)
+      end
+    end
+
+    context "with matches on multiple collections" do
+      before { allow(test_service).to receive(:run).and_return(expected_result_for([matching_renewal1, matching_registration2])) }
+
+      it "returns the expected count" do
+        expect(run_service[:count]).to eq 2
+      end
+
+      it "returns aggregated results from the different collections" do
+        expect(run_service[:results]).to contain_exactly(matching_renewal1, matching_registration2)
+      end
+    end
+
+    context "when there is a match on an edit registration" do
+      let(:edit_registration) { create(:edit_registration) }
+      # Un-stub `run` in the test class to allow search to be stubbed
+      let(:test_class) do
+        Class.new(described_class) do
+          def search(); end
+        end
+      end
+
+      before do
+        allow(test_service).to receive(:search).and_return([
+                                                             matching_renewal1.reg_identifier,
+                                                             matching_registration2.reg_identifier,
+                                                             edit_registration.reg_identifier
+                                                           ])
+      end
+
+      it "does not include the edit registration" do
+        expect(run_service[:results]).not_to include(edit_registration)
+      end
+    end
+  end
+end

--- a/spec/services/search_email_service_spec.rb
+++ b/spec/services/search_email_service_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SearchEmailService do
+  let(:page) { 1 }
+  let(:term) { nil }
+
+  let(:service) do
+    described_class.run(page: page, term: term)
+  end
+
+  let(:contact_email) { Faker::Internet.unique.email }
+  let(:account_email) { Faker::Internet.unique.email }
+  let!(:matching_renewal) { create(:renewing_registration, contact_email: contact_email, account_email: account_email) }
+  let!(:matching_registration) { WasteCarriersEngine::Registration.where(reg_identifier: matching_renewal.reg_identifier).first }
+
+  before do
+    # create an instance which should not be in the results
+    create(:renewing_registration, contact_email: Faker::Internet.unique.email, account_email: Faker::Internet.unique.email)
+
+    # force registration to align with renewing registration
+    matching_registration.contact_email = matching_renewal.contact_email
+    matching_registration.account_email = matching_renewal.account_email
+    matching_registration.save!
+  end
+
+  shared_examples "no matches" do
+    it "returns no results" do
+      expect(service).to eq(count: 0, results: [])
+    end
+  end
+
+  shared_examples "matching registration and renewal" do
+    it "matches the expected registration and renewal only" do
+      expect(service[:results]).to contain_exactly(matching_renewal, matching_registration)
+    end
+  end
+
+  context "when there is no search term" do
+    it_behaves_like "no matches"
+  end
+
+  context "when there is a search term" do
+
+    context "without an expected match" do
+      let(:term) { Faker::Internet.unique.email }
+
+      it_behaves_like "no matches"
+    end
+
+    context "with an expected contact_email match" do
+      let(:term) { matching_renewal.contact_email }
+
+      it_behaves_like "matching registration and renewal"
+    end
+
+    context "with an expected account_email match" do
+      let(:term) { matching_renewal.account_email }
+
+      it_behaves_like "matching registration and renewal"
+    end
+
+    context "when the term has a case-insensitive match" do
+      let(:term) { matching_renewal.contact_email.upcase }
+
+      it_behaves_like "matching registration and renewal"
+    end
+
+    context "when the term has excess whitespace" do
+      let(:term) { " #{matching_renewal.contact_email} " }
+
+      it_behaves_like "matching registration and renewal"
+    end
+
+    context "when there is a match on both the contact_email and account_email" do
+      let(:term) { matching_renewal.contact_email }
+
+      before do
+        matching_registration.account_email = matching_renewal.contact_email
+        matching_registration.save!
+      end
+
+      it "returns each matching registration and renewal once only" do
+        expect(service[:results]).to contain_exactly(matching_renewal, matching_registration)
+      end
+    end
+  end
+end

--- a/spec/services/search_fullname_service_spec.rb
+++ b/spec/services/search_fullname_service_spec.rb
@@ -21,73 +21,64 @@ RSpec.describe SearchFullnameService do
     matching_registration.save!
   end
 
-  context "when there is no search term" do
-    it "returns no results" do
-      expect(service).to eq(count: 0, results: [])
+  context "with an expected full name match" do
+    let(:term) { "#{first_name} #{last_name}" }
+
+    it "matches the expected registration and renewal only" do
+      expect(service[:results]).to contain_exactly(matching_renewal, matching_registration)
     end
   end
 
-  context "when there is a search term" do
+  context "when there is a match on a last_name only" do
+    let(:term) { last_name }
 
-    context "with an expected full name match" do
-      let(:term) { "#{first_name} #{last_name}" }
+    it "does not return any results" do
+      expect(service[:count]).to eq(0)
+    end
+  end
 
-      it "matches the expected registration and renewal only" do
-        expect(service[:results]).to contain_exactly(matching_renewal, matching_registration)
+  context "when the term has a case-insensitive match" do
+    let(:term) { "#{first_name} #{last_name}".upcase }
+
+    it "matches the expected registration and renewal only" do
+      expect(service[:results]).to contain_exactly(matching_renewal, matching_registration)
+    end
+  end
+
+  context "when the term has excess whitespace" do
+    let(:term) { " #{first_name} #{last_name} " }
+
+    it "matches the term without whitespace" do
+      expect(service[:results]).to include(matching_registration)
+    end
+  end
+
+  context "when there is a match on a key person" do
+    let(:key_first_name) { Faker::Name.first_name }
+    let(:key_last_name) { Faker::Name.last_name }
+    let(:term) { "#{key_first_name} #{key_last_name}" }
+
+    before do
+      matching_registration.key_people[0].first_name = key_first_name
+      matching_registration.key_people[0].last_name = key_last_name
+      matching_registration.save!
+    end
+
+    context "when there is no match on the registration owner" do
+      it "matches the expected registration only" do
+        expect(service[:results]).to contain_exactly(matching_registration)
       end
     end
 
-    context "when there is a match on a last_name only" do
-      let(:term) { last_name }
-
-      it "does not return any results" do
-        expect(service[:count]).to eq(0)
-      end
-    end
-
-    context "when the term has a case-insensitive match" do
-      let(:term) { "#{first_name} #{last_name}".upcase }
-
-      it "matches the expected registration and renewal only" do
-        expect(service[:results]).to contain_exactly(matching_renewal, matching_registration)
-      end
-    end
-
-    context "when the term has excess whitespace" do
-      let(:term) { " #{first_name} #{last_name} " }
-
-      it "matches the term without whitespace" do
-        expect(service[:results]).to include(matching_registration)
-      end
-    end
-
-    context "when there is a match on a key person" do
-      let(:key_first_name) { Faker::Name.first_name }
-      let(:key_last_name) { Faker::Name.last_name }
-      let(:term) { "#{key_first_name} #{key_last_name}" }
-
+    context "when there is a match on both the registration owner and a key person" do
       before do
-        matching_registration.key_people[0].first_name = key_first_name
-        matching_registration.key_people[0].last_name = key_last_name
+        matching_registration.first_name = key_first_name
+        matching_registration.last_name = key_last_name
         matching_registration.save!
       end
 
-      context "when there is no match on the registration owner" do
-        it "matches the expected registration only" do
-          expect(service[:results]).to contain_exactly(matching_registration)
-        end
-      end
-
-      context "when there is a match on both the registration owner and a key person" do
-        before do
-          matching_registration.first_name = key_first_name
-          matching_registration.last_name = key_last_name
-          matching_registration.save!
-        end
-
-        it "returns the registration once only" do
-          expect(service[:results].length).to eq 1
-        end
+      it "returns the registration once only" do
+        expect(service[:results].length).to eq 1
       end
     end
   end

--- a/spec/services/search_service_spec.rb
+++ b/spec/services/search_service_spec.rb
@@ -12,181 +12,158 @@ RSpec.describe SearchService do
 
   let(:non_matching_renewal) { create(:renewing_registration) }
   let(:non_matching_registration) { WasteCarriersEngine::Registration.where(reg_identifier: non_matching_renewal.reg_identifier).first }
+  let(:matching_renewal) { create(:renewing_registration) }
+  let(:matching_registration) { WasteCarriersEngine::Registration.where(reg_identifier: matching_renewal.reg_identifier).first }
 
-  context "when there is no search term" do
-    it "returns no results" do
-      expect(service).to eq(count: 0, results: [])
+  context "when there is a match on a reg_identifier" do
+    let(:term) { matching_renewal.reg_identifier }
+
+    it "returns the correct count" do
+      expect(service[:count]).to eq(2)
+    end
+
+    it "displays the matching transient_registration" do
+      expect(service[:results]).to include(matching_renewal)
+    end
+
+    it "displays the matching registration" do
+      expect(service[:results]).to include(matching_registration)
+    end
+
+    it "does not display a non-matching transient_registration" do
+      expect(service[:results]).not_to include(non_matching_renewal)
+    end
+
+    it "does not display a non-matching registration" do
+      expect(service[:results]).not_to include(non_matching_registration)
     end
   end
 
-  context "when there is a search term" do
-    let(:matching_renewal) do
-      create(:renewing_registration)
-    end
-    let(:matching_registration) { WasteCarriersEngine::Registration.where(reg_identifier: matching_renewal.reg_identifier).first }
+  context "when there is a match on a company_name" do
+    let(:term) { matching_renewal.company_name }
 
-    context "when there are results in different collections" do
-      let(:term) { "search for me" }
-
-      it "returns aggregated results from the different collections" do
-        matching_renewal = create(:renewing_registration, company_name: term)
-        matching_new_registration = create(:new_registration, company_name: term)
-
-        expect(service[:results]).to include(matching_renewal)
-        expect(service[:results]).to include(matching_new_registration)
-      end
+    it "returns the correct count" do
+      expect(service[:count]).to eq(2)
     end
 
-    context "when there is a match on a reg_identifier" do
-      let(:term) { matching_renewal.reg_identifier }
-
-      it "returns the correct count" do
-        expect(service[:count]).to eq(2)
-      end
-
-      it "displays the matching transient_registration" do
-        expect(service[:results]).to include(matching_renewal)
-      end
-
-      it "displays the matching registration" do
-        expect(service[:results]).to include(matching_registration)
-      end
-
-      it "does not display a non-matching transient_registration" do
-        expect(service[:results]).not_to include(non_matching_renewal)
-      end
-
-      it "does not display a non-matching registration" do
-        expect(service[:results]).not_to include(non_matching_registration)
-      end
+    it "displays the matching transient_registration" do
+      expect(service[:results]).to include(matching_renewal)
     end
 
-    context "when there is a match on a company_name" do
-      let(:term) { matching_renewal.company_name }
+    it "displays the matching registration" do
+      expect(service[:results]).to include(matching_registration)
+    end
+  end
 
-      it "returns the correct count" do
-        expect(service[:count]).to eq(2)
-      end
+  context "when there is a match on a last_name" do
+    let(:term) { matching_renewal.last_name }
 
-      it "displays the matching transient_registration" do
-        expect(service[:results]).to include(matching_renewal)
-      end
-
-      it "displays the matching registration" do
-        expect(service[:results]).to include(matching_registration)
-      end
+    it "returns the correct count" do
+      expect(service[:count]).to eq(2)
     end
 
-    context "when there is a match on a last_name" do
-      let(:term) { matching_renewal.last_name }
-
-      it "returns the correct count" do
-        expect(service[:count]).to eq(2)
-      end
-
-      it "displays the matching transient_registration" do
-        expect(service[:results]).to include(matching_renewal)
-      end
-
-      it "displays the matching registration" do
-        expect(service[:results]).to include(matching_registration)
-      end
+    it "displays the matching transient_registration" do
+      expect(service[:results]).to include(matching_renewal)
     end
 
-    context "when there is a match on a postcode" do
-      let(:term) { matching_renewal.addresses.first.postcode }
+    it "displays the matching registration" do
+      expect(service[:results]).to include(matching_registration)
+    end
+  end
 
-      it "returns the correct count" do
-        expect(service[:count]).to eq(2)
-      end
+  context "when there is a match on a postcode" do
+    let(:term) { matching_renewal.addresses.first.postcode }
 
-      it "displays the matching transient_registration" do
-        expect(service[:results]).to include(matching_renewal)
-      end
-
-      it "displays the matching registration" do
-        expect(service[:results]).to include(matching_registration)
-      end
+    it "returns the correct count" do
+      expect(service[:count]).to eq(2)
     end
 
-    context "when the term has a case-insensitive match" do
-      let(:term) { matching_renewal.reg_identifier.downcase }
-
-      it "returns the correct count" do
-        expect(service[:count]).to eq(2)
-      end
-
-      it "displays the matching transient_registration" do
-        expect(service[:results]).to include(matching_renewal)
-      end
-
-      it "displays the matching registration" do
-        expect(service[:results]).to include(matching_registration)
-      end
+    it "displays the matching transient_registration" do
+      expect(service[:results]).to include(matching_renewal)
     end
 
-    context "when there is a partial match on the reg_identifier" do
-      let(:term) { matching_renewal.reg_identifier.chop }
+    it "displays the matching registration" do
+      expect(service[:results]).to include(matching_registration)
+    end
+  end
 
-      it "returns the correct count" do
-        expect(service[:count]).to eq(0)
-      end
+  context "when the term has a case-insensitive match" do
+    let(:term) { matching_renewal.reg_identifier.downcase }
 
-      it "does not include the partially-matching transient_registration" do
-        expect(service[:results]).not_to include(matching_renewal)
-      end
-
-      it "does not include the partially-matching registration" do
-        expect(service[:results]).not_to include(matching_registration)
-      end
+    it "returns the correct count" do
+      expect(service[:count]).to eq(2)
     end
 
-    context "when there is a partial match on the last_name" do
-      let(:term) { matching_renewal.last_name.chop }
-
-      it "returns the correct count" do
-        expect(service[:count]).to eq(2)
-      end
-
-      it "includes the partially-matching transient_registration" do
-        expect(service[:results]).to include(matching_renewal)
-      end
-
-      it "includes the partially-matching registration" do
-        expect(service[:results]).to include(matching_registration)
-      end
+    it "displays the matching transient_registration" do
+      expect(service[:results]).to include(matching_renewal)
     end
 
-    context "when the term has excess whitespace" do
-      let(:term) { " #{matching_registration.reg_identifier} " }
+    it "displays the matching registration" do
+      expect(service[:results]).to include(matching_registration)
+    end
+  end
 
-      it "matches the term without whitespace" do
-        expect(service[:results]).to include(matching_registration)
-      end
+  context "when there is a partial match on the reg_identifier" do
+    let(:term) { matching_renewal.reg_identifier.chop }
+
+    it "returns the correct count" do
+      expect(service[:count]).to eq(0)
     end
 
-    context "when there is a match on telephone number" do
-      let(:term) { matching_renewal.phone_number }
+    it "does not include the partially-matching transient_registration" do
+      expect(service[:results]).not_to include(matching_renewal)
+    end
 
-      it "returns the correct count" do
-        expect(service[:count]).to eq(2)
-      end
+    it "does not include the partially-matching registration" do
+      expect(service[:results]).not_to include(matching_registration)
+    end
+  end
 
-      it "displays the matching transient_registration" do
-        expect(service[:results]).to include(matching_renewal)
-      end
+  context "when there is a partial match on the last_name" do
+    let(:term) { matching_renewal.last_name.chop }
 
-      it "displays the matching registration" do
-        expect(service[:results]).to include(matching_registration)
-      end
+    it "returns the correct count" do
+      expect(service[:count]).to eq(2)
+    end
 
-      it "does not display a non-matching transient_registration" do
-        expect(service[:results]).not_to include(non_matching_renewal)
-      end
+    it "includes the partially-matching transient_registration" do
+      expect(service[:results]).to include(matching_renewal)
+    end
 
-      it "does not display a non-matching registration" do
-        expect(service[:results]).not_to include(non_matching_registration)
-      end
+    it "includes the partially-matching registration" do
+      expect(service[:results]).to include(matching_registration)
+    end
+  end
+
+  context "when the term has excess whitespace" do
+    let(:term) { " #{matching_registration.reg_identifier} " }
+
+    it "matches the term without whitespace" do
+      expect(service[:results]).to include(matching_registration)
+    end
+  end
+
+  context "when there is a match on telephone number" do
+    let(:term) { matching_renewal.phone_number }
+
+    it "returns the correct count" do
+      expect(service[:count]).to eq(2)
+    end
+
+    it "displays the matching transient_registration" do
+      expect(service[:results]).to include(matching_renewal)
+    end
+
+    it "displays the matching registration" do
+      expect(service[:results]).to include(matching_registration)
+    end
+
+    it "does not display a non-matching transient_registration" do
+      expect(service[:results]).not_to include(non_matching_renewal)
+    end
+
+    it "does not display a non-matching registration" do
+      expect(service[:results]).not_to include(non_matching_registration)
     end
   end
 end


### PR DESCRIPTION
This change refactors the search services to avoid duplication, and adds the ability to search by email address.
https://eaflood.atlassian.net/browse/RUBY-2195