### PR TITLE
Handle nil order item descriptions

### DIFF
--- a/app/views/shared/registrations/_charges_and_amendments.html.erb
+++ b/app/views/shared/registrations/_charges_and_amendments.html.erb
@@ -26,7 +26,7 @@
                 <%= order.date_created.to_formatted_s(:day_month_year_time_slashes) %>
               </td>
               <td class="govuk-table__cell">
-                <%= order_item.description.capitalize %>
+                <%= order_item&.description.capitalize %>
               </td>
               <td class="govuk-table__cell govuk-table__cell--numeric">
                 <%= display_pence_as_pounds_and_cents(order_item.amount) %>

--- a/app/views/shared/registrations/_finance_details.html.erb
+++ b/app/views/shared/registrations/_finance_details.html.erb
@@ -27,7 +27,7 @@
       <% resource.latest_order.order_items.each do |item| %>
         <tr class="govuk-table__row">
           <th scope="row" class="govuk-table__header">
-            <%= item.description.capitalize %>
+            <%= item.description&.capitalize %>
           </th>
           <td class="govuk-table__cell govuk-table__cell--numeric">
             £<%= display_pence_as_pounds(item.amount) %>


### PR DESCRIPTION
This change prevents errors when presenting an order item with a nil description
https://eaflood.atlassian.net/browse/RUBY-2279