### PR TITLE
Rename wcrs_renewals_url config variable to wcrs_fo_link_domain

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: 34fc9435d49a260a64e846f2bae7fb96f4856e6e
+  revision: a02edec6887e3bb3261edbfdaad251f17af9f532
   branch: main
   specs:
     waste_carriers_engine (0.0.1)
@@ -314,7 +314,7 @@ GEM
       net-protocol
     netrc (0.11.0)
     nio4r (2.5.8)
-    nokogiri (1.14.0)
+    nokogiri (1.14.1)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     notifications-ruby-client (5.4.0)

--- a/app/helpers/ad_privacy_policy_helper.rb
+++ b/app/helpers/ad_privacy_policy_helper.rb
@@ -4,7 +4,7 @@ module AdPrivacyPolicyHelper
   def link_to_privacy_policy
     link_to(
       t(".privacy_policy_link_text"),
-      URI.join(Rails.configuration.wcrs_renewals_url, "/fo/pages/privacy").to_s,
+      URI.join(Rails.configuration.wcrs_fo_link_domain, "/fo/pages/privacy").to_s,
       target: "_blank", rel: "noopener"
     )
   end

--- a/app/presenters/notify_renewal_letter_presenter.rb
+++ b/app/presenters/notify_renewal_letter_presenter.rb
@@ -21,7 +21,7 @@ class NotifyRenewalLetterPresenter < WasteCarriersEngine::BasePresenter
   end
 
   def renewal_url
-    root_url = Rails.configuration.wcrs_renewals_url.split("//").last
+    root_url = Rails.configuration.wcrs_fo_link_domain.split("//").last
 
     [root_url,
      "/fo/renew/",

--- a/app/presenters/reminder_letter_presenter.rb
+++ b/app/presenters/reminder_letter_presenter.rb
@@ -40,7 +40,7 @@ class ReminderLetterPresenter < WasteCarriersEngine::BasePresenter
   end
 
   def renewal_url
-    root_url = Rails.configuration.wcrs_renewals_url.split("//").last
+    root_url = Rails.configuration.wcrs_fo_link_domain.split("//").last
 
     [root_url,
      "/fo/renew/",

--- a/app/services/notify/registration_transfer_email_service.rb
+++ b/app/services/notify/registration_transfer_email_service.rb
@@ -12,7 +12,7 @@ module Notify
           reg_identifier: @registration.reg_identifier,
           account_email: @registration.account_email,
           company_name: @registration.company_name,
-          sign_in_link: "#{Rails.configuration.wcrs_renewals_url}/fo/users/sign_in"
+          sign_in_link: "#{Rails.configuration.wcrs_fo_link_domain}/fo/users/sign_in"
         }
       }
     end

--- a/app/services/notify/registration_transfer_with_invite_email_service.rb
+++ b/app/services/notify/registration_transfer_with_invite_email_service.rb
@@ -24,7 +24,7 @@ module Notify
     end
 
     def accept_invite_url
-      [Rails.configuration.wcrs_renewals_url,
+      [Rails.configuration.wcrs_fo_link_domain,
        "/fo/users/invitation/accept?invitation_token=",
        @token].join
     end

--- a/app/services/renewal_magic_link_service.rb
+++ b/app/services/renewal_magic_link_service.rb
@@ -3,7 +3,7 @@
 class RenewalMagicLinkService < WasteCarriersEngine::BaseService
   def run(token:)
     [
-      Rails.configuration.wcrs_renewals_url,
+      Rails.configuration.wcrs_fo_link_domain,
       "/fo/renew/",
       token
     ].join

--- a/config/application.rb
+++ b/config/application.rb
@@ -84,7 +84,9 @@ module WasteCarriersBackOffice
       end
 
     # Paths
-    config.wcrs_renewals_url = ENV["WCRS_RENEWALS_DOMAIN"] || "http://localhost:3002"
+    # This is the domain to use on URLs for FO services such as renewal and deregistration
+    config.wcrs_fo_link_domain = ENV["WCRS_RENEWALS_DOMAIN"] || "http://localhost:3002"
+
     config.wcrs_frontend_url = ENV["WCRS_FRONTEND_DOMAIN"] || "http://localhost:3000"
     config.wcrs_backend_url = ENV["WCRS_FRONTEND_ADMIN_DOMAIN"] || "http://localhost:3000"
     config.wcrs_back_office_url = ENV["WCRS_BACK_OFFICE_DOMAIN"] || "http://localhost:8001"

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -180,7 +180,7 @@ RSpec.describe ActionLinksHelper do
 
         it "returns the registration path" do
           expect(helper.renewal_magic_link_for(resource))
-            .to eq("#{Rails.configuration.wcrs_renewals_url}/fo/renew/#{renew_token}")
+            .to eq("#{Rails.configuration.wcrs_fo_link_domain}/fo/renew/#{renew_token}")
         end
       end
 

--- a/spec/presenters/notify_renewal_letter_presenter_spec.rb
+++ b/spec/presenters/notify_renewal_letter_presenter_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe NotifyRenewalLetterPresenter do
     it "returns a correctly formatted URL" do
       expected_url = "wastecarriersregistration.service.gov.uk/fo/renew/tokengoeshere"
 
-      allow(Rails.configuration).to receive(:wcrs_renewals_url).and_return("https://wastecarriersregistration.service.gov.uk")
+      allow(Rails.configuration).to receive(:wcrs_fo_link_domain).and_return("https://wastecarriersregistration.service.gov.uk")
       expect(subject.renewal_url).to eq(expected_url)
     end
   end

--- a/spec/presenters/reminder_letter_presenter_spec.rb
+++ b/spec/presenters/reminder_letter_presenter_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe ReminderLetterPresenter do
     it "returns a correctly formatted URL" do
       expected_url = "wastecarriersregistration.service.gov.uk/fo/renew/tokengoeshere"
 
-      allow(Rails.configuration).to receive(:wcrs_renewals_url).and_return("https://wastecarriersregistration.service.gov.uk")
+      allow(Rails.configuration).to receive(:wcrs_fo_link_domain).and_return("https://wastecarriersregistration.service.gov.uk")
       expect(subject.renewal_url).to eq(expected_url)
     end
   end

--- a/spec/services/renewal_magic_link_service_spec.rb
+++ b/spec/services/renewal_magic_link_service_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe RenewalMagicLinkService do
   before do
-    allow(Rails.configuration).to receive(:wcrs_renewals_url).and_return("http://example.com")
+    allow(Rails.configuration).to receive(:wcrs_fo_link_domain).and_return("http://example.com")
   end
 
   let(:service) do


### PR DESCRIPTION
This change aligns the front-office configuration with the engine by renaming the `wcrs_renewals_url` config variable to `wcrs_fo_link_domain`.
https://eaflood.atlassian.net/browse/RUBY-2294