### PR TITLE
Email search errors

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: 36bd51ec486321ed31f16dc76054aadd9ad8641c
+  revision: 186a2c77672a1b256a58be16eb3e6c8a64f849f8
   branch: main
   specs:
     waste_carriers_engine (0.0.1)
@@ -140,8 +140,8 @@ GEM
     concurrent-ruby (1.1.10)
     console (1.13.1)
       fiber-local
-    countries (5.1.2)
-      sixarm_ruby_unaccent (~> 1.1)
+    countries (5.2.0)
+      unaccent (~> 0.3)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -149,6 +149,7 @@ GEM
     database_cleaner-mongoid (2.0.1)
       database_cleaner-core (~> 2.0.0)
       mongoid
+    date (3.3.1)
     defra_ruby_address (0.1.0)
       rest-client (~> 2.0)
     defra_ruby_alert (2.1.1)
@@ -278,8 +279,11 @@ GEM
     loofah (2.19.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.7.1)
+    mail (2.8.0)
       mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
@@ -299,17 +303,18 @@ GEM
       mongoid (>= 5.0, < 8)
     multi_json (1.15.0)
     multipart-post (2.1.1)
-    net-imap (0.3.1)
+    net-imap (0.3.2)
+      date
       net-protocol
     net-pop (0.1.2)
       net-protocol
-    net-protocol (0.1.3)
+    net-protocol (0.2.1)
       timeout
     net-smtp (0.3.3)
       net-protocol
     netrc (0.11.0)
     nio4r (2.5.8)
-    nokogiri (1.13.9)
+    nokogiri (1.13.10)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     notifications-ruby-client (5.4.0)
@@ -325,7 +330,7 @@ GEM
     passenger (5.3.7)
       rack
       rake (>= 0.8.1)
-    phonelib (0.7.4)
+    phonelib (0.7.5)
     protocol-hpack (1.4.2)
     protocol-http (0.22.5)
     protocol-http1 (0.14.1)
@@ -340,7 +345,7 @@ GEM
       byebug (~> 11.0)
       pry (>= 0.13, < 0.15)
     public_suffix (5.0.0)
-    racc (1.6.0)
+    racc (1.6.1)
     rack (2.2.4)
     rack-test (2.0.2)
       rack (>= 1.3)
@@ -448,7 +453,6 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    sixarm_ruby_unaccent (1.2.0)
     spring (4.1.0)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
@@ -460,7 +464,7 @@ GEM
     thor (1.2.1)
     tilt (2.0.11)
     timecop (0.9.6)
-    timeout (0.3.0)
+    timeout (0.3.1)
     timers (4.3.3)
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
@@ -470,6 +474,7 @@ GEM
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
     uk_postcode (2.1.8)
+    unaccent (0.4.0)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8.2)

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -14,7 +14,7 @@ class DashboardsController < ApplicationController
     @results = []
 
     if params[:search_fullname] == "1" && params[:search_email] == "1"
-      flash_error(I18n.t(".dashboards.index.search.search_type_error"), nil)
+      flash.now[:error] = I18n.t(".dashboards.index.search.search_type_error")
     else
       @search_type = search_type(params)
     end
@@ -29,7 +29,7 @@ class DashboardsController < ApplicationController
       :fullname
     elsif params[:search_email] == "1"
       if ValidatesEmailFormatOf.validate_email_format(@term)
-        flash_error(I18n.t(".dashboards.index.search.invalid_email_error"), nil)
+        flash.now[:error] = I18n.t(".dashboards.index.search.invalid_email_error")
         nil
       else
         :email

--- a/app/services/base_search_service.rb
+++ b/app/services/base_search_service.rb
@@ -26,9 +26,8 @@ class BaseSearchService < ::WasteCarriersEngine::BaseService
   end
 
   def matching_resources
-    # De-duplicate Registration results by reg_identifier
-    # and TransientRegistration results by reg_identifier and classname.
+    # De-duplicate results for each class by reg_identifier
     search(WasteCarriersEngine::Registration).uniq(&:reg_identifier) +
-      search(WasteCarriersEngine::TransientRegistration).uniq { |reg| "#{reg.reg_identifier}_#{reg.class}" }
+      search(WasteCarriersEngine::RenewingRegistration).uniq(&:reg_identifier)
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -58,7 +58,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   # config.log_tags = [ :subdomain, :uuid ]

