### PR TITLE
email export performance

### DIFF
--- a/app/controllers/email_exports_controller.rb
+++ b/app/controllers/email_exports_controller.rb
@@ -33,7 +33,7 @@ class EmailExportsController < ApplicationController
   private
 
   def valid_batch_size?(batch_size)
-    batch_size.is_a?(Integer) && batch_size.positive? && batch_size < 1_000_000
+    batch_size.is_a?(Integer) && batch_size.positive? && batch_size <= 100_000
   end
 
   def authorize_user

--- a/app/controllers/email_exports_controller.rb
+++ b/app/controllers/email_exports_controller.rb
@@ -21,7 +21,7 @@ class EmailExportsController < ApplicationController
     batch_size = params[:batch_size].to_i
 
     if valid_batch_size?(batch_size)
-      DeregistrationEmailExportService.run(params[:batch_size])
+      DeregistrationEmailExportService.run(batch_size)
       redirect_to new_email_exports_list_path
     else
       flash_error(I18n.t("email_exports.messages.error"),

--- a/app/models/deregistration_email_export_serializer.rb
+++ b/app/models/deregistration_email_export_serializer.rb
@@ -31,7 +31,7 @@ class DeregistrationEmailExportSerializer < Reports::BaseCsvFileSerializer
         { "$match": {
           "metaData.status": "ACTIVE",
           tier: "LOWER",
-          contactEmail: { "$exists": true, "$type": 2 },
+          contactEmail: { "$exists": true, "$type": 2, "$ne": "" },
           "metaData.dateRegistered": { "$lte": registration_date_cutoff },
           "email_history.template_id": { "$nin": [@notify_template_id] }
         } },

--- a/app/models/deregistration_email_export_serializer.rb
+++ b/app/models/deregistration_email_export_serializer.rb
@@ -1,14 +1,15 @@
 # frozen_string_literal: true
 
 class DeregistrationEmailExportSerializer < Reports::BaseCsvFileSerializer
-  ATTRIBUTES = {
-    reg_identifier: "reg_identifier",
-    contact_email: "email_address",
-    company_name: "company_name",
-    first_name: "first_name",
-    last_name: "last_name",
-    deregistration_link: "deregistration_link"
+  DATA_ATTRIBUTES = {
+    regIdentifier: "reg_identifier",
+    contactEmail: "email_address",
+    companyName: "company_name",
+    firstName: "first_name",
+    lastName: "last_name"
   }.freeze
+
+  ATTRIBUTES = DATA_ATTRIBUTES.merge({ deregistration_link: "deregistration_link" }).freeze
 
   def initialize(file_path, email_type, notify_template_id, batch_size)
     @email_type = email_type
@@ -25,19 +26,38 @@ class DeregistrationEmailExportSerializer < Reports::BaseCsvFileSerializer
   private
 
   def scope
-    WasteCarriersEngine::Registration
-      .active
-      .lower_tier
-      .where(
-        :contact_email.nin => ["", nil],
-        "metaData.dateRegistered": { "$lte": registration_date_cutoff }
-      )
-      .not_selected_for_email(@notify_template_id)
-      .order_by("metaData.dateRegistered": :asc)
-      .limit(@batch_size)
+    WasteCarriersEngine::Registration.collection.aggregate(
+      [
+        { "$match": {
+          "metaData.status": "ACTIVE",
+          tier: "LOWER",
+          contactEmail: { "$exists": true, "$type": 2 },
+          "metaData.dateRegistered": { "$lte": registration_date_cutoff },
+          "email_history.template_id": { "$nin": [@notify_template_id] }
+        } },
+        { "$project": projectable },
+        { "$sort": { "metaData.dateRegistered": 1 } },
+        { "$limit": @batch_size }
+      ],
+      { allow_disk_use: true }
+    )
   end
 
-  def parse_object(registration)
+  def projectable
+    # DATA_ATTRIBUTES are required in the export
+    # tier and addresses are required to instantiate the registration
+    # metaData.dateRegistered is required to support sorting
+    DATA_ATTRIBUTES.keys.index_with { 1 }
+                   .merge(tier: 1, addresses: 1, "metaData.dateRegistered": 1)
+  end
+
+  # Add just enough to allow the registration to be instantiated for token generation
+  def extend_bson(bson)
+    bson.merge(metaData: {})
+  end
+
+  def parse_object(registration_bson)
+    registration = WasteCarriersEngine::Registration.instantiate(extend_bson(registration_bson))
     presenter = DeregistrationEmailExportPresenter.new(registration)
     row = ATTRIBUTES.map do |key, _value|
       presenter.public_send(key)

--- a/app/models/deregistration_email_export_serializer.rb
+++ b/app/models/deregistration_email_export_serializer.rb
@@ -35,9 +35,9 @@ class DeregistrationEmailExportSerializer < Reports::BaseCsvFileSerializer
           "metaData.dateRegistered": { "$lte": registration_date_cutoff },
           "email_history.template_id": { "$nin": [@notify_template_id] }
         } },
-        { "$project": projectable },
         { "$sort": { "metaData.dateRegistered": 1 } },
-        { "$limit": @batch_size }
+        { "$limit": @batch_size },
+        { "$project": projectable }
       ],
       { allow_disk_use: true }
     )
@@ -46,9 +46,8 @@ class DeregistrationEmailExportSerializer < Reports::BaseCsvFileSerializer
   def projectable
     # DATA_ATTRIBUTES are required in the export
     # tier and addresses are required to instantiate the registration
-    # metaData.dateRegistered is required to support sorting
     DATA_ATTRIBUTES.keys.index_with { 1 }
-                   .merge(tier: 1, addresses: 1, "metaData.dateRegistered": 1)
+                   .merge(tier: 1, addresses: 1)
   end
 
   # Add just enough to allow the registration to be instantiated for token generation

--- a/spec/models/deregistration_email_export_serializer_spec.rb
+++ b/spec/models/deregistration_email_export_serializer_spec.rb
@@ -46,6 +46,24 @@ RSpec.describe DeregistrationEmailExportSerializer do
                            dateRegistered: 15.months.ago))
   end
 
+  let!(:no_email_registration) do
+    create(:registration,
+           tier: "LOWER",
+           contact_email: nil,
+           metaData: build(:metaData,
+                           :active,
+                           dateRegistered: 15.months.ago))
+  end
+
+  let!(:empty_email_registration) do
+    create(:registration,
+           tier: "LOWER",
+           contact_email: "",
+           metaData: build(:metaData,
+                           :active,
+                           dateRegistered: 15.months.ago))
+  end
+
   let!(:already_emailed_registration) do
     create(:registration,
            tier: "LOWER",
@@ -108,6 +126,14 @@ RSpec.describe DeregistrationEmailExportSerializer do
 
       it "does not include the revoked registration" do
         expect(export_content.scan(revoked_registration.reg_identifier).size).to eq 0
+      end
+
+      it "does not include a registration with no contact_email" do
+        expect(export_content.scan(no_email_registration.reg_identifier).size).to eq 0
+      end
+
+      it "does not include a registration with an empty string as contact_email" do
+        expect(export_content.scan(empty_email_registration.reg_identifier).size).to eq 0
       end
 
       context "when the cutoff months environment variable is set" do


### PR DESCRIPTION
This change replaces the query for targeting registrations for deregistration emails with a MongoDB aggregation pipeline. This allows us to apply the `allow_disk_use` flag, which avoids running out of memory, and to better control the sequencing of matching and data retrieval so that only the required attributes are returned.
https://eaflood.atlassian.net/browse/RUBY-2412