### PR TITLE
Drop metaData.distance

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: 9d8cf392402daa2d3743e9a5d49005c73b83a0a2
+  revision: 249b874b6f6bb3d32bb33694d77082dde8632455
   branch: main
   specs:
     waste_carriers_engine (0.0.1)
@@ -25,7 +25,7 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    aasm (5.4.0)
+    aasm (5.5.0)
       concurrent-ruby (~> 1.0)
     actioncable (6.1.7.2)
       actionpack (= 6.1.7.2)
@@ -260,7 +260,7 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (2.6.3)
-    jwt (2.6.0)
+    jwt (2.7.0)
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.2)
@@ -330,7 +330,7 @@ GEM
     passenger (5.3.7)
       rack
       rake (>= 0.8.1)
-    phonelib (0.7.6)
+    phonelib (0.7.7)
     protocol-hpack (1.4.2)
     protocol-http (0.22.5)
     protocol-http1 (0.14.1)

--- a/spec/support/fixtures/expire_set_registration_seed.json
+++ b/spec/support/fixtures/expire_set_registration_seed.json
@@ -19,8 +19,7 @@
         "lastModified" : "2018-05-14T10:38:22.692Z",
         "dateActivated" : "2018-05-14T10:38:22.692Z",
         "status" : "ACTIVE",
-        "route" : "DIGITAL",
-        "distance" : "n/a"
+        "route" : "DIGITAL"
     },
     "financeDetails" : {
         "orders" : [

--- a/spec/support/fixtures/lower_tier_registration_seed.json
+++ b/spec/support/fixtures/lower_tier_registration_seed.json
@@ -18,8 +18,7 @@
         "lastModified" : "2018-05-14T10:38:22.692Z",
         "dateActivated" : "2018-05-14T10:38:22.692Z",
         "status" : "ACTIVE",
-        "route" : "DIGITAL",
-        "distance" : "n/a"
+        "route" : "DIGITAL"
     },
     "financeDetails" : {
         "orders" : [

--- a/spec/support/fixtures/registration_seed.json
+++ b/spec/support/fixtures/registration_seed.json
@@ -18,8 +18,7 @@
         "lastModified" : "2018-05-14T10:38:22.692Z",
         "dateActivated" : "2018-05-14T10:38:22.692Z",
         "status" : "ACTIVE",
-        "route" : "DIGITAL",
-        "distance" : "n/a"
+        "route" : "DIGITAL"
     },
     "financeDetails" : {
         "orders" : [


### PR DESCRIPTION
This change drops `distance` from the test seed JSON files. `distance` was removed from `metaData` in the engine as part of the deregistration changes, as it was unused.
https://eaflood.atlassian.net/browse/RUBY-2297