### PR TITLE
RUBY 2555 govpay integration gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,8 @@ gem "waste_carriers_engine",
 # manage feature toggle (create / update / delete) from the back-office.
 gem "defra_ruby_features", "~> 0.1"
 
+gem "defra_ruby_govpay"
+
 # Use the defra ruby mocks engine to add support for mocking external services
 # in live environment. Essentially with this gem added and enabled the app
 # also becomes a 'mock' for external services like companies house.

--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,7 @@ gem "defra_ruby_aws", "~> 0.5"
 # Use the waste carriers engine for the user journey
 gem "waste_carriers_engine",
     git: "https://github.com/DEFRA/waste-carriers-engine",
-    branch: "defra-govpay-fix"
+    branch: "main"
 
 # Use the Defra Ruby Features gem to allow users with the correct permissions to
 # manage feature toggle (create / update / delete) from the back-office.

--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,7 @@ gem "defra_ruby_aws", "~> 0.5"
 # Use the waste carriers engine for the user journey
 gem "waste_carriers_engine",
     git: "https://github.com/DEFRA/waste-carriers-engine",
-    branch: "main"
+    branch: "defra-govpay-fix"
 
 # Use the Defra Ruby Features gem to allow users with the correct permissions to
 # manage feature toggle (create / update / delete) from the back-office.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: 1901d2d1a26c2efca0da32ecb9a6c94c087169e0
+  revision: 2382118c5955e3d5986cc779a3d82ad8afcb2b51
   branch: main
   specs:
     waste_carriers_engine (0.0.1)
@@ -10,6 +10,7 @@ GIT
       defra_ruby_alert (~> 2.1)
       defra_ruby_area (~> 2.0)
       defra_ruby_email
+      defra_ruby_govpay
       defra_ruby_validators (>= 2.5.0)
       high_voltage (~> 3.1)
       jbuilder (~> 2.11)
@@ -170,6 +171,8 @@ GEM
       cancancan (>= 1.10)
       devise (>= 4.4.3)
       rails (~> 6.0)