--- a/spec/factories/edit_registration.rb
+++ b/spec/factories/edit_registration.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :edit_registration, class: "WasteCarriersEngine::EditRegistration" do
+    initialize_with { new(reg_identifier: create(:registration, :active).reg_identifier) }
+  end
+end

--- a/spec/services/base_search_service_spec.rb
+++ b/spec/services/base_search_service_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BaseSearchService do
+
+  subject(:run_service) { test_service.run(page: page, term: search_term) }
+
+  let(:test_class) do
+    Class.new(described_class) do
+      def run(page:, term:); end
+    end
+  end
+  let(:page) { 1 }
+  let(:search_term) { "search for me" }
+  let(:non_matching_renewal) { create(:renewing_registration) }
+  let(:non_matching_registration) { WasteCarriersEngine::Registration.find_by(reg_identifier: non_matching_renewal.reg_identifier) }
+  let(:matching_renewal1) { create(:renewing_registration) }
+  let(:matching_registration1) { WasteCarriersEngine::Registration.find_by(reg_identifier: matching_renewal1.reg_identifier) }
+  let(:matching_renewal2) { create(:renewing_registration) }
+  let(:matching_registration2) { WasteCarriersEngine::Registration.find_by(reg_identifier: matching_renewal2.reg_identifier) }
+  let(:test_service) { instance_double(test_class) }
+
+  def expected_result_for(entities)
+    {
+      count: entities.count,
+      results: entities
+    }
+  end
+
+  before do
+    allow(test_class).to receive(:new).and_return(test_service)
+    allow(test_service).to receive(:run).with(any_args).and_return(count: 0, results: [])
+  end
+
+  context "when there is no search term" do
+    let(:search_term) { nil }
+
+    it "returns no results" do
+      expect(run_service).to eq(count: 0, results: [])
+    end
+  end
+
+  context "when there is a search term" do
+
+    context "with no matches" do
+      it "returns no results" do
+        expect(run_service).to eq(count: 0, results: [])
+      end
+    end
+
+    context "with matches on a single collection" do
+      before { allow(test_service).to receive(:run).with(any_args).and_return(expected_result_for([matching_renewal1, matching_renewal2])) }
+
+      it "returns the expected count" do
+        expect(run_service[:count]).to eq 2
+      end
+
+      it "returns all matches from the collection" do
+        expect(run_service[:results]).to contain_exactly(matching_renewal1, matching_renewal2)
+      end
+    end
+
+    context "with matches on multiple collections" do
+      before { allow(test_service).to receive(:run).and_return(expected_result_for([matching_renewal1, matching_registration2])) }
+
+      it "returns the expected count" do
+        expect(run_service[:count]).to eq 2
+      end
+
+      it "returns aggregated results from the different collections" do
+        expect(run_service[:results]).to contain_exactly(matching_renewal1, matching_registration2)
+      end
+    end
+
+    context "when there is a match on an edit registration" do
+      let(:edit_registration) { create(:edit_registration) }
+      # Un-stub `run` in the test class to allow search to be stubbed
+      let(:test_class) do
+        Class.new(described_class) do
+          def search(); end
+        end
+      end
+
+      before do
+        allow(test_service).to receive(:search).and_return([
+                                                             matching_renewal1.reg_identifier,
+                                                             matching_registration2.reg_identifier,
+                                                             edit_registration.reg_identifier
+                                                           ])
+      end
+
+      it "does not include the edit registration" do
+        expect(run_service[:results]).not_to include(edit_registration)
+      end
+    end
+  end
+end

--- a/spec/services/search_fullname_service_spec.rb
+++ b/spec/services/search_fullname_service_spec.rb
@@ -21,73 +21,64 @@ RSpec.describe SearchFullnameService do
     matching_registration.save!
   end
 
-  context "when there is no search term" do
-    it "returns no results" do
-      expect(service).to eq(count: 0, results: [])
+  context "with an expected full name match" do
+    let(:term) { "#{first_name} #{last_name}" }
+
+    it "matches the expected registration and renewal only" do
+      expect(service[:results]).to contain_exactly(matching_renewal, matching_registration)
     end
   end
 
-  context "when there is a search term" do
+  context "when there is a match on a last_name only" do
+    let(:term) { last_name }
 
