### PR TITLE
Chore/ruby 2770 controller permission checks

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,58 +3,5 @@
 class ApplicationController < ActionController::Base
   include WasteCarriersEngine::CanAddDebugLogging
   include CanAuthenticateUser
-
-  # Prevent CSRF attacks by raising an exception.
-  # For APIs, you may want to use :null_session instead.
-  protect_from_forgery with: :exception
-
-  before_action :back_button_cache_buster
-
-  helper WasteCarriersEngine::ApplicationHelper
-
-  # Within our production 'like' environments access to the app can only be
-  # obtained through `/bo`. Therefore to make this clear and ensure there is
-  # no confusion we redirect all requests to `/` to `/bo`
-  # https://stackoverflow.com/a/28822626/6117745
-  def redirect_root_to_dashboard
-    redirect_to bo_path
-  end
-
-  # We need to handle users coming to the app via /bo/renew/CBDU12345 that are
-  # first required to sign in, and those that just come straight to the sign in
-  # page. In the first case we need to redirect them back to /bo/renew/CBDU12345
-  # after sign in, which we're able to do thanks to a handy helper method in
-  # Devise which stores the previous url. In the second case we redirect them to
-  # our dashboard.
-  def after_sign_in_path_for(resource)
-    stored_location_for(resource) || bo_path
-  end
-
-  def after_sign_out_path_for(*)
-    new_user_session_path
-  end
-
-  def after_accept_path_for(*)
-    bo_path
-  end
-
-  # Most generic handler first:
-  # https://apidock.com/rails/ActiveSupport/Rescuable/ClassMethods/rescue_from#518-Define-handlers-in-order-of-most-generic-to-most-specific
-  rescue_from StandardError do |e|
-    Airbrake.notify e
-    Rails.logger.error "Unhandled exception: #{e}"
-    log_transient_registration_details("Uncaught system error", e, @transient_registration)
-    redirect_to "/bo/pages/system_error"
-  end
-
-  rescue_from CanCan::AccessDenied do
-    redirect_to "/bo/pages/permission"
-  end
-
-  # http://jacopretorius.net/2014/01/force-page-to-reload-on-browser-back-in-rails.html
-  def back_button_cache_buster
-    response.headers["Cache-Control"] = "no-cache, no-store, max-age=0, must-revalidate"
-    response.headers["Pragma"] = "no-cache"
-    response.headers["Expires"] = "Fri, 01 Jan 1990 00:00:00 GMT"
-  end
+  include CanActAsBackOfficePage
 end

--- a/app/controllers/back_office_forms_controller.rb
+++ b/app/controllers/back_office_forms_controller.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+# This class combines the form handling logic of WasteCarriersEngine::FormsController
+# with back-office ApplicationController security methods.
+class BackOfficeFormsController < WasteCarriersEngine::FormsController
+  include WasteCarriersEngine::CanAddDebugLogging
+  include CanAuthenticateUser
+
+  prepend_before_action :authenticate_user!
+  before_action :authorize_user
+
+  # Prevent CSRF attacks by raising an exception.
+  # For APIs, you may want to use :null_session instead.
+  protect_from_forgery with: :exception
+
+  before_action :back_button_cache_buster
+
+  helper WasteCarriersEngine::ApplicationHelper
+
+  # Within our production 'like' environments access to the app can only be
+  # obtained through `/bo`. Therefore to make this clear and ensure there is
+  # no confusion we redirect all requests to `/` to `/bo`
+  # https://stackoverflow.com/a/28822626/6117745
+  def redirect_root_to_dashboard
+    redirect_to bo_path
+  end
+
+  # We need to handle users coming to the app via /bo/renew/CBDU12345 that are
+  # first required to sign in, and those that just come straight to the sign in
+  # page. In the first case we need to redirect them back to /bo/renew/CBDU12345
+  # after sign in, which we're able to do thanks to a handy helper method in
+  # Devise which stores the previous url. In the second case we redirect them to
+  # our dashboard.
+  def after_sign_in_path_for(resource)
+    stored_location_for(resource) || bo_path
+  end
+
+  def after_sign_out_path_for(*)
+    new_user_session_path
+  end
+
+  def after_accept_path_for(*)
+    bo_path
+  end
+
+  # Most generic handler first:
+  # https://apidock.com/rails/ActiveSupport/Rescuable/ClassMethods/rescue_from#518-Define-handlers-in-order-of-most-generic-to-most-specific
+  rescue_from StandardError do |e|
+    Airbrake.notify e
+    Rails.logger.error "Unhandled exception: #{e}"
+    log_transient_registration_details("Uncaught system error", e, @transient_registration)
+    redirect_to "/bo/pages/system_error"
+  end
+
+  rescue_from CanCan::AccessDenied do
+    redirect_to "/bo/pages/permission"
+  end
+
+  # http://jacopretorius.net/2014/01/force-page-to-reload-on-browser-back-in-rails.html
+  def back_button_cache_buster
+    response.headers["Cache-Control"] = "no-cache, no-store, max-age=0, must-revalidate"
+    response.headers["Pragma"] = "no-cache"
+    response.headers["Expires"] = "Fri, 01 Jan 1990 00:00:00 GMT"
+  end
+end

