### PR TITLE
Non-moto refunds

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ gem "defra_ruby_aws", "~> 0.5"
 # Use the waste carriers engine for the user journey
 gem "waste_carriers_engine",
     git: "https://github.com/DEFRA/waste-carriers-engine",
-    branch: "main"
+    branch: "fix/is_moto"
 
 # Use the Defra Ruby Features gem to allow users with the correct permissions to
 # manage feature toggle (create / update / delete) from the back-office.

--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ gem "defra_ruby_aws", "~> 0.5"
 # Use the waste carriers engine for the user journey
 gem "waste_carriers_engine",
     git: "https://github.com/DEFRA/waste-carriers-engine",
-    branch: "fix/is_moto"
+    branch: "main"
 
 # Use the Defra Ruby Features gem to allow users with the correct permissions to
 # manage feature toggle (create / update / delete) from the back-office.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: 72d05c13c66bfc91ed8f962f5c48f741465c539c
-  branch: main
+  revision: b450a6e413440d591dec05da9404dd7a4faffa0d
+  branch: fix/is_moto
   specs:
     waste_carriers_engine (0.0.1)
       aasm (~> 5.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: b450a6e413440d591dec05da9404dd7a4faffa0d
-  branch: fix/is_moto
+  revision: fd9947f00f3fe3afea35803252c99e702e9b571d
+  branch: main
   specs:
     waste_carriers_engine (0.0.1)
       aasm (~> 5.3)
@@ -137,7 +137,7 @@ GEM
     cancancan (3.4.0)
     chronic (0.10.2)
     coderay (1.1.3)
-    concurrent-ruby (1.2.0)
+    concurrent-ruby (1.2.2)
     console (1.13.1)
       fiber-local
     countries (5.3.1)
@@ -325,7 +325,7 @@ GEM
     orm_adapter (0.5.0)
     os_map_ref (0.5.0)
     parallel (1.22.1)
-    parser (3.2.0.0)
+    parser (3.2.1.0)
       ast (~> 2.4.1)
     passenger (5.3.7)
       rack
@@ -385,7 +385,7 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rbtree3 (0.7.0)
-    regexp_parser (2.6.1)
+    regexp_parser (2.7.0)
     responders (3.1.0)
       actionpack (>= 5.2)
       railties (>= 5.2)
@@ -412,21 +412,21 @@ GEM
       rspec-mocks (~> 3.11)
       rspec-support (~> 3.11)
     rspec-support (3.11.1)
-    rubocop (1.43.0)
+    rubocop (1.47.0)
       json (~> 2.3)
       parallel (~> 1.10)
       parser (>= 3.2.0.0)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.24.1, < 2.0)
+      rubocop-ast (>= 1.26.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.24.1)
-      parser (>= 3.1.1.0)
+    rubocop-ast (1.27.0)
+      parser (>= 3.2.1.0)
     rubocop-capybara (2.17.0)
       rubocop (~> 1.41)
-    rubocop-rails (2.17.4)
+    rubocop-rails (2.18.0)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 1.33.0, < 2.0)

--- a/app/services/govpay_refund_service.rb
+++ b/app/services/govpay_refund_service.rb
@@ -25,11 +25,6 @@ class GovpayRefundService < WasteCarriersEngine::BaseService
 
   attr_reader :transient_registration, :payment, :current_user, :amount
 
-  # Use the FO API token unless this is a MOTO payment
-  def override_api_token
-    !payment.moto
-  end
-
   def govpay_payment
     @govpay_payment ||=
       WasteCarriersEngine::GovpayPaymentDetailsService.new(
@@ -59,7 +54,7 @@ class GovpayRefundService < WasteCarriersEngine::BaseService
   def request
     @request ||=
       send_request(
-        method: :post, path: "/payments/#{payment.govpay_id}/refunds", params:, override_api_token:
+        method: :post, path: "/payments/#{payment.govpay_id}/refunds", params:, is_moto: payment.moto
       )
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -242,10 +242,8 @@ Rails.application.routes.draw do
            path: "/bo/reports/quarterly_reports"
 
   # Redirect old Devise routes
-  # rubocop:disable Style/FormatStringToken
   get "/agency_users(*all)" => redirect("/bo/users%{all}")
   get "/admins(*all)" => redirect("/bo/users%{all}")
-  # rubocop:enable Style/FormatStringToken
 
   mount DefraRubyMocks::Engine => "/bo/mocks"
 

--- a/spec/requests/api/registrations_spec.rb
+++ b/spec/requests/api/registrations_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "Registrations API" do
 
       post "/bo/api/registrations", params: data, headers: headers
 
-      response_info = JSON.parse(response.body)
+      response_info = response.parsed_body
       expect(response_info).to have_key("reg_identifier")
       expect(response_info["reg_identifier"]).to start_with("CBDU")
 
@@ -48,7 +48,7 @@ RSpec.describe "Registrations API" do
 
         post "/bo/api/registrations", params: data, headers: headers
 
-        response_info = JSON.parse(response.body)
+        response_info = response.parsed_body
         expect(response_info["reg_identifier"]).to start_with("CBDL")
       end
     end
@@ -62,7 +62,7 @@ RSpec.describe "Registrations API" do
 
         post "/bo/api/registrations", params: data, headers: headers
 
-        response_info = JSON.parse(response.body)
+        response_info = response.parsed_body
         registration = WasteCarriersEngine::Registration.find_by reg_identifier: response_info["reg_identifier"]
 
         expect(registration.expires_on.to_s).to eq("2021-05-14T10:38:22+00:00")


### PR DESCRIPTION
This change aligns the back-office with engine changes to support refunds for non-moto payments.
https://eaflood.atlassian.net/browse/RUBY-2341