-    context "with an expected full name match" do
-      let(:term) { "#{first_name} #{last_name}" }
+    it "does not return any results" do
+      expect(service[:count]).to eq(0)
+    end
+  end
 
-      it "matches the expected registration and renewal only" do
-        expect(service[:results]).to contain_exactly(matching_renewal, matching_registration)
+  context "when the term has a case-insensitive match" do
+    let(:term) { "#{first_name} #{last_name}".upcase }
+
+    it "matches the expected registration and renewal only" do
+      expect(service[:results]).to contain_exactly(matching_renewal, matching_registration)
+    end
+  end
+
+  context "when the term has excess whitespace" do
+    let(:term) { " #{first_name} #{last_name} " }
+
+    it "matches the term without whitespace" do
+      expect(service[:results]).to include(matching_registration)
+    end
+  end
+
+  context "when there is a match on a key person" do
+    let(:key_first_name) { Faker::Name.first_name }
+    let(:key_last_name) { Faker::Name.last_name }
+    let(:term) { "#{key_first_name} #{key_last_name}" }
+
+    before do
+      matching_registration.key_people[0].first_name = key_first_name
+      matching_registration.key_people[0].last_name = key_last_name
+      matching_registration.save!
+    end
+
+    context "when there is no match on the registration owner" do
+      it "matches the expected registration only" do
+        expect(service[:results]).to contain_exactly(matching_registration)
       end
     end
 
-    context "when there is a match on a last_name only" do
-      let(:term) { last_name }
-
-      it "does not return any results" do
-        expect(service[:count]).to eq(0)
-      end
-    end
-
-    context "when the term has a case-insensitive match" do
-      let(:term) { "#{first_name} #{last_name}".upcase }
-
-      it "matches the expected registration and renewal only" do
-        expect(service[:results]).to contain_exactly(matching_renewal, matching_registration)
-      end
-    end
-
-    context "when the term has excess whitespace" do
-      let(:term) { " #{first_name} #{last_name} " }
-
-      it "matches the term without whitespace" do
-        expect(service[:results]).to include(matching_registration)
-      end
-    end
-
-    context "when there is a match on a key person" do
-      let(:key_first_name) { Faker::Name.first_name }
-      let(:key_last_name) { Faker::Name.last_name }
-      let(:term) { "#{key_first_name} #{key_last_name}" }
-
+    context "when there is a match on both the registration owner and a key person" do
       before do
-        matching_registration.key_people[0].first_name = key_first_name
-        matching_registration.key_people[0].last_name = key_last_name
+        matching_registration.first_name = key_first_name
+        matching_registration.last_name = key_last_name
         matching_registration.save!
       end
 
-      context "when there is no match on the registration owner" do
-        it "matches the expected registration only" do
-          expect(service[:results]).to contain_exactly(matching_registration)
-        end
-      end
-
-      context "when there is a match on both the registration owner and a key person" do
-        before do
-          matching_registration.first_name = key_first_name
-          matching_registration.last_name = key_last_name
-          matching_registration.save!
-        end
-
-        it "returns the registration once only" do
-          expect(service[:results].length).to eq 1
-        end
+      it "returns the registration once only" do
+        expect(service[:results].length).to eq 1
       end
     end
   end

--- a/spec/services/search_service_spec.rb
+++ b/spec/services/search_service_spec.rb
@@ -12,181 +12,158 @@ RSpec.describe SearchService do
 
   let(:non_matching_renewal) { create(:renewing_registration) }
   let(:non_matching_registration) { WasteCarriersEngine::Registration.where(reg_identifier: non_matching_renewal.reg_identifier).first }
+  let(:matching_renewal) { create(:renewing_registration) }
+  let(:matching_registration) { WasteCarriersEngine::Registration.where(reg_identifier: matching_renewal.reg_identifier).first }
 
-  context "when there is no search term" do
-    it "returns no results" do
-      expect(service).to eq(count: 0, results: [])
+  context "when there is a match on a reg_identifier" do
+    let(:term) { matching_renewal.reg_identifier }
+
+    it "returns the correct count" do
+      expect(service[:count]).to eq(2)
+    end
+
+    it "displays the matching transient_registration" do
+      expect(service[:results]).to include(matching_renewal)
+    end
+
+    it "displays the matching registration" do
+      expect(service[:results]).to include(matching_registration)
+    end
+
+    it "does not display a non-matching transient_registration" do
+      expect(service[:results]).not_to include(non_matching_renewal)
+    end
+
+    it "does not display a non-matching registration" do
+      expect(service[:results]).not_to include(non_matching_registration)
     end
   end
 