--- a/app/controllers/back_office_forms_controller.rb
+++ b/app/controllers/back_office_forms_controller.rb
@@ -1,65 +1,11 @@
 # frozen_string_literal: true
 
 # This class combines the form handling logic of WasteCarriersEngine::FormsController
-# with back-office ApplicationController security methods.
+# with the back-office security methods used by ApplicationController.
 class BackOfficeFormsController < WasteCarriersEngine::FormsController
-  include WasteCarriersEngine::CanAddDebugLogging
-  include CanAuthenticateUser
+  include CanActAsBackOfficePage
 
   prepend_before_action :authenticate_user!
   before_action :authorize_user
 
-  # Prevent CSRF attacks by raising an exception.
-  # For APIs, you may want to use :null_session instead.
-  protect_from_forgery with: :exception
-
-  before_action :back_button_cache_buster
-
-  helper WasteCarriersEngine::ApplicationHelper
-
-  # Within our production 'like' environments access to the app can only be
-  # obtained through `/bo`. Therefore to make this clear and ensure there is
-  # no confusion we redirect all requests to `/` to `/bo`
-  # https://stackoverflow.com/a/28822626/6117745
-  def redirect_root_to_dashboard
-    redirect_to bo_path
-  end
-
-  # We need to handle users coming to the app via /bo/renew/CBDU12345 that are
-  # first required to sign in, and those that just come straight to the sign in
-  # page. In the first case we need to redirect them back to /bo/renew/CBDU12345
-  # after sign in, which we're able to do thanks to a handy helper method in
-  # Devise which stores the previous url. In the second case we redirect them to
-  # our dashboard.
-  def after_sign_in_path_for(resource)
-    stored_location_for(resource) || bo_path
-  end
-
-  def after_sign_out_path_for(*)
-    new_user_session_path
-  end
-
-  def after_accept_path_for(*)
-    bo_path
-  end
-
-  # Most generic handler first:
-  # https://apidock.com/rails/ActiveSupport/Rescuable/ClassMethods/rescue_from#518-Define-handlers-in-order-of-most-generic-to-most-specific
-  rescue_from StandardError do |e|
-    Airbrake.notify e
-    Rails.logger.error "Unhandled exception: #{e}"
-    log_transient_registration_details("Uncaught system error", e, @transient_registration)
-    redirect_to "/bo/pages/system_error"
-  end
-
-  rescue_from CanCan::AccessDenied do
-    redirect_to "/bo/pages/permission"
-  end
-
-  # http://jacopretorius.net/2014/01/force-page-to-reload-on-browser-back-in-rails.html
-  def back_button_cache_buster
-    response.headers["Cache-Control"] = "no-cache, no-store, max-age=0, must-revalidate"
-    response.headers["Pragma"] = "no-cache"
-    response.headers["Expires"] = "Fri, 01 Jan 1990 00:00:00 GMT"
-  end
 end

