### PR TITLE
[RUBY-2779] disabling broken auto sign in for back office users after password reset

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: 81eb5f6d6682cc3e780f72346738a323e836a3e0
+  revision: 52415bdd826a31904021eb42c2d5c0caca39577a
   branch: main
   specs:
     waste_carriers_engine (0.0.1)
@@ -324,7 +324,7 @@ GEM
     mongoid-locker (2.0.2)
       mongoid (>= 5.0, < 9)
     multi_json (1.15.0)
-    net-imap (0.4.8)
+    net-imap (0.4.9)
       date
       net-protocol
     net-pop (0.1.2)

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -220,7 +220,7 @@ Devise.setup do |config|
 
   # When set to false, does not sign a user in automatically after their password is
   # reset. Defaults to true, so a user is signed in automatically after a reset.
-  # config.sign_in_after_reset_password = true
+  config.sign_in_after_reset_password = false
 
   # ==> Configuration for :encryptable
   # Allow you to use another hashing or encryption algorithm besides bcrypt (default).


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-2779
- engine updated
- broken auto sign-in has been disabled, preventing misleading "Your login credentials were used in another browser" messages from appearing 