### PR TITLE
Increasing user invite expiry period to four weeks

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -122,7 +122,7 @@ Devise.setup do |config|
   # The period the generated invitation token is valid, after
   # this period, the invited resource won't be able to accept the invitation.
   # When invite_for is 0 (the default), the invitation won't expire.
-  config.invite_for = 2.weeks
+  config.invite_for = 4.weeks
 
   # Auto-login after the user accepts the invite. If this is false,
   # the user will need to manually log in after accepting the invite.


### PR DESCRIPTION
After feedback increasing user invite expiry period from two to four weeks.
https://eaflood.atlassian.net/browse/RUBY-2358