--- a/app/controllers/cease_or_revoke_forms_controller.rb
+++ b/app/controllers/cease_or_revoke_forms_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-class CeaseOrRevokeFormsController < WasteCarriersEngine::FormsController
-  prepend_before_action :authenticate_user!
+class CeaseOrRevokeFormsController < BackOfficeFormsController
 
   def new
     super(CeaseOrRevokeForm, "cease_or_revoke_form")
@@ -24,4 +23,9 @@ class CeaseOrRevokeFormsController < WasteCarriersEngine::FormsController
                                 CeasedOrRevokedRegistration.new(reg_identifier: token)
   end
   # rubocop:enable Naming/MemoizedInstanceVariableName
+
+  def authorize_user
+    authorize! :cease, WasteCarriersEngine::Registration
+    authorize! :revoke, WasteCarriersEngine::Registration
+  end
 end

--- a/app/controllers/ceased_or_revoked_confirm_forms_controller.rb
+++ b/app/controllers/ceased_or_revoked_confirm_forms_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CeasedOrRevokedConfirmFormsController < WasteCarriersEngine::FormsController
+class CeasedOrRevokedConfirmFormsController < BackOfficeFormsController
   def new
     super(CeasedOrRevokedConfirmForm, "ceased_or_revoked_confirm_form")
   end
@@ -22,5 +22,12 @@ class CeasedOrRevokedConfirmFormsController < WasteCarriersEngine::FormsControll
     flash[:message] = message
 
     redirect_to("/bo")
+  end
+
+  private
+
+  def authorize_user
+    authorize! :cease, WasteCarriersEngine::Registration
+    authorize! :revoke, WasteCarriersEngine::Registration
   end
 end

--- a/app/controllers/concerns/can_act_as_back_office_page.rb
+++ b/app/controllers/concerns/can_act_as_back_office_page.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module CanActAsBackOfficePage
+  extend ActiveSupport::Concern
+
+  # rubocop:disable Metrics/BlockLength
+  included do
+    include WasteCarriersEngine::CanAddDebugLogging
+    include CanAuthenticateUser
+
+    # Prevent CSRF attacks by raising an exception.
+    # For APIs, you may want to use :null_session instead.
+    protect_from_forgery with: :exception
+
+    before_action :back_button_cache_buster
+
+    helper WasteCarriersEngine::ApplicationHelper
+
+    # Within our production 'like' environments access to the app can only be
+    # obtained through `/bo`. Therefore to make this clear and ensure there is
+    # no confusion we redirect all requests to `/` to `/bo`
+    # https://stackoverflow.com/a/28822626/6117745
+    def redirect_root_to_dashboard
+      redirect_to bo_path
+    end
+
+    # We need to handle users coming to the app via /bo/renew/CBDU12345 that are
+    # first required to sign in, and those that just come straight to the sign in
+    # page. In the first case we need to redirect them back to /bo/renew/CBDU12345
+    # after sign in, which we're able to do thanks to a handy helper method in
+    # Devise which stores the previous url. In the second case we redirect them to
+    # our dashboard.
+    def after_sign_in_path_for(resource)
+      stored_location_for(resource) || bo_path
+    end
+
+    def after_sign_out_path_for(*)
+      new_user_session_path
+    end
+
+    def after_accept_path_for(*)
+      bo_path
+    end
+
+    # Most generic handler first:
+    # https://apidock.com/rails/ActiveSupport/Rescuable/ClassMethods/rescue_from#518-Define-handlers-in-order-of-most-generic-to-most-specific
+    rescue_from StandardError do |e|
+      Airbrake.notify e
+      Rails.logger.error "Unhandled exception: #{e}"
+      log_transient_registration_details("Uncaught system error", e, @transient_registration)
+      redirect_to "/bo/pages/system_error"
+    end
+
+    rescue_from CanCan::AccessDenied do
+      redirect_to "/bo/pages/permission"
+    end
+
+    # http://jacopretorius.net/2014/01/force-page-to-reload-on-browser-back-in-rails.html
+    def back_button_cache_buster
+      response.headers["Cache-Control"] = "no-cache, no-store, max-age=0, must-revalidate"
+      response.headers["Pragma"] = "no-cache"
+      response.headers["Expires"] = "Fri, 01 Jan 1990 00:00:00 GMT"
+    end
+  end
+  # rubocop:enable Metrics/BlockLength
+end

