### PR TITLE
fix/clear_transient_reg_pending_payment

### DIFF
--- a/app/services/remove_deletable_registrations_service.rb
+++ b/app/services/remove_deletable_registrations_service.rb
@@ -34,10 +34,8 @@ class RemoveDeletableRegistrationsService < WasteCarriersEngine::BaseService
     Rails.configuration.data_retention_years.to_i.years.ago.end_of_day
   end
 
-  # rubocop:disable Rails/Output
   def log(msg)
     # Avoid cluttering up the test logs
-    puts msg unless Rails.env.test?
+    puts msg unless Rails.env.test? # rubocop:disable Rails/Output
   end
-  # rubocop:enable Rails/Output
 end

--- a/app/services/transient_registration_cleanup_service.rb
+++ b/app/services/transient_registration_cleanup_service.rb
@@ -6,11 +6,13 @@ class TransientRegistrationCleanupService < WasteCarriersEngine::BaseService
     transient_registrations_without_created_at = no_created_at_transient_registrations_to_remove
 
     # rubocop:disable Rails/Output
+    # :nocov:
     unless Rails.env.test?
       puts "Removing transient_registrations created up to #{oldest_possible_date} excluding #{excluded_states}"
       puts "Removing #{transient_registrations_with_created_at} transient_registrations with a created_at value"
       puts "Removing #{transient_registrations_without_created_at} transient_registrations without a created_at value"
     end
+    # :nocov:
     # rubocop:enable Rails/Output
 
     transient_registrations_with_created_at.destroy_all

--- a/app/services/transient_registration_cleanup_service.rb
+++ b/app/services/transient_registration_cleanup_service.rb
@@ -10,7 +10,8 @@ class TransientRegistrationCleanupService < WasteCarriersEngine::BaseService
     unless Rails.env.test?
       puts "Removing transient_registrations created up to #{oldest_possible_date} excluding #{excluded_states}"
       puts "Removing #{transient_registrations_with_created_at.count} transient_registrations with a created_at value"
-      puts "Removing #{transient_registrations_without_created_at.count} transient_registrations without a created_at value"
+      puts "Removing #{transient_registrations_without_created_at.count} transient_registrations " \
+           "without a created_at value"
     end
     # :nocov:
     # rubocop:enable Rails/Output

--- a/app/services/transient_registration_cleanup_service.rb
+++ b/app/services/transient_registration_cleanup_service.rb
@@ -2,8 +2,19 @@
 
 class TransientRegistrationCleanupService < WasteCarriersEngine::BaseService
   def run
-    transient_registrations_to_remove.destroy_all
-    no_created_at_transient_registrations_to_remove.destroy_all
+    transient_registrations_with_created_at = transient_registrations_to_remove
+    transient_registrations_without_created_at = no_created_at_transient_registrations_to_remove
+
+    # rubocop:disable Rails/Output
+    unless Rails.env.test?
+      puts "Removing transient_registrations created up to #{oldest_possible_date} excluding #{excluded_states}"
+      puts "Removing #{transient_registrations_with_created_at} transient_registrations with a created_at value"
+      puts "Removing #{transient_registrations_without_created_at} transient_registrations without a created_at value"
+    end
+    # rubocop:enable Rails/Output
+
+    transient_registrations_with_created_at.destroy_all
+    transient_registrations_without_created_at.destroy_all
   end
 
   private
@@ -28,12 +39,14 @@ class TransientRegistrationCleanupService < WasteCarriersEngine::BaseService
   end
 
   def oldest_possible_date
-    max = Rails.configuration.max_transient_registration_age_days.to_i
-    max.days.ago
+    @oldest_possible_date = Rails.configuration.max_transient_registration_age_days.to_i.days.ago
   end
 
   def excluded_states
     # we also remove submitted-but-pending-payment transient_registrations older than the cutoff
-    WasteCarriersEngine::RenewingRegistration::SUBMITTED_STATES - ["renewal_received_pending_payment_form"]
+    @excluded_states ||= WasteCarriersEngine::RenewingRegistration::SUBMITTED_STATES - %w[
+      renewal_received_pending_payment_form
+      registration_received_pending_payment_form
+    ]
   end
 end

--- a/app/services/transient_registration_cleanup_service.rb
+++ b/app/services/transient_registration_cleanup_service.rb
@@ -9,8 +9,8 @@ class TransientRegistrationCleanupService < WasteCarriersEngine::BaseService
     # :nocov:
     unless Rails.env.test?
       puts "Removing transient_registrations created up to #{oldest_possible_date} excluding #{excluded_states}"
-      puts "Removing #{transient_registrations_with_created_at} transient_registrations with a created_at value"
-      puts "Removing #{transient_registrations_without_created_at} transient_registrations without a created_at value"
+      puts "Removing #{transient_registrations_with_created_at.count} transient_registrations with a created_at value"
+      puts "Removing #{transient_registrations_without_created_at.count} transient_registrations without a created_at value"
     end
     # :nocov:
     # rubocop:enable Rails/Output