-  context "when there is a search term" do
-    let(:matching_renewal) do
-      create(:renewing_registration)
-    end
-    let(:matching_registration) { WasteCarriersEngine::Registration.where(reg_identifier: matching_renewal.reg_identifier).first }
+  context "when there is a match on a company_name" do
+    let(:term) { matching_renewal.company_name }
 
-    context "when there are results in different collections" do
-      let(:term) { "search for me" }
-
-      it "returns aggregated results from the different collections" do
-        matching_renewal = create(:renewing_registration, company_name: term)
-        matching_new_registration = create(:new_registration, company_name: term)
-
-        expect(service[:results]).to include(matching_renewal)
-        expect(service[:results]).to include(matching_new_registration)
-      end
+    it "returns the correct count" do
+      expect(service[:count]).to eq(2)
     end
 
-    context "when there is a match on a reg_identifier" do
-      let(:term) { matching_renewal.reg_identifier }
-
-      it "returns the correct count" do
-        expect(service[:count]).to eq(2)
-      end
-
-      it "displays the matching transient_registration" do
-        expect(service[:results]).to include(matching_renewal)
-      end
-
-      it "displays the matching registration" do
-        expect(service[:results]).to include(matching_registration)
-      end
-
-      it "does not display a non-matching transient_registration" do
-        expect(service[:results]).not_to include(non_matching_renewal)
-      end
-
-      it "does not display a non-matching registration" do
-        expect(service[:results]).not_to include(non_matching_registration)
-      end
+    it "displays the matching transient_registration" do
+      expect(service[:results]).to include(matching_renewal)
     end
 
-    context "when there is a match on a company_name" do
-      let(:term) { matching_renewal.company_name }
+    it "displays the matching registration" do
+      expect(service[:results]).to include(matching_registration)
+    end
+  end
 
-      it "returns the correct count" do
-        expect(service[:count]).to eq(2)
-      end
+  context "when there is a match on a last_name" do
+    let(:term) { matching_renewal.last_name }
 
-      it "displays the matching transient_registration" do
-        expect(service[:results]).to include(matching_renewal)
-      end
-
-      it "displays the matching registration" do
-        expect(service[:results]).to include(matching_registration)
-      end
+    it "returns the correct count" do
+      expect(service[:count]).to eq(2)
     end
 
-    context "when there is a match on a last_name" do
-      let(:term) { matching_renewal.last_name }
-
-      it "returns the correct count" do
-        expect(service[:count]).to eq(2)
-      end
-
-      it "displays the matching transient_registration" do
-        expect(service[:results]).to include(matching_renewal)
-      end
-
-      it "displays the matching registration" do
-        expect(service[:results]).to include(matching_registration)
-      end
+    it "displays the matching transient_registration" do
+      expect(service[:results]).to include(matching_renewal)
     end
 
-    context "when there is a match on a postcode" do
-      let(:term) { matching_renewal.addresses.first.postcode }
+    it "displays the matching registration" do
+      expect(service[:results]).to include(matching_registration)
+    end
+  end
 
-      it "returns the correct count" do
-        expect(service[:count]).to eq(2)
-      end
+  context "when there is a match on a postcode" do
+    let(:term) { matching_renewal.addresses.first.postcode }
 
-      it "displays the matching transient_registration" do
-        expect(service[:results]).to include(matching_renewal)
-      end
-
-      it "displays the matching registration" do
-        expect(service[:results]).to include(matching_registration)
-      end
+    it "returns the correct count" do
+      expect(service[:count]).to eq(2)
     end
 
-    context "when the term has a case-insensitive match" do
-      let(:term) { matching_renewal.reg_identifier.downcase }
-
-      it "returns the correct count" do
-        expect(service[:count]).to eq(2)
-      end
-
-      it "displays the matching transient_registration" do
-        expect(service[:results]).to include(matching_renewal)
-      end
-
-      it "displays the matching registration" do
-        expect(service[:results]).to include(matching_registration)
-      end
+    it "displays the matching transient_registration" do
+      expect(service[:results]).to include(matching_renewal)
     end
 