--- a/app/controllers/confirm_edit_cancelled_forms_controller.rb
+++ b/app/controllers/confirm_edit_cancelled_forms_controller.rb
@@ -1,11 +1,17 @@
 # frozen_string_literal: true
 
-class ConfirmEditCancelledFormsController < WasteCarriersEngine::FormsController
+class ConfirmEditCancelledFormsController < BackOfficeFormsController
   def new
     super(ConfirmEditCancelledForm, "confirm_edit_cancelled_form")
   end
 
   def create
     super(ConfirmEditCancelledForm, "confirm_edit_cancelled_form")
+  end
+
+  private
+
+  def authorize_user
+    authorize! :edit, WasteCarriersEngine::Registration
   end
 end

--- a/app/controllers/copy_cards_bank_transfer_forms_controller.rb
+++ b/app/controllers/copy_cards_bank_transfer_forms_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CopyCardsBankTransferFormsController < WasteCarriersEngine::FormsController
+class CopyCardsBankTransferFormsController < BackOfficeFormsController
   def new
     return unless super(CopyCardsBankTransferForm, "copy_cards_bank_transfer_form")
 
@@ -18,6 +18,6 @@ class CopyCardsBankTransferFormsController < WasteCarriersEngine::FormsControlle
   end
 
   def authorize_user
-    authorize! :order_copy_cards, @resource
+    authorize! :order_copy_cards, WasteCarriersEngine::Registration
   end
 end

--- a/app/controllers/copy_cards_forms_controller.rb
+++ b/app/controllers/copy_cards_forms_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-class CopyCardsFormsController < WasteCarriersEngine::FormsController
-  prepend_before_action :authenticate_user!
+class CopyCardsFormsController < BackOfficeFormsController
 
   def new
     super(CopyCardsForm, "copy_cards_form")
@@ -24,4 +23,8 @@ class CopyCardsFormsController < WasteCarriersEngine::FormsController
                                 OrderCopyCardsRegistration.new(reg_identifier: token)
   end
   # rubocop:enable Naming/MemoizedInstanceVariableName
+
+  def authorize_user
+    authorize! :order_copy_cards, WasteCarriersEngine::Registration
+  end
 end

--- a/app/controllers/copy_cards_order_completed_forms_controller.rb
+++ b/app/controllers/copy_cards_order_completed_forms_controller.rb
@@ -4,7 +4,6 @@ class CopyCardsOrderCompletedFormsController < WasteCarriersEngine::FormsControl
   include WasteCarriersEngine::UnsubmittableForm
   include WasteCarriersEngine::CannotGoBackForm
   include CanResumeCallRecording
-  include CanAuthenticateUser
 
   before_action :check_and_resume_call_recording, only: %i[new]
 

--- a/app/controllers/copy_cards_payment_forms_controller.rb
+++ b/app/controllers/copy_cards_payment_forms_controller.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
-class CopyCardsPaymentFormsController < WasteCarriersEngine::FormsController
+class CopyCardsPaymentFormsController < BackOfficeFormsController
   include CanPauseCallRecording
-  include CanAuthenticateUser
 
   before_action :check_and_pause_call_recording, only: %i[new]
 
