### PR TITLE
[RUBY-2821] Ensuring that Refresh EA Area link does not appear for transient registrations

### DIFF
--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -91,6 +91,7 @@ module ActionLinksHelper
   end
 
   def display_refresh_ea_area_link_for?(resource)
+    return false unless a_registration?(resource)
     return false if resource.company_address.blank?
     return false if resource.company_address.postcode.blank?
 

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -931,6 +931,14 @@ RSpec.describe ActionLinksHelper do
         expect(helper.display_refresh_ea_area_link_for?(resource)).to be(false)
       end
     end
+
+    context "when the resource is a transient registration" do
+      let(:resource) { build(:renewing_registration) }
+
+      it "returns false" do
+        expect(helper.display_refresh_ea_area_link_for?(resource)).to be(false)
+      end
+    end
   end
 
   describe "#display_communication_records_link_for?" do


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-2821