### PR TITLE
Fix email search validation

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -8,7 +8,7 @@ class DashboardsController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @term = params[:term].strip if params[:term].present?
+    @term = params[:term]&.strip
     @search_type = nil
     @result_count = 0
     @results = []

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -8,7 +8,7 @@ class DashboardsController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @term = params[:term].strip
+    @term = params[:term].strip if params[:term].present?
     @search_type = nil
     @result_count = 0
     @results = []

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -8,7 +8,7 @@ class DashboardsController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @term = params[:term]
+    @term = params[:term].strip
     @search_type = nil
     @result_count = 0
     @results = []

--- a/spec/requests/dashboards_spec.rb
+++ b/spec/requests/dashboards_spec.rb
@@ -33,7 +33,13 @@ RSpec.describe "Dashboards" do
         expect(response).to have_http_status(:ok)
       end
 
-      context "when a search term is included" do
+      context "when no search term is provided" do
+        it "does not raise an error" do
+          expect { get "/bo", params: { term: nil } }.not_to raise_error
+        end
+      end
+
+      context "when a search term is provided" do
 
         context "when there are no matches" do
           it "says there are no results" do

--- a/spec/requests/dashboards_spec.rb
+++ b/spec/requests/dashboards_spec.rb
@@ -107,6 +107,16 @@ RSpec.describe "Dashboards" do
               expect(response.body).to include(registration_path(matching_registration.reg_identifier))
             end
           end
+
+          context "with a valid email search term with whitespace otherwise matching contact_email" do
+            let(:search_term) { " #{matching_registration.contact_email}   " }
+
+            it "includes links to the matched registrations" do
+              subject
+
+              expect(response.body).to include(registration_path(matching_registration.reg_identifier))
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
This change strips whitespace before validating an email address search term.
https://eaflood.atlassian.net/browse/RUBY-2195