-    context "when there is a partial match on the reg_identifier" do
-      let(:term) { matching_renewal.reg_identifier.chop }
+    it "displays the matching registration" do
+      expect(service[:results]).to include(matching_registration)
+    end
+  end
 
-      it "returns the correct count" do
-        expect(service[:count]).to eq(0)
-      end
+  context "when the term has a case-insensitive match" do
+    let(:term) { matching_renewal.reg_identifier.downcase }
 
-      it "does not include the partially-matching transient_registration" do
-        expect(service[:results]).not_to include(matching_renewal)
-      end
-
-      it "does not include the partially-matching registration" do
-        expect(service[:results]).not_to include(matching_registration)
-      end
+    it "returns the correct count" do
+      expect(service[:count]).to eq(2)
     end
 
-    context "when there is a partial match on the last_name" do
-      let(:term) { matching_renewal.last_name.chop }
-
-      it "returns the correct count" do
-        expect(service[:count]).to eq(2)
-      end
-
-      it "includes the partially-matching transient_registration" do
-        expect(service[:results]).to include(matching_renewal)
-      end
-
-      it "includes the partially-matching registration" do
-        expect(service[:results]).to include(matching_registration)
-      end
+    it "displays the matching transient_registration" do
+      expect(service[:results]).to include(matching_renewal)
     end
 
-    context "when the term has excess whitespace" do
-      let(:term) { " #{matching_registration.reg_identifier} " }
+    it "displays the matching registration" do
+      expect(service[:results]).to include(matching_registration)
+    end
+  end
 
-      it "matches the term without whitespace" do
-        expect(service[:results]).to include(matching_registration)
-      end
+  context "when there is a partial match on the reg_identifier" do
+    let(:term) { matching_renewal.reg_identifier.chop }
+
+    it "returns the correct count" do
+      expect(service[:count]).to eq(0)
     end
 
-    context "when there is a match on telephone number" do
-      let(:term) { matching_renewal.phone_number }
+    it "does not include the partially-matching transient_registration" do
+      expect(service[:results]).not_to include(matching_renewal)
+    end
 
-      it "returns the correct count" do
-        expect(service[:count]).to eq(2)
-      end
+    it "does not include the partially-matching registration" do
+      expect(service[:results]).not_to include(matching_registration)
+    end
+  end
 
-      it "displays the matching transient_registration" do
-        expect(service[:results]).to include(matching_renewal)
-      end
+  context "when there is a partial match on the last_name" do
+    let(:term) { matching_renewal.last_name.chop }
 
-      it "displays the matching registration" do
-        expect(service[:results]).to include(matching_registration)
-      end
+    it "returns the correct count" do
+      expect(service[:count]).to eq(2)
+    end
 
-      it "does not display a non-matching transient_registration" do
-        expect(service[:results]).not_to include(non_matching_renewal)
-      end
+    it "includes the partially-matching transient_registration" do
+      expect(service[:results]).to include(matching_renewal)
+    end
 
-      it "does not display a non-matching registration" do
-        expect(service[:results]).not_to include(non_matching_registration)
-      end
+    it "includes the partially-matching registration" do
+      expect(service[:results]).to include(matching_registration)
+    end
+  end
+
+  context "when the term has excess whitespace" do
+    let(:term) { " #{matching_registration.reg_identifier} " }
+
+    it "matches the term without whitespace" do
+      expect(service[:results]).to include(matching_registration)
+    end
+  end
+
+  context "when there is a match on telephone number" do
+    let(:term) { matching_renewal.phone_number }
+
+    it "returns the correct count" do
+      expect(service[:count]).to eq(2)
+    end
+
+    it "displays the matching transient_registration" do
+      expect(service[:results]).to include(matching_renewal)
+    end
+
+    it "displays the matching registration" do
+      expect(service[:results]).to include(matching_registration)
+    end
+
+    it "does not display a non-matching transient_registration" do
+      expect(service[:results]).not_to include(non_matching_renewal)
+    end
+
+    it "does not display a non-matching registration" do
+      expect(service[:results]).not_to include(non_matching_registration)
     end
   end
 end


### PR DESCRIPTION
This change addresses two issues:
* edit_registrations were unintentionally included in search results, causing an error when the search results were being displayed
* Flash error messages due to an invalid email address were being displayed after the form was reloaded
https://eaflood.atlassian.net/browse/RUBY-2195