+    defra_ruby_govpay (0.1.2)
+      rest-client (~> 2.1)
     defra_ruby_mocks (2.4.2)
       rails (~> 6.0)
       sprockets (~> 3.7.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: f1f5a7b758dd53bf819277311fe0930d83772063
-  branch: defra-govpay-fix
+  revision: 86864901b9cbd1aee1012473b28f9db4d0fc9c15
+  branch: main
   specs:
     waste_carriers_engine (0.0.1)
       aasm (~> 5.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -543,6 +543,7 @@ DEPENDENCIES
   database_cleaner-mongoid
   defra_ruby_aws (~> 0.5)
   defra_ruby_features (~> 0.1)
+  defra_ruby_govpay
   defra_ruby_mocks
   defra_ruby_style
   defra_ruby_template

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: 2382118c5955e3d5986cc779a3d82ad8afcb2b51
-  branch: main
+  revision: f1f5a7b758dd53bf819277311fe0930d83772063
+  branch: defra-govpay-fix
   specs:
     waste_carriers_engine (0.0.1)
       aasm (~> 5.3)
@@ -171,7 +171,7 @@ GEM
       cancancan (>= 1.10)
       devise (>= 4.4.3)
       rails (~> 6.0)
-    defra_ruby_govpay (0.1.2)
+    defra_ruby_govpay (0.2.0)
       rest-client (~> 2.1)
     defra_ruby_mocks (2.4.2)
       rails (~> 6.0)
@@ -345,7 +345,7 @@ GEM
     passenger (5.3.7)
       rack
       rake (>= 0.8.1)
-    phonelib (0.8.3)
+    phonelib (0.8.4)
     protocol-hpack (1.4.2)
     protocol-http (0.24.7)
     protocol-http1 (0.15.1)

--- a/app/services/govpay_refund_details_service.rb
+++ b/app/services/govpay_refund_details_service.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class GovpayRefundDetailsService < WasteCarriersEngine::BaseService
-  include WasteCarriersEngine::CanSendGovpayRequest
-
   def run(refund_id:)
     @refund = GovpayFindPaymentService.run(payment_id: refund_id)
     raise ArgumentError, "Invalid refund id #{refund_id}" if refund.nil?
@@ -26,7 +24,7 @@ class GovpayRefundDetailsService < WasteCarriersEngine::BaseService
 
   def request
     @request ||=
-      send_request(
+      DefraRubyGovpayAPI.send_request(
         method: :get, path: "/payments/#{payment.govpay_id}/refunds/#{refund.govpay_id}", is_moto: payment.moto
       )
   end

--- a/app/services/govpay_refund_service.rb
+++ b/app/services/govpay_refund_service.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class GovpayRefundService < WasteCarriersEngine::BaseService
-  include WasteCarriersEngine::CanSendGovpayRequest
-
   def run(payment:, amount:)
     return false unless WasteCarriersEngine.configuration.host_is_back_office?
     return false unless payment.govpay?
@@ -54,7 +52,7 @@ class GovpayRefundService < WasteCarriersEngine::BaseService
 
   def request
     @request ||=
-      send_request(
+      DefraRubyGovpayAPI.send_request(
         method: :post, path: "/payments/#{payment.govpay_id}/refunds", params:, is_moto: payment.moto
       )
   end

--- a/app/services/govpay_refund_service.rb
+++ b/app/services/govpay_refund_service.rb
@@ -34,13 +34,13 @@ class GovpayRefundService < WasteCarriersEngine::BaseService
   end
 
   def refund
-    @refund ||= WasteCarriersEngine::Govpay::Refund.new response
+    @refund ||= DefraRubyGovpay::Refund.new response
   end
 
   def error
     return @error if defined?(@error)
 
-    @error = (Govpay::Error.new(response) if status_code.is_a?(Integer) && (400..500).include?(status_code))
+    @error = (DefraRubyGovpay::Error.new(response) if status_code.is_a?(Integer) && (400..500).include?(status_code))
   end
 
   def params

--- a/spec/services/govpay_refund_details_service_spec.rb
+++ b/spec/services/govpay_refund_details_service_spec.rb
@@ -17,6 +17,15 @@ module WasteCarriersEngine
       before do
         allow(WasteCarriersEngine.configuration).to receive(:host_is_back_office?).and_return(true)
         allow(Rails.configuration).to receive(:govpay_url).and_return(govpay_host)
+
+        DefraRubyGovpay.configure do |config|
+          config.govpay_front_office_api_token = "front_office_token"
+          config.govpay_back_office_api_token = "back_office_token"
+          config.host_is_back_office = true
+        end
+
+        stub_const("DefraRubyGovpayAPI", DefraRubyGovpay::API.new)
+
         registration.finance_details.payments << refund
       end
 
@@ -41,22 +50,33 @@ module WasteCarriersEngine
 
       context "with a valid refund id" do
         let(:refund_id) { refund.govpay_id }
-        let(:front_office_token) { "front office token" }
-        let(:back_office_token) { "back office token" }
+        let(:front_office_token) { "front_office_token" }
+        let(:back_office_token) { "back_office_token" }
         let(:govpay_api_token) { back_office_token }
 
         context "when the govpay request succeeds" do
           before do
             allow(Rails.configuration).to receive(:govpay_front_office_api_token).and_return(front_office_token)
             allow(Rails.configuration).to receive(:govpay_back_office_api_token).and_return(back_office_token)
-            stub_request(:get, %r{.*#{govpay_host}/payments/#{govpay_payment_id}/refunds/#{govpay_refund_id}})
-              .with(headers: { "Authorization" => "Bearer #{govpay_api_token}" })
-              .to_return(status: 200, body: File.read("./spec/fixtures/files/govpay/get_refund_details_response_submitted.json"))
+
+            # https://publicapi.payments.service.gov.uk
+            puts "govpay_api_token: #{govpay_api_token}"
+            stub_request(:get, %r{#{govpay_host}/v1/payments/#{govpay_payment_id}/refunds/#{govpay_refund_id}})
+              .with(
+                headers: {
+                  "Authorization" => "Bearer #{govpay_api_token}",
+                  "Content-Type" => "application/json"
+                }
+              ).to_return(status: 200, body: File.read("./spec/fixtures/files/govpay/get_refund_details_response_submitted.json"))
+
+            # stub_request(:get, %r{.*#{govpay_host}/payments/#{govpay_payment_id}/refunds/#{govpay_refund_id}})
+            # .with(headers: { "Authorization" => "Bearer #{govpay_api_token}" })
+            # .to_return(status: 200, body: File.read("./spec/fixtures/files/govpay/get_refund_details_response_submitted.json"))
           end
 
           context "with a non-MOTO payment" do
             # This ensures that the Govpay API is not stubbed for the back office bearer token,
-            # so the spec will fail if the request is made using the back office token.
+            # so the spec will fail if the request is made using the back_office_token.
             let(:govpay_api_token) { front_office_token }
 
             before { original_payment.update!(moto: false) }
@@ -68,7 +88,7 @@ module WasteCarriersEngine
 
           context "with a MOTO payment" do
             # This ensures that the Govpay API is not stubbed for the front office bearer token,
-            # so the spec will fail if the request is made using the front office token.
+            # so the spec will fail if the request is made using the front_office_token.
             let(:govpay_api_token) { back_office_token }
 
             before { original_payment.update(moto: true) }
@@ -81,24 +101,26 @@ module WasteCarriersEngine
 
         context "when the govpay request fails" do
           before do
-            stub_request(:get, %r{.*#{govpay_host}/payments/#{govpay_payment_id}/refunds/#{govpay_refund_id}})
+            stub_request(:get, %r{#{govpay_host}/v1/payments/#{govpay_payment_id}/refunds/#{govpay_refund_id}})
               .to_return(status: 500)
             allow(Airbrake).to receive(:notify)
           end
 
           it "raises an exception" do
-            expect { run_service }.to raise_exception(WasteCarriersEngine::GovpayApiError)
+            expect { run_service }.to raise_exception(DefraRubyGovpay::GovpayApiError)
           end
 
           it "notifies Airbrake" do
             run_service
-          rescue GovpayApiError
-            expect(Airbrake).to have_received(:notify)
-              .with(RestClient::InternalServerError,
-                    hash_including(
-                      message: "Error sending govpay request",
-                      path: "/payments/#{govpay_payment_id}/refunds/#{govpay_refund_id}"
-                    ))
+          rescue DefraRubyGovpay::GovpayApiError
+            error_message = "Error sending request to govpay (get /payments/#{govpay_payment_id}/refunds/#{govpay_refund_id}, params: ): 500 Internal Server Error"
+            expect(Airbrake).to have_received(:notify) do |error, details|
+              expect(error).to be_a(DefraRubyGovpay::GovpayApiError)
+              expect(error.message).to eq(error_message)
+              expect(details[:message]).to eq("Error in Govpay refund details service")
+              expect(details[:payment_id]).to eq(govpay_payment_id)
+              expect(details[:refund_id]).to eq(govpay_refund_id)
+            end
           end
         end
       end

--- a/spec/services/govpay_refund_details_service_spec.rb
+++ b/spec/services/govpay_refund_details_service_spec.rb
@@ -60,7 +60,6 @@ module WasteCarriersEngine
             allow(Rails.configuration).to receive(:govpay_back_office_api_token).and_return(back_office_token)
 
             # https://publicapi.payments.service.gov.uk
-            puts "govpay_api_token: #{govpay_api_token}"
             stub_request(:get, %r{#{govpay_host}/v1/payments/#{govpay_payment_id}/refunds/#{govpay_refund_id}})
               .with(
                 headers: {
@@ -68,10 +67,6 @@ module WasteCarriersEngine
                   "Content-Type" => "application/json"
                 }
               ).to_return(status: 200, body: File.read("./spec/fixtures/files/govpay/get_refund_details_response_submitted.json"))
-
-            # stub_request(:get, %r{.*#{govpay_host}/payments/#{govpay_payment_id}/refunds/#{govpay_refund_id}})
-            # .with(headers: { "Authorization" => "Bearer #{govpay_api_token}" })
-            # .to_return(status: 200, body: File.read("./spec/fixtures/files/govpay/get_refund_details_response_submitted.json"))
           end
 
           context "with a non-MOTO payment" do

--- a/spec/services/govpay_refund_service_spec.rb
+++ b/spec/services/govpay_refund_service_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe GovpayRefundService do
     stub_const("DefraRubyGovpayAPI", DefraRubyGovpay::API.new)
 
     # retrieve a payment's details
-    stub_request(:get, %r{#{govpay_host}/v1/payments/#{payment.govpay_id}})
+    stub_request(:get, "#{govpay_host}/v1/payments/#{payment.govpay_id}")
       .with(headers: { "Authorization" => "Bearer #{govpay_api_token}" })
       .to_return(
         status: 200,
@@ -40,7 +40,7 @@ RSpec.describe GovpayRefundService do
       )
 
     # requesting a refund
-    stub_request(:post, %r{#{govpay_host}/v1/payments/#{payment.govpay_id}/refunds})
+    stub_request(:post, "#{govpay_host}/v1/payments/#{payment.govpay_id}/refunds")
       .with(headers: { "Authorization" => "Bearer #{govpay_api_token}" })
       .to_return(
         status: 200,

--- a/spec/services/govpay_refund_service_spec.rb
+++ b/spec/services/govpay_refund_service_spec.rb
@@ -23,8 +23,16 @@ RSpec.describe GovpayRefundService do
     allow(Rails.configuration).to receive(:govpay_back_office_api_token).and_return(back_office_api_token)
     payment.update!(govpay_id: "govpay123", payment_type: "GOVPAY", moto: true)
 
+    DefraRubyGovpay.configure do |config|
+      config.govpay_front_office_api_token = "front_office_token"
+      config.govpay_back_office_api_token = "back_office_token"
+      config.host_is_back_office = true
+    end
+
+    stub_const("DefraRubyGovpayAPI", DefraRubyGovpay::API.new)
+
     # retrieve a payment's details
-    stub_request(:get, "#{govpay_host}/payments/#{payment.govpay_id}")
+    stub_request(:get, %r{#{govpay_host}/v1/payments/#{payment.govpay_id}})
       .with(headers: { "Authorization" => "Bearer #{govpay_api_token}" })
       .to_return(
         status: 200,
@@ -32,18 +40,19 @@ RSpec.describe GovpayRefundService do
       )
 
     # requesting a refund
-    stub_request(:post, "#{govpay_host}/payments/#{payment.govpay_id}/refunds")
+    stub_request(:post, %r{#{govpay_host}/v1/payments/#{payment.govpay_id}/refunds})
       .with(headers: { "Authorization" => "Bearer #{govpay_api_token}" })
       .to_return(
         status: 200,
         body: file_fixture("govpay/#{refund_response}.json")
       )
+
   end
 
   describe ".run" do
     context "when the request is valid" do
       it "returns a Refund object with 'submitted' status" do
-        expect(govpay_refund.class).to eq WasteCarriersEngine::Govpay::Refund
+        expect(govpay_refund.class).to eq DefraRubyGovpay::Refund
         expect(govpay_refund.submitted?).to be true
       end
     end
@@ -88,7 +97,7 @@ RSpec.describe GovpayRefundService do
       rescue StandardError
         expect(Airbrake).to have_received(:notify).with(RestClient::InternalServerError,
                                                         hash_including(message: "Error sending govpay request", path: "/payments/#{payment.govpay_id}"))
-        expect(Airbrake).to have_received(:notify).with(WasteCarriersEngine::GovpayApiError,
+        expect(Airbrake).to have_received(:notify).with(DefraRubyGovpay::GovpayApiError,
                                                         hash_including(message: "Error in Govpay refund service", govpay_id: payment.govpay_id))
       end
     end
@@ -104,7 +113,7 @@ RSpec.describe GovpayRefundService do
       rescue StandardError
         expect(Airbrake).to have_received(:notify).with(RestClient::InternalServerError,
                                                         hash_including(message: "Error sending govpay request", path: "/payments/#{payment.govpay_id}/refunds"))
-        expect(Airbrake).to have_received(:notify).with(WasteCarriersEngine::GovpayApiError,
+        expect(Airbrake).to have_received(:notify).with(DefraRubyGovpay::GovpayApiError,
                                                         hash_including(message: "Error in Govpay refund service", govpay_id: payment.govpay_id))
       end
     end

--- a/spec/services/process_refund_service_spec.rb
+++ b/spec/services/process_refund_service_spec.rb
@@ -50,13 +50,13 @@ RSpec.describe ProcessRefundService do
 
           before do
             allow(GovpayRefundService).to receive(:new).and_return(govpay_refund_service)
-            allow(govpay_refund_service).to receive(:run).and_raise(WasteCarriersEngine::GovpayApiError)
+            allow(govpay_refund_service).to receive(:run).and_raise(DefraRubyGovpay::GovpayApiError)
             allow(Airbrake).to receive(:notify)
           end
 
           it "notifies Airbrake" do
             refund_service.run(finance_details: finance_details, payment: payment, user: user)
-          rescue WasteCarriersEngine::GovpayApiError
+          rescue DefraRubyGovpay::GovpayApiError
             expect(Airbrake).to have_received(:notify)
           end
         end


### PR DESCRIPTION
- Bump waste_carriers_engine from `1901d2d` to `2382118`
- Add defra_ruby_govpay gem to gemfile
- Upgrade for new gem
- Fix to specs integrated with govpay gem
- Fix to failing specs
- Update govpay error module
- Update to latest wcr engine
