### PR TITLE
[RUBY-2806] Implement CSV file upload for conviction data import with error handling and UI updates

### DIFF
--- a/app/controllers/conviction_imports_controller.rb
+++ b/app/controllers/conviction_imports_controller.rb
@@ -19,7 +19,8 @@ class ConvictionImportsController < ApplicationController
         render :new
       end
     else
-      flash_error(I18n.t("conviction_imports.flash_messages.invalid_file_type"))
+      flash[:error] = I18n.t("conviction_imports.flash_messages.error")
+      flash[:error_details] = I18n.t("conviction_imports.flash_messages.invalid_file_type_details")
       render :new
     end
   end

--- a/app/controllers/conviction_imports_controller.rb
+++ b/app/controllers/conviction_imports_controller.rb
@@ -8,10 +8,18 @@ class ConvictionImportsController < ApplicationController
   def new; end
 
   def create
-    if data_updated_successfully?
-      add_success_flash_message
-      redirect_to bo_path
+    uploaded_file = params[:file]
+    if uploaded_file && File.extname(uploaded_file.original_filename).casecmp(".csv").zero?
+      begin
+        ConvictionImportService.run(uploaded_file.read)
+        add_success_flash_message
+        redirect_to bo_path
+      rescue StandardError => e
+        add_error_flash_message(e)
+        render :new
+      end
     else
+      flash_error(I18n.t("conviction_imports.flash_messages.invalid_file_type"))
       render :new
     end
   end
@@ -20,14 +28,6 @@ class ConvictionImportsController < ApplicationController
 
   def authorize
     authorize! :import_conviction_data, current_user
-  end
-
-  def data_updated_successfully?
-    ConvictionImportService.run(params[:data])
-    true
-  rescue StandardError => e
-    add_error_flash_message(e)
-    false
   end
 
   def add_success_flash_message

--- a/app/views/conviction_imports/new.html.erb
+++ b/app/views/conviction_imports/new.html.erb
@@ -10,17 +10,13 @@
 
     <%= render("shared/flash_messages") %>
 
-    <%= form_tag(conviction_imports_path) do %>
+    <%= form_tag(conviction_imports_path, multipart: true) do %>
       <div class="govuk-form-group">
-        <label class="govuk-label govuk-label--s" for="data">
-          <%= t(".textarea_label") %>
-          <p class="govuk-hint">
-            <%= t(".textarea_hint_1") %>
-            <br>
-            <%= t(".textarea_hint_2") %>
-          </p>
+        <label class="govuk-label govuk-label--s" for="file">
+          <%= t(".file_label") %>
         </label>
-        <%= text_area_tag :data, nil, rows: 10, class: "govuk-textarea" %>
+        <p class="govuk-hint"><%= t(".file_hint") %></p>
+        <%= file_field_tag :file, accept: 'text/csv', class: "govuk-file-upload" %>
       </div>
 
       <div class="govuk-warning-text">

--- a/config/locales/conviction_imports.en.yml
+++ b/config/locales/conviction_imports.en.yml
@@ -16,3 +16,4 @@ en:
         one: "Convictions data has been updated successfully. %{count} record in database."
         other: "Convictions data has been updated successfully. %{count} records in database."
       error: "Error occurred while importing data: %{error}"
+      error_details: "Invalid file format. Please upload a CSV file."

--- a/config/locales/conviction_imports.en.yml
+++ b/config/locales/conviction_imports.en.yml
@@ -1,14 +1,16 @@
 en:
   conviction_imports:
     new:
-      title: "Import conviction data"
-      heading: "Import conviction data"
+      title: "Upload conviction data"
+      heading: "Upload conviction data"
       paragraph1: "The service uses this data when checking for conviction matches. To update the matches, paste the contents of a CSV of convictions into the textarea."
       textarea_label: "Convictions data"
       textarea_hint_1: "The first line must be the headers, for example:"
       textarea_hint_2: "Offender,Birth Date,Company No.,System Flag,Inc Number"
+      file_label: "Upload a file"
+      file_hint: "The conviction data file has to be a CSV"
       warning: "This will overwrite all existing conviction data."
-      button: "Submit data"
+      button: "Upload data"
     flash_messages:
       successful:
         one: "Convictions data has been updated successfully. %{count} record in database."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,7 +12,7 @@ en:
         convictions: Conviction checks
         letters: Download letters
         users: Manage users
-        conviction_imports: Import conviction data
+        conviction_imports: Upload conviction data
         finance_reports: Download finance reports
         quarterly_reports: DEFRA quarterly statistics
         feature_toggles: Toggle features