--- a/spec/services/transient_registration_cleanup_service_spec.rb
+++ b/spec/services/transient_registration_cleanup_service_spec.rb
@@ -11,79 +11,75 @@ RSpec.describe TransientRegistrationCleanupService do
     let(:transient_registration) { create(:new_registration) }
     let(:token) { transient_registration.token }
 
-    context "when a transient_registration was created more than 30 days ago" do
-      before do
-        transient_registration.update(created_at: 31.days.ago)
+    shared_examples "deletes it" do
+      it do
+        expect { described_class.run }
+          .to change { WasteCarriersEngine::TransientRegistration.where(token: token).count }
+          .from(1).to(0)
       end
+    end
 
-      it "deletes it" do
-        expect { described_class.run }.to change { WasteCarriersEngine::TransientRegistration.where(token: token).count }.from(1).to(0)
+    shared_examples "does not delete it" do
+      it do
+        expect { described_class.run }
+          .not_to change { WasteCarriersEngine::TransientRegistration.where(token: token).count }
+          .from(1)
+      end
+    end
+
+    context "when a transient_registration was created more than 30 days ago" do
+      before { transient_registration.update(created_at: 31.days.ago) }
+
+      it_behaves_like "deletes it"
+
+      context "when the transient_registration is a submitted registration with a pending payment" do
+        let(:transient_registration) { create(:new_registration, workflow_state: "registration_received_pending_payment_form") }
+
+        it_behaves_like "deletes it"
       end
 
       context "when the transient_registration is a submitted renewal with a pending payment" do
         let(:transient_registration) { create(:renewing_registration, workflow_state: "renewal_received_pending_payment_form") }
 
-        it "deletes it" do
-          expect { described_class.run }.to change { WasteCarriersEngine::TransientRegistration.where(token: token).count }.from(1).to(0)
-        end
+        it_behaves_like "deletes it"
       end
 
       context "when the transient_registration is a submitted renewal with a pending conviction check" do
         let(:transient_registration) { create(:renewing_registration, workflow_state: "renewal_received_pending_conviction_form") }
 
-        it "does not delete it" do
-          expect { described_class.run }.not_to change { WasteCarriersEngine::TransientRegistration.where(token: token).count }.from(1)
-        end
+        it_behaves_like "does not delete it"
       end
 
       context "when the transient_registration was last modified within the last 30 days" do
-        before do
-          transient_registration.metaData.set(last_modified: 31.days.ago)
-        end
+        before { transient_registration.metaData.set(last_modified: 31.days.ago) }
 
-        it "deletes it" do
-          expect { described_class.run }.to change { WasteCarriersEngine::TransientRegistration.where(token: token).count }.from(1).to(0)
-        end
+        it_behaves_like "deletes it"
       end
     end
 
     context "when a transient_registration was created within the last 30 days" do
-      it "does not delete it" do
-        expect { described_class.run }.not_to change { WasteCarriersEngine::TransientRegistration.where(token: token).count }.from(1)
-      end
+      it_behaves_like "does not delete it"
     end
 
     context "when a transient_registration has no created_at" do
-      before do
-        transient_registration.unset(:created_at)
-      end
+      before { transient_registration.unset(:created_at) }
 
       context "when a transient_registration was last modified more than 30 days ago" do
-        before do
-          transient_registration.metaData.set(last_modified: 31.days.ago)
-        end
+        before { transient_registration.metaData.set(last_modified: 31.days.ago) }
 
-        it "deletes it" do
-          expect { described_class.run }.to change { WasteCarriersEngine::TransientRegistration.where(token: token).count }.from(1).to(0)
-        end
+        it_behaves_like "deletes it"
 
         context "when the transient_registration is a submitted renewal" do
           let(:transient_registration) { create(:renewing_registration, workflow_state: "renewal_received_pending_conviction_form") }
 
-          it "does not delete it" do
-            expect { described_class.run }.not_to change { WasteCarriersEngine::TransientRegistration.where(token: token).count }.from(1)
-          end
+          it_behaves_like "does not delete it"
         end
       end
 
       context "when a transient_registration was last modified within the last 30 days" do
-        before do
-          transient_registration.metaData.set(last_modified: 1.day.ago)
-        end
+        before { transient_registration.metaData.set(last_modified: 1.day.ago) }
 
-        it "does not delete it" do
-          expect { described_class.run }.not_to change { WasteCarriersEngine::TransientRegistration.where(token: token).count }.from(1)
-        end
+        it_behaves_like "does not delete it"
       end
     end
   end


### PR DESCRIPTION
Add handling of new registrations and console output to task for clearing old transient registrations.
https://eaflood.atlassian.net/browse/RUBY-2091