@@ -18,5 +17,9 @@ class CopyCardsPaymentFormsController < WasteCarriersEngine::FormsController
 
   def transient_registration_attributes
     params.fetch(:copy_cards_payment_form, {}).permit(:temp_payment_method)
+  end
+
+  def authorize_user
+    authorize! :order_copy_cards, WasteCarriersEngine::Registration
   end
 end

--- a/app/controllers/edit_bank_transfer_forms_controller.rb
+++ b/app/controllers/edit_bank_transfer_forms_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class EditBankTransferFormsController < WasteCarriersEngine::FormsController
+class EditBankTransferFormsController < BackOfficeFormsController
   def new
     return unless super(EditBankTransferForm, "edit_bank_transfer_form")
 
@@ -15,5 +15,9 @@ class EditBankTransferFormsController < WasteCarriersEngine::FormsController
 
   def set_up_finance_details
     @transient_registration.prepare_for_payment(:bank_transfer, current_user)
+  end
+
+  def authorize_user
+    authorize! :edit, WasteCarriersEngine::Registration
   end
 end

--- a/app/controllers/edit_forms_controller.rb
+++ b/app/controllers/edit_forms_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class EditFormsController < WasteCarriersEngine::FormsController
+class EditFormsController < BackOfficeFormsController
 
   prepend_before_action :authenticate_user!
 
@@ -69,5 +69,9 @@ class EditFormsController < WasteCarriersEngine::FormsController
 
   def fetch_presenters
     @presenter = EditFormPresenter.new(@edit_form, view_context)
+  end
+
+  def authorize_user
+    authorize! :edit, WasteCarriersEngine::Registration
   end
 end

--- a/spec/requests/cease_or_revoke_forms_spec.rb
+++ b/spec/requests/cease_or_revoke_forms_spec.rb
@@ -4,12 +4,14 @@ require "rails_helper"
 
 RSpec.describe "CeaseOrRevokeForms" do
   describe "GET new_cease_or_revoke_form_path" do
-    context "when a user is signed in" do
+
+    it_behaves_like "user is not logged in", action: :get, path: :new_cease_or_revoke_form_path
+    it_behaves_like "user is not authorised to perform action", action: :get, path: :new_cease_or_revoke_form_path, role: :finance
+
+    context "when an agency user is signed in" do
       let(:user) { create(:user, role: "agency_with_refund") }
 
-      before do
-        sign_in(user)
-      end
+      before { sign_in(user) }
 
       context "when no matching registration exists" do
         it "redirects to the invalid token error page" do
@@ -70,29 +72,17 @@ RSpec.describe "CeaseOrRevokeForms" do
         end
       end
     end
-
-    context "when a user is not signed in" do
-      before do
-        user = create(:user)
-        sign_out(user)
-      end
-
-      it "returns a 302 response and redirects to the sign in page" do
-        get new_cease_or_revoke_form_path("foo")
-
-        expect(response).to have_http_status(:found)
-        expect(response).to redirect_to(new_user_session_path)
-      end
-    end
   end
 
   describe "POST cease_or_revoke_forms_path" do
-    context "when a user is signed in" do
+
+    it_behaves_like "user is not logged in", action: :post, path: :cease_or_revoke_forms_path
+    it_behaves_like "user is not authorised to perform action", action: :post, path: :new_cease_or_revoke_form_path, role: :finance
+
+    context "when a valid user is signed in" do
       let(:user) { create(:user, role: "agency_with_refund") }
 
-      before do
-        sign_in(user)
-      end
+      before { sign_in(user) }
 
       context "when no matching registration exists" do
         it "redirects to the invalid token error page and does not create a new transient registration" do
@@ -148,26 +138,6 @@ RSpec.describe "CeaseOrRevokeForms" do
             expect(response).to render_template("cease_or_revoke_forms/new")
           end
         end
