### PR TITLE
Add NewRegistrations to default search scope

### DIFF
--- a/app/services/base_search_service.rb
+++ b/app/services/base_search_service.rb
@@ -28,6 +28,7 @@ class BaseSearchService < ::WasteCarriersEngine::BaseService
   def matching_resources
     # De-duplicate results for each class by reg_identifier
     search(WasteCarriersEngine::Registration).uniq(&:reg_identifier) +
-      search(WasteCarriersEngine::RenewingRegistration).uniq(&:reg_identifier)
+      search(WasteCarriersEngine::RenewingRegistration).uniq(&:reg_identifier) +
+      search(WasteCarriersEngine::NewRegistration).uniq(&:reg_identifier)
   end
 end

--- a/app/services/search_fullname_service.rb
+++ b/app/services/search_fullname_service.rb
@@ -4,6 +4,14 @@ class SearchFullnameService < BaseSearchService
 
   private
 
+  # This service searches directly on the collections, not via the models, so we need
+  # to override the base class to ensure only one search on TransientRegistrations.
+  def matching_resources
+    # De-duplicate results for each class by reg_identifier
+    search(WasteCarriersEngine::Registration).uniq(&:reg_identifier) +
+      search(WasteCarriersEngine::RenewingRegistration).uniq(&:reg_identifier)
+  end
+
   def search(model)
     search_registered_name(model) + search_key_people(model)
   end

--- a/spec/services/search_service_spec.rb
+++ b/spec/services/search_service_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe SearchService do
   let(:non_matching_registration) { WasteCarriersEngine::Registration.where(reg_identifier: non_matching_renewal.reg_identifier).first }
   let(:matching_renewal) { create(:renewing_registration) }
   let(:matching_registration) { WasteCarriersEngine::Registration.where(reg_identifier: matching_renewal.reg_identifier).first }
+  let!(:in_progress_registration) { create(:new_registration, company_name: matching_renewal.company_name) }
 
   context "when there is a match on a reg_identifier" do
     let(:term) { matching_renewal.reg_identifier }
@@ -43,7 +44,7 @@ RSpec.describe SearchService do
     let(:term) { matching_renewal.company_name }
 
     it "returns the correct count" do
-      expect(service[:count]).to eq(2)
+      expect(service[:count]).to eq(3)
     end
 
     it "displays the matching transient_registration" do
@@ -52,6 +53,10 @@ RSpec.describe SearchService do
 
     it "displays the matching registration" do
       expect(service[:results]).to include(matching_registration)
+    end
+
+    it "displays the matching in-progress registration" do
+      expect(service[:results]).to include(in_progress_registration)
     end
   end
 


### PR DESCRIPTION
This change fixes a gap in the search service where in-progress registrations were not included in the search results.
https://eaflood.atlassian.net/browse/RUBY-2195