### PR TITLE
Registration handling for email exports

### DIFF
--- a/app/models/deregistration_email_export_serializer.rb
+++ b/app/models/deregistration_email_export_serializer.rb
@@ -56,7 +56,7 @@ class DeregistrationEmailExportSerializer < Reports::BaseCsvFileSerializer
   end
 
   def parse_object(registration_bson)
-    registration = WasteCarriersEngine::Registration.instantiate(extend_bson(registration_bson))
+    registration = WasteCarriersEngine::Registration.find_by(reg_identifier: registration_bson[:regIdentifier])
     presenter = DeregistrationEmailExportPresenter.new(registration)
     row = ATTRIBUTES.map do |key, _value|
       presenter.public_send(key)

--- a/app/models/deregistration_email_export_serializer.rb
+++ b/app/models/deregistration_email_export_serializer.rb
@@ -37,22 +37,10 @@ class DeregistrationEmailExportSerializer < Reports::BaseCsvFileSerializer
         } },
         { "$sort": { "metaData.dateRegistered": 1 } },
         { "$limit": @batch_size },
-        { "$project": projectable }
+        { "$project": DATA_ATTRIBUTES.keys.index_with { 1 } }
       ],
       { allow_disk_use: true }
     )
-  end
-
-  def projectable
-    # DATA_ATTRIBUTES are required in the export
-    # tier and addresses are required to instantiate the registration
-    DATA_ATTRIBUTES.keys.index_with { 1 }
-                   .merge(tier: 1, addresses: 1)
-  end
-
-  # Add just enough to allow the registration to be instantiated for token generation
-  def extend_bson(bson)
-    bson.merge(metaData: {})
   end
 
   def parse_object(registration_bson)


### PR DESCRIPTION
This fixes an error which was replacing registrations with partial ones based on query results.
https://eaflood.atlassian.net/browse/RUBY-2412