-      end
-    end
-
-    context "when a user is not signed in" do
-      let(:registration) { create(:registration) }
-      let(:valid_params) { { token: registration.reg_identifier } }
-
-      before do
-        user = create(:user)
-        sign_out(user)
-      end
-
-      it "returns a 302 response, redirects to the login page and does not create a new transient registration" do
-        original_tr_count = CeasedOrRevokedRegistration.count
-
-        post cease_or_revoke_forms_path(registration.reg_identifier), params: { renewal_start_form: valid_params }
-
-        expect(response).to redirect_to(new_user_session_path)
-        expect(response).to have_http_status(:found)
-        expect(CeasedOrRevokedRegistration.count).to eq(original_tr_count)
       end
     end
   end

--- a/spec/requests/confirm_edit_cancelled_forms_spec.rb
+++ b/spec/requests/confirm_edit_cancelled_forms_spec.rb
@@ -4,12 +4,14 @@ require "rails_helper"
 
 RSpec.describe "ConfirmEditCancelledForms" do
   describe "GET new_confirm_edit_cancelled_form_path" do
-    context "when a valid user is signed in" do
-      let(:user) { create(:user) }
 
-      before do
-        sign_in(user)
-      end
+    it_behaves_like "user is not logged in", action: :get, path: :new_confirm_edit_cancelled_form_path
+    it_behaves_like "user is not authorised to perform action", action: :get, path: :new_confirm_edit_cancelled_form_path, role: :finance
+
+    context "when a valid user is signed in" do
+      let(:user) { create(:user, role: "agency_with_refund") }
+
+      before { sign_in(user) }
 
       context "when no edit registration exists" do
         it "redirects to the invalid page" do
@@ -21,8 +23,7 @@ RSpec.describe "ConfirmEditCancelledForms" do
 
       context "when a valid edit registration exists" do
         let(:transient_registration) do
-          create(:edit_registration,
-                 workflow_state: "confirm_edit_cancelled_form")
+          create(:edit_registration, workflow_state: "confirm_edit_cancelled_form")
         end
 
         it "returns a 200 status" do
@@ -35,12 +36,14 @@ RSpec.describe "ConfirmEditCancelledForms" do
   end
 
   describe "POST confirm_edit_cancelled_form_path" do
-    context "when a valid user is signed in" do
-      let(:user) { create(:user) }
 
-      before do
-        sign_in(user)
-      end
+    it_behaves_like "user is not logged in", action: :post, path: :confirm_edit_cancelled_forms_path
+    it_behaves_like "user is not authorised to perform action", action: :post, path: :confirm_edit_cancelled_forms_path, role: :finance
+
+    context "when a valid user is signed in" do
+      let(:user) { create(:user, role: "agency_with_refund") }
+
+      before { sign_in(user) }
 
       context "when no edit registration exists" do
         it "redirects to the invalid page" do
@@ -52,8 +55,7 @@ RSpec.describe "ConfirmEditCancelledForms" do
 
       context "when a valid edit registration exists" do
         let(:transient_registration) do
-          create(:edit_registration,
-                 workflow_state: "confirm_edit_cancelled_form")
+          create(:edit_registration, workflow_state: "confirm_edit_cancelled_form")
         end
 
         it "redirects to the edit cancelled page" do

--- a/spec/requests/copy_cards_bank_transfer_forms_spec.rb
+++ b/spec/requests/copy_cards_bank_transfer_forms_spec.rb
@@ -4,12 +4,14 @@ require "rails_helper"
 
 RSpec.describe "CopyCardsBankTransferForms" do
   describe "GET new_copy_cards_bank_transfer_form" do
-    context "when a valid user is signed in" do
-      let(:user) { create(:user) }
 
-      before do
-        sign_in(user)
-      end
+    it_behaves_like "user is not logged in", action: :get, path: :new_copy_cards_bank_transfer_form_path
+    it_behaves_like "user is not authorised to perform action", action: :get, path: :new_copy_cards_bank_transfer_form_path, role: :finance
+
+    context "when a valid user is signed in" do
+      let(:user) { create(:user, role: "agency_with_refund") }
+
+      before { sign_in(user) }
 
       context "when a valid transient registration exists" do
         let(:transient_registration) do