--- a/spec/fixtures/files/invalid_entities.csv
+++ b/spec/fixtures/files/invalid_entities.csv
@@ -1,0 +1,6 @@
+Offender,Wrong Birth Date Header,Company No.,System Flag,Inc Number
+Apex Limited,NotADate,11111111,ABC,99999999
+"Doe, John",01/01/1991,,DFG,
+Whitespace Inc,,,,
+MissingComma John,01/01/1991,22222222,DEF
+BinaryData John,01/01/1991,33333333,EFG,<<Binary Content>>

--- a/spec/fixtures/files/valid_entities.csv
+++ b/spec/fixtures/files/valid_entities.csv
@@ -1,0 +1,9 @@
+Offender,Birth Date,Company No.,System Flag,Inc Number
+"Blogs, Fred",01/01/1981,,ABC,1234
+"Blogs, Jane",02/02/1982,,BCDEF,2345
+Alex Smith-Brown,1983-03-03T00:00:00.000Z,,CDE,3456
+Bobby Smith,,,,A4567
+Test Waste Services Ltd.,,12345678,PQR,7766
+Recycle-pro (UK) Limited,,9876,RST,
+"Waste Not Want Not, UK",,654321,XYZ,Z-4321-01
+CACI (Test),,1649776,CACI,123

--- a/spec/requests/conviction_imports_spec.rb
+++ b/spec/requests/conviction_imports_spec.rb
@@ -37,16 +37,9 @@ RSpec.describe "ConvictionImports" do
   end
 
   describe "POST /bo/import-convictions" do
-    let(:params) do
-      {
-        data: %(
-Offender,Birth Date,Company No.,System Flag,Inc Number
-Apex Limited,,11111111,ABC,99999999
-"Doe, John",01/01/1991,,DFG,
-   Whitespace Inc   , , , ,
-)
-      }
-    end
+    let(:valid_csv) { fixture_file_upload(Rails.root.join("spec/fixtures/files/valid_entities.csv"), "text/csv") }
+    let(:invalid_csv) { fixture_file_upload(Rails.root.join("spec/fixtures/files/invalid_entities.csv"), "text/csv") }
+    let(:invalid_file) { fixture_file_upload(Rails.root.join("spec/fixtures/files/invalid_file.txt"), "text") }
 
     context "when a valid user is signed in" do
       let(:user) { create(:user, role: :developer) }
@@ -56,20 +49,27 @@ Apex Limited,,11111111,ABC,99999999
       end
 
       it "redirects to the results page and displays a flash message" do
-        post "/bo/import-convictions", params: params
+        post "/bo/import-convictions", params: { file: valid_csv }
 
-        expect(response).to redirect_to("/bo")
-        expect(request.flash[:success]).to eq("Convictions data has been updated successfully. 3 records in database.")
+        expect(response).to redirect_to(bo_path)
+        expect(flash[:success]).to match(/Convictions data has been updated successfully. \d+ records in database./)
+      end
+
+      context "when invalid file type is submitted" do
+        it "renders the new template and displays an error message" do
+          post "/bo/import-convictions", params: { file: invalid_file }
+
+          expect(response).to render_template(:new)
+          expect(flash[:error]).to eq(I18n.t("conviction_imports.flash_messages.error"))
+        end
       end
 
       context "when invalid data is submitted" do
-        let(:params) { { data: "foo" } }
-
-        it "redirects to the :new template and displays an error message" do
-          post "/bo/import-convictions", params: params
+        it "renders the new template and displays an error message" do
+          post "/bo/import-convictions", params: { file: invalid_csv }
 
           expect(response).to render_template(:new)
-          expect(request.flash[:error]).to eq("Error occurred while importing data: Invalid headers")
+          expect(flash[:error]).to match(/Error occurred while importing data:/)
         end
       end
     end
@@ -82,7 +82,7 @@ Apex Limited,,11111111,ABC,99999999
       end
 
       it "redirects to the permissions error page" do
-        post "/bo/import-convictions", params: params
+        post "/bo/import-convictions", params: { file: valid_csv }
 
         expect(response).to redirect_to("/bo/pages/permission")
       end


### PR DESCRIPTION
This pull request allows users to upload conviction data via CSV files rather than pasting it in.

- The import form has been updated to include a file upload field, where only CSV files are allowed. This aligns with the acceptance criteria stated in the corresponding Jira ticket.

- The ConvictionImportsController has been refactored to handle file uploads. It includes error handling for scenarios such as incorrect file types and malformed CSV data.

- The ConvictionImportService has been modified to accept and process the read data from the uploaded file, maintaining the same logic for database population.

- Test cases have been updated to reflect the new file upload functionality, including scenarios for both successful uploads and various error cases.

<img width="1494" alt="image" src="https://github.com/DEFRA/waste-carriers-back-office/assets/8081830/bde93b4e-2fab-4918-9e44-24183125ca1a">

