### PR TITLE
feature/RUBY 2226 wcr ithc low logout functionality does not invalidate session cookie

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,8 @@ ruby "3.1.2"
 
 # Use MongoDB as the database, and mongoid as our ORM for it.
 gem "mongoid", "~> 7.5"
+
+gem "mongo_session_store"
 # Bundle edge Rails instead: gem "rails", github: "rails/rails"
 gem "rails", ">= 6.1.7"
 # Use SCSS for stylesheets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: 1ea1a820863c8b228e21b4d38dabb364bf9c44c9
+  revision: 9c5c55cf5df8a91b94883b7650bfcb77302bcd5c
   branch: main
   specs:
     waste_carriers_engine (0.0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: 35209814e6cc9f122354fa1baa6d4455b2bc1792
+  revision: 1ea1a820863c8b228e21b4d38dabb364bf9c44c9
   branch: main
   specs:
     waste_carriers_engine (0.0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: 9c5c55cf5df8a91b94883b7650bfcb77302bcd5c
+  revision: a66381da21eedfde6bbdb091a822020207876793
   branch: main
   specs:
     waste_carriers_engine (0.0.1)
@@ -13,6 +13,7 @@ GIT
       defra_ruby_validators (>= 2.5.0)
       high_voltage (~> 3.1)
       jbuilder (~> 2.11)
+      mongo_session_store
       mongoid
       mongoid-locker (= 2.0.0)
       nokogiri
@@ -298,6 +299,9 @@ GEM
     minitest (5.18.0)
     mongo (2.18.2)
       bson (>= 4.14.1, < 5.0.0)
+    mongo_session_store (3.2.1)
+      actionpack (>= 4.0)
+      mongo (~> 2.0)
     mongoid (7.5.2)
       activemodel (>= 5.1, < 7.1, != 7.0.0)
       mongo (>= 2.10.5, < 3.0.0)
@@ -537,6 +541,7 @@ DEPENDENCIES
   kaminari (~> 1.2)
   kaminari-mongoid (~> 1.0)
   matrix
+  mongo_session_store
   mongoid (~> 7.5)
   net-imap
   net-pop

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -2,4 +2,4 @@
 
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: "_registrations_back_office_session"
+Rails.application.config.session_store :mongoid_store, key: "_registrations_back_office_session"

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -86,3 +86,7 @@ end
 every :day, at: (ENV["AREA_LOOKUP"] || "01:05"), roles: [:db] do
   rake "lookups:update:missing_area"
 end
+
+every :day, at: (ENV["CLEANUP_OLD_SESSIONS_TIME"] || "01:00"), roles: [:db] do
+  rake "db:sessions:trim"
+end

--- a/lib/tasks/trim.rake
+++ b/lib/tasks/trim.rake
@@ -1,0 +1,14 @@
+namespace :db do
+  namespace :sessions do
+    desc "Trim old sessions from the database (older than 30 days)"
+    task :trim => :environment do
+      cutoff_period = 30.days.ago
+
+      # Assuming that the session data is stored in a Mongoid document named 'Session'
+      MongoidStore::Session.where(:updated_at.lt => cutoff_period).delete_all
+
+      puts "Sessions older than #{cutoff_period} have been removed."
+    end
+  end
+end
+

--- a/lib/tasks/trim.rake
+++ b/lib/tasks/trim.rake
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 namespace :db do
   namespace :sessions do
     desc "Trim old sessions from the database (older than 30 days)"
-    task :trim => :environment do
+    task trim: :environment do
       cutoff_period = 30.days.ago
 
       # Assuming that the session data is stored in a Mongoid document named 'Session'
@@ -11,4 +13,3 @@ namespace :db do
     end
   end
 end
-

--- a/lib/tasks/trim.rake
+++ b/lib/tasks/trim.rake
@@ -4,12 +4,12 @@ namespace :db do
   namespace :sessions do
     desc "Trim old sessions from the database (older than 30 days)"
     task trim: :environment do
-      cutoff_period = 30.days.ago
+      cutoff_time = 30.days.ago
 
       # Assuming that the session data is stored in a Mongoid document named 'Session'
-      MongoidStore::Session.where(:updated_at.lt => cutoff_period).delete_all
+      MongoidStore::Session.where(:updated_at.lt => cutoff_time).delete_all
 
-      puts "Sessions older than #{cutoff_period} have been removed."
+      puts "Sessions older than #{cutoff_time} have been removed."
     end
   end
 end

--- a/spec/lib/tasks/trim_spec.rb
+++ b/spec/lib/tasks/trim_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe 'db:sessions:trim' do
+  before :all do
+    Rails.application.load_tasks
+  end
+
+  it 'removes sessions older than 30 days' do
+    # Create test sessions
+    newer_session = MongoidStore::Session.create!(updated_at: 1.day.ago)
+    older_session = MongoidStore::Session.create!(updated_at: 31.days.ago)
+
+    # Run the rake task
+    Rake::Task['db:sessions:trim'].invoke
+
+    # The newer_session should still exist
+    expect(MongoidStore::Session.find_by(id: newer_session.id)).to be_present
+
+    # The older_session should have been deleted
+    expect {
+      MongoidStore::Session.find(older_session.id)
+    }.to raise_error(Mongoid::Errors::DocumentNotFound)
+  end
+end
+

--- a/spec/lib/tasks/trim_spec.rb
+++ b/spec/lib/tasks/trim_spec.rb
@@ -1,26 +1,23 @@
-require 'rails_helper'
-require 'rake'
+# frozen_string_literal: true
 
-RSpec.describe 'db:sessions:trim' do
-  before :all do
-    Rails.application.load_tasks
-  end
+require "rails_helper"
+require "rake"
 
-  it 'removes sessions older than 30 days' do
+RSpec.describe "db:sessions:trim" do
+  it "removes sessions older than 30 days" do
     # Create test sessions
     newer_session = MongoidStore::Session.create!(updated_at: 1.day.ago)
     older_session = MongoidStore::Session.create!(updated_at: 31.days.ago)
 
     # Run the rake task
-    Rake::Task['db:sessions:trim'].invoke
+    Rake::Task["db:sessions:trim"].invoke
 
     # The newer_session should still exist
     expect(MongoidStore::Session.find_by(id: newer_session.id)).to be_present
 
     # The older_session should have been deleted
-    expect {
+    expect do
       MongoidStore::Session.find(older_session.id)
-    }.to raise_error(Mongoid::Errors::DocumentNotFound)
+    end.to raise_error(Mongoid::Errors::DocumentNotFound)
   end
 end
-

--- a/spec/schedule_spec.rb
+++ b/spec/schedule_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Whenever::Test::Shedule" do
 
   it "makes sure 'rake' statements exist" do
     rake_jobs = schedule.jobs[:rake]
-    expect(rake_jobs.count).to eq(12)
+    expect(rake_jobs.count).to eq(13)
   end
 
   it "picks up the EPR export run frequency and time" do


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-2226

Following the example of https://github.com/DEFRA/flood-risk-back-office/pull/371

This ticket is to fix the issue with old session cookies being reuseable. By now using mongo_session_store they will be persisted

- Add mongoid as session store 
- Add task to remove old sessions from db