@@ -43,12 +45,14 @@ RSpec.describe "CopyCardsBankTransferForms" do
   end
 
   describe "POST new_copy_cards_bank_transfer_form" do
-    context "when a valid user is signed in" do
-      let(:user) { create(:user) }
 
-      before do
-        sign_in(user)
-      end
+    it_behaves_like "user is not logged in", action: :post, path: :copy_cards_bank_transfer_forms_path
+    it_behaves_like "user is not authorised to perform action", action: :post, path: :copy_cards_bank_transfer_forms_path, role: :finance
+
+    context "when a valid user is signed in" do
+      let(:user) { create(:user, role: "agency_with_refund") }
+
+      before { sign_in(user) }
 
       context "when an order is in progress" do
         let(:transient_registration) do

--- a/spec/requests/copy_cards_forms_spec.rb
+++ b/spec/requests/copy_cards_forms_spec.rb
@@ -4,12 +4,14 @@ require "rails_helper"
 
 RSpec.describe "CopyCardsForms" do
   describe "GET new_copy_cards_form_path" do
-    context "when a user is signed in" do
-      let(:user) { create(:user) }
 
-      before do
-        sign_in(user)
-      end
+    it_behaves_like "user is not logged in", action: :get, path: :new_copy_cards_form_path
+    it_behaves_like "user is not authorised to perform action", action: :get, path: :new_copy_cards_form_path, role: :finance
+
+    context "when a valid user is signed in" do
+      let(:user) { create(:user, role: "agency_with_refund") }
+
+      before { sign_in(user) }
 
       context "when no matching registration exists" do
         it "redirects to the invalid token error page" do
@@ -70,29 +72,17 @@ RSpec.describe "CopyCardsForms" do
         end
       end
     end
-
-    context "when a user is not signed in" do
-      before do
-        user = create(:user)
-        sign_out(user)
-      end
-
-      it "returns a 302 response and redirects to the sign in page" do
-        get new_copy_cards_form_path("foo")
-
-        expect(response).to have_http_status(:found)
-        expect(response).to redirect_to(new_user_session_path)
-      end
-    end
   end
 
   describe "POST copy_cards_forms_path" do
-    context "when a user is signed in" do
-      let(:user) { create(:user) }
 
-      before do
-        sign_in(user)
-      end
+    it_behaves_like "user is not logged in", action: :post, path: :copy_cards_forms_path
+    it_behaves_like "user is not authorised to perform action", action: :post, path: :copy_cards_forms_path, role: :finance
+
+    context "when a valid user is signed in" do
+      let(:user) { create(:user, role: "agency_with_refund") }
+
+      before { sign_in(user) }
 
       context "when no matching registration exists" do
         it "redirects to the invalid token error page and does not create a new transient registration" do

--- a/spec/requests/copy_cards_payment_forms_spec.rb
+++ b/spec/requests/copy_cards_payment_forms_spec.rb
@@ -4,6 +4,10 @@ require "rails_helper"
 
 RSpec.describe "CopyCardsPaymentForms" do
   describe "GET new_copy_cards_payment_form_path" do
+
+    it_behaves_like "user is not logged in", action: :get, path: :new_copy_cards_payment_form_path
+    it_behaves_like "user is not authorised to perform action", action: :get, path: :new_copy_cards_payment_form_path, role: :finance
+
     context "when a user is signed in" do
       let(:user) { create(:user, role: :agency_super) }
       let(:call_recording_service) { instance_spy(CallRecordingService) }
@@ -53,25 +57,15 @@ RSpec.describe "CopyCardsPaymentForms" do
         end
       end
     end
