### PR TITLE
handle namespaces on obsolete transient registration types

### DIFF
--- a/app/services/transient_registration_cleanup_service.rb
+++ b/app/services/transient_registration_cleanup_service.rb
@@ -76,7 +76,13 @@ class TransientRegistrationCleanupService < WasteCarriersEngine::BaseService
     # transient_registrations to be instantiated and destroyed:
     invalid_transient_registration_types.each do |type_name|
       console_log "Handling obsolete transient registration type #{type_name}"
-      Object.const_set type_name, Class.new(WasteCarriersEngine::TransientRegistration)
+      # some types are in the WasteCarriersEngine namespace:
+      elements = type_name.split("::")
+      if elements.length > 1
+        elements[0].constantize.const_set elements[1], Class.new(WasteCarriersEngine::TransientRegistration)
+      else
+        Object.const_set type_name, Class.new(WasteCarriersEngine::TransientRegistration)
+      end
     end
   end
 

--- a/spec/services/transient_registration_cleanup_service_spec.rb
+++ b/spec/services/transient_registration_cleanup_service_spec.rb
@@ -86,16 +86,22 @@ RSpec.describe TransientRegistrationCleanupService do
     # This can happen when a transient_registration class is renamed or retired
     # if transient_registrations of the old type remain in the DB.
     context "when a transient_registration has an invalid _type" do
-      before do
-        transient_registration.update(created_at: 31.days.ago, _type: "NonExistentClass")
+      shared_examples "deletes the transient registration" do |type_name|
+        before do
+          transient_registration.update(created_at: 31.days.ago, _type: type_name)
+        end
+
+        # validate test setup
+        it { expect(WasteCarriersEngine::TransientRegistration.pluck(:_type)).to eq [type_name] }
+
+        it { expect { described_class.run }.not_to raise_error }
+
+        it_behaves_like "deletes it"
       end
 
-      # validate test setup
-      it { expect(WasteCarriersEngine::TransientRegistration.pluck(:_type)).to eq ["NonExistentClass"] }
+      it_behaves_like "deletes the transient registration", "NonExistentClass"
 
-      it { expect { described_class.run }.not_to raise_error }
-
-      it_behaves_like "deletes it"
+      it_behaves_like "deletes the transient registration", "WasteCarriersEngine::NonExistentClass"
     end
   end
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-2917