### PR TITLE
Add rake task to clean up invalid conviction signoffs

### DIFF
--- a/lib/tasks/one_off/clear_invalid_conviction_signoffs.rake
+++ b/lib/tasks/one_off/clear_invalid_conviction_signoffs.rake
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+namespace :one_off do
+  desc "Clear redundant conviction signoffs"
+  task clear_invalid_conviction_signoffs: :environment do
+
+    registrations = WasteCarriersEngine::Registration.where(
+      declared_convictions: { "$ne": "yes" },
+      "conviction_search_result.match_result": "NO",
+      "key_people.person_type": { "$ne": "RELEVANT" },
+      "metaData.last_modified": { "$gte": DateTime.parse("2024-03-01") }
+    )
+
+    registrations.each do |registration|
+      registration.conviction_sign_offs&.last&.delete
+    end
+  end
+end

--- a/spec/lib/tasks/clear_invalid_conviction_signoffs_spec.rb
+++ b/spec/lib/tasks/clear_invalid_conviction_signoffs_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "one_off:clear_invalid_conviction_signoffs", type: :rake do
+  let(:task) { Rake::Task["one_off:clear_invalid_conviction_signoffs"] }
+  let(:conviction_sign_offs) { [build(:conviction_sign_off)] }
+  let(:conviction_search_result) { build(:conviction_search_result, :match_result_no) }
+
+  include_context "rake"
+
+  before { task.reenable }
+
+  shared_examples "does not remove the conviction signoff" do
+    it { expect { task.invoke }.not_to change { registration.reload.conviction_sign_offs } }
+  end
+
+  it "runs without error" do
+    expect { task.invoke }.not_to raise_error
+  end
+
+  context "when a registration has declared convictions" do
+    let!(:registration) do # rubocop:disable RSpec/LetSetup
+      create(:registration, conviction_search_result:,
+                            declared_convictions: "yes",
+                            conviction_sign_offs:)
+    end
+
+    it_behaves_like "does not remove the conviction signoff"
+  end
+
+  context "when a registration has a potential conviction match" do
+    let!(:registration) do # rubocop:disable RSpec/LetSetup
+      create(:registration, :requires_conviction_check,
+             conviction_search_result: build(:conviction_search_result, :match_result_yes),
+             conviction_sign_offs:)
+    end
+
+    it_behaves_like "does not remove the conviction signoff"
+  end
+
+  context "when a registration has no declared convictions and no conviction matches" do
+    let!(:registration) do
+      create(:registration, conviction_search_result:,
+                            conviction_sign_offs:)
+    end
+
+    it "removes the redundant conviction signoff" do
+      expect { task.invoke }.to change { registration.reload.conviction_sign_offs.length }.by(-1)
+    end
+
+    context "when the registration has relevant key people" do
+      before { registration.key_people.first.update(person_type: "RELEVANT") }
+
+      it_behaves_like "does not remove the conviction signoff"
+    end
+
+    # limit the scope to the time after this issue manifested in production
+    context "when the registration was last updated before March 2023" do
+      before { registration.metaData.update(last_modified: DateTime.parse("2024-02-29")) }
+
+      it_behaves_like "does not remove the conviction signoff"
+    end
+  end
+end


### PR DESCRIPTION
This one-off task removes conviction signoffs which have been incorrectly added since the last release. 

Registration selection criteria:
- No declared convictions
- No conviction matches
- No "relevant" key people
- Last modified from March 1st 2024 onwards

https://eaflood.atlassian.net/browse/RUBY-3015