-
-    context "when a user is not signed in" do
-      before do
-        user = create(:user)
-        sign_out(user)
-      end
-
-      it "returns a 302 response and redirects to the invalid page" do
-        get new_copy_cards_payment_form_path("foo")
-
-        expect(response).to have_http_status(:found)
-        expect(response).to redirect_to(page_path("invalid"))
-      end
-    end
   end
 
   describe "POST copy_cards_payment_forms_path" do
+
+    it_behaves_like "user is not logged in", action: :post, path: :copy_cards_payment_forms_path
+    it_behaves_like "user is not authorised to perform action", action: :post, path: :copy_cards_payment_forms_path, role: :finance
+
     context "when a user is signed in" do
-      let(:user) { create(:user) }
+      let(:user) { create(:user, role: :agency_super) }
 
       before do
         sign_in(user)
@@ -133,20 +127,6 @@ RSpec.describe "CopyCardsPaymentForms" do
             expect(response).to render_template("copy_cards_payment_forms/new")
           end
         end
-      end
-    end
-
-    context "when a user is not signed in" do
-      before do
-        user = create(:user)
-        sign_out(user)
-      end
-
-      it "returns a 302 response and redirects to an invalid page" do
-        post copy_cards_payment_forms_path(token: "1234")
-
-        expect(response).to have_http_status(:found)
-        expect(response).to redirect_to(page_path("invalid"))
       end
     end
   end

--- a/spec/requests/edit_bank_transfer_forms_spec.rb
+++ b/spec/requests/edit_bank_transfer_forms_spec.rb
@@ -4,8 +4,12 @@ require "rails_helper"
 
 RSpec.describe "EditBankTransferForms" do
   describe "GET new_edit_bank_transfer_form" do
+
+    it_behaves_like "user is not logged in", action: :get, path: :new_edit_bank_transfer_form_path
+    it_behaves_like "user is not authorised to perform action", action: :get, path: :new_edit_bank_transfer_form_path, role: :data_agent
+
     context "when a valid user is signed in" do
-      let(:user) { create(:user) }
+      let(:user) { create(:user, role: :agency) }
 
       before do
         sign_in(user)
@@ -42,8 +46,12 @@ RSpec.describe "EditBankTransferForms" do
   end
 
   describe "POST new_edit_bank_transfer_form" do
+
+    it_behaves_like "user is not logged in", action: :post, path: :edit_bank_transfer_forms_path
+    it_behaves_like "user is not authorised to perform action", action: :post, path: :edit_bank_transfer_forms_path, role: :data_agent
+
     context "when a valid user is signed in" do
-      let(:user) { create(:user) }
+      let(:user) { create(:user, role: :agency) }
 
       before do
         sign_in(user)

--- a/spec/support/shared_examples/user_not_authorised.rb
+++ b/spec/support/shared_examples/user_not_authorised.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "user is not authorised to perform action" do |action:, path:, role:|
+  let(:user) { create(:user, role:) }
+  let(:transient_registration) { create(:new_registration) }
+
+  before { sign_in(user) }
+
+  it "redirects to the permissions error page" do
+    send(action, send(path, transient_registration.token))
+
+    expect(response).to redirect_to("/bo/pages/permission")
+  end
+end

--- a/spec/support/shared_examples/user_not_logged_in.rb
+++ b/spec/support/shared_examples/user_not_logged_in.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "user is not logged in" do |action:, path:|
+  subject(:call_route) { send(action, send(path, "foo")) }
+
+  before do
+    user = create(:user)
+    sign_out(user)
+  end
+
+  it "returns a 302 response" do
+    call_route
+
+    expect(response).to have_http_status(:found)
+  end
+
+  it "redirects to the login page" do
+    call_route
+
+    expect(response).to redirect_to(new_user_session_path)
+  end
+
+  it "does not create a new transient registration" do
+    expect { call_route }.not_to change(WasteCarriersEngine::TransientRegistration, :count)
+  end
+end


### PR DESCRIPTION
This change implements a new BackOfficeFormsController to combine engine forms behaviour and back-office authorisation logic.
https://eaflood.atlassian.net/browse/RUBY-2770