### PR TITLE
find renewal dates message to be displayed only for upper registrations

### DIFF
--- a/app/views/shared/registrations/_company_details_panel.html.erb
+++ b/app/views/shared/registrations/_company_details_panel.html.erb
@@ -8,8 +8,8 @@
     <p class="govuk-body">
       <%= resource.display_tier_and_registration_type %>
     </p>
-  <% end %>
-  <% if resource.display_expiry_text.present? || resource.account_email.present? %>
+  <% end %> 
+  <% if resource.display_expiry_text.present? || resource.account_email.present? || resource.display_original_registration_date.present? %>
     <p class="govuk-body">
       <% if resource.display_expiry_text.present? %>
         <%= resource.display_expiry_text %>
@@ -21,9 +21,11 @@
       <% end %>
       <%= resource.display_original_registration_date %>
     </p>
-    <p class="govuk-body">
-      <%= t(".find_renewal_dates") %>
-    </p>
+    <% if resource.upper_tier? %>
+      <p class="govuk-body">
+        <%= t(".find_renewal_dates") %>
+      </p>
+    <% end %>
   <% end %>
 <% else %>
   <%= t(".no_company_details_available") %>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-2497

A change has been requested not to show "Find renewal dates" message for lower tier registrations