### PR TITLE
Fix/ruby 3082 convictions queue missing regs

### DIFF
--- a/lib/tasks/one_off/fix_missing_conviction_signoffs.rake
+++ b/lib/tasks/one_off/fix_missing_conviction_signoffs.rake
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+namespace :one_off do
+  desc "Fix missing conviction signoffs"
+  task fix_missing_conviction_signoffs: :environment do
+
+    registrations = WasteCarriersEngine::Registration.where(
+      :conviction_sign_offs.in => [nil, []],
+      "key_people.conviction_search_result.match_result": "YES",
+      "metaData.last_modified": { "$gte": DateTime.parse("2024-03-01") }
+    )
+
+    puts "Updating #{registrations.count} registration(s)" unless Rails.env.test?
+    count = 0
+    registrations.each do |registration|
+
+      registration.conviction_sign_offs << WasteCarriersEngine::ConvictionSignOff.new(confirmed: "no")
+
+      count += 1
+      puts "#{count}. Added conviction_sign_off to registration #{registration.regIdentifier}" unless Rails.env.test?
+    end
+  end
+end

--- a/spec/lib/tasks/export_copy_card_orders_date_range_spec.rb
+++ b/spec/lib/tasks/export_copy_card_orders_date_range_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Export copy card orders date range task", type: :rake do
+RSpec.describe "Export copy card orders date range task", type: :task do
   subject { Rake.application["reports:export:date_range_copy_card_orders"] }
 
   include_context "rake"

--- a/spec/lib/tasks/export_copy_card_orders_spec.rb
+++ b/spec/lib/tasks/export_copy_card_orders_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Export copy card orders task", type: :rake do
+RSpec.describe "Export copy card orders task", type: :task do
   subject { Rake.application["reports:export:weekly_copy_card_orders"] }
 
   include_context "rake"

--- a/spec/lib/tasks/export_roles_permissions_csv_spec.rb
+++ b/spec/lib/tasks/export_roles_permissions_csv_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "debug:export_roles_permissions", type: :rake do
+RSpec.describe "debug:export_roles_permissions", type: :task do
   subject(:rake_task) { Rake::Task["debug:export_roles_permissions"] }
 
   include_context "rake"

--- a/spec/lib/tasks/generate_finance_reports_spec.rb
+++ b/spec/lib/tasks/generate_finance_reports_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "reports:export:generate_finance_reports", type: :rake do
+RSpec.describe "reports:export:generate_finance_reports", type: :task do
   include_context "rake"
 
   it "runs without error" do

--- a/spec/lib/tasks/lookups_spec.rb
+++ b/spec/lib/tasks/lookups_spec.rb
@@ -3,7 +3,7 @@
 # spec/tasks/lookups_rake_spec.rb
 require "rails_helper"
 
-RSpec.describe "lookups:update:missing_area", type: :rake do
+RSpec.describe "lookups:update:missing_area", type: :task do
   include_context "rake"
   let(:task) { Rake::Task["lookups:update:missing_area"] }
 

--- a/spec/lib/tasks/notify_spec.rb
+++ b/spec/lib/tasks/notify_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Notify task", type: :rake do
+RSpec.describe "Notify task", type: :task do
   include_context "rake"
 
   describe "notify:letters:ad_renewals" do

--- a/spec/lib/tasks/one_off/clear_area_not_found_values_spec.rb
+++ b/spec/lib/tasks/one_off/clear_area_not_found_values_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "one_off:clear_area_not_found_values", type: :rake do
+RSpec.describe "one_off:clear_area_not_found_values", type: :task do
   subject(:rake_task) { Rake::Task["one_off:clear_area_not_found_values"] }
 
   include_context "rake"

--- a/spec/lib/tasks/one_off/clear_duplicate_page_views_spec.rb
+++ b/spec/lib/tasks/one_off/clear_duplicate_page_views_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "one_off:clear_duplicate_page_views", type: :rake do
+RSpec.describe "one_off:clear_duplicate_page_views", type: :task do
   subject(:rake_task) { Rake::Task["one_off:clear_duplicate_page_views"] }
 
   include_context "rake"

--- a/spec/lib/tasks/one_off/clear_invalid_conviction_signoffs_spec.rb
+++ b/spec/lib/tasks/one_off/clear_invalid_conviction_signoffs_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "clearing invalid conviction signoffs", type: :rake do
+RSpec.describe "clearing invalid conviction signoffs", type: :task do
   describe "one_off:clear_invalid_conviction_signoffs" do
     let(:task) { Rake::Task["one_off:clear_invalid_conviction_signoffs"] }
     let(:conviction_sign_offs) { [build(:conviction_sign_off)] }

--- a/spec/lib/tasks/one_off/clear_lower_tier_with_conviction_flags_spec.rb
+++ b/spec/lib/tasks/one_off/clear_lower_tier_with_conviction_flags_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "one_off:clear_lower_tier_with_conviction_flags", type: :rake do
+RSpec.describe "one_off:clear_lower_tier_with_conviction_flags", type: :task do
   let(:task) { Rake::Task["one_off:clear_lower_tier_with_conviction_flags"] }
 
   include_context "rake"

--- a/spec/lib/tasks/one_off/clear_nccc_contact_emails_spec.rb
+++ b/spec/lib/tasks/one_off/clear_nccc_contact_emails_spec.rb
@@ -2,10 +2,11 @@
 
 require "rails_helper"
 
-RSpec.describe "one_off:create_unsubscribe_token_index", type: :rake do
+RSpec.describe "one_off:clear_nccc_contact_emails", type: :task do
   include_context "rake"
 
   it "runs without error" do
+    expect(ClearNcccContactEmailsService).to receive(:run)
     expect { subject.invoke }.not_to raise_error
   end
 end

--- a/spec/lib/tasks/one_off/create_unsubscribe_token_index_spec.rb
+++ b/spec/lib/tasks/one_off/create_unsubscribe_token_index_spec.rb
@@ -2,11 +2,10 @@
 
 require "rails_helper"
 
-RSpec.describe "one_off:clear_nccc_contact_emails", type: :rake do
+RSpec.describe "one_off:create_unsubscribe_token_index", type: :task do
   include_context "rake"
 
   it "runs without error" do
-    expect(ClearNcccContactEmailsService).to receive(:run)
     expect { subject.invoke }.not_to raise_error
   end
 end

--- a/spec/lib/tasks/one_off/embed_page_views_in_user_journey_spec.rb
+++ b/spec/lib/tasks/one_off/embed_page_views_in_user_journey_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "one_off:embed_page_views_in_user_journey", type: :rake do
+RSpec.describe "one_off:embed_page_views_in_user_journey", type: :task do
   subject(:rake_task) { Rake::Task["one_off:embed_page_views_in_user_journey"] }
 
   include_context "rake"

--- a/spec/lib/tasks/one_off/fix_missing_conviction_signoffs_spec.rb
+++ b/spec/lib/tasks/one_off/fix_missing_conviction_signoffs_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "fix missing conviction signoffs", type: :task do
+  describe "one_off:fix_missing_conviction_signoffs" do
+    let(:task) { Rake::Task["one_off:fix_missing_conviction_signoffs"] }
+    let(:conviction_search_result) { build(:conviction_search_result, :match_result_no) }
+    let(:key_people) { build_list(:key_person, 2, conviction_search_result:) }
+
+    include_context "rake"
+
+    before { task.reenable }
+
+    shared_examples "does not add a conviction signoff" do
+      it { expect { task.invoke }.not_to change { registration.reload.conviction_sign_offs } }
+    end
+
+    shared_examples "adds a conviction signoff" do
+      it { expect { task.invoke }.to change { registration.reload.conviction_sign_offs } }
+
+      it "is matched for display on the dashboard" do
+        expect(WasteCarriersEngine::Registration.convictions_possible_match).not_to include(registration)
+
+        task.invoke
+
+        expect(WasteCarriersEngine::Registration.convictions_possible_match).to include(registration)
+      end
+    end
+
+    it { expect { task.invoke }.not_to raise_error }
+
+    context "when a registration has a conviction_sign_off" do
+
+      let!(:registration) do # rubocop:disable RSpec/LetSetup
+        create(:registration, key_people:, conviction_sign_offs: [build(:conviction_sign_off)])
+      end
+
+      it_behaves_like "does not add a conviction signoff"
+    end
+
+    context "when a registration does not have a conviction sign off" do
+
+      let!(:registration) do
+        create(:registration, key_people:, conviction_sign_offs: [])
+      end
+
+      context "when all key people have a conviction search result of \"NO\"" do
+        let(:match_result) { :match_result_no }
+
+        it_behaves_like "does not add a conviction signoff"
+      end
+
+      context "when a key person has a conviction search result of \"YES\"" do
+        before { registration.key_people.last.conviction_search_result.update(match_result: "YES") }
+
+        it_behaves_like "adds a conviction signoff"
+      end
+
+      # limit the scope to the time after this issue manifested in production
+      context "when the registration was last updated before March 2023" do
+        before { registration.metaData.update(last_modified: DateTime.parse("2024-02-29")) }
+
+        it_behaves_like "does not add a conviction signoff"
+      end
+    end
+  end
+end

--- a/spec/lib/tasks/one_off/fix_transient_registrations_with_obsolete_fields_spec.rb
+++ b/spec/lib/tasks/one_off/fix_transient_registrations_with_obsolete_fields_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "one_off:fix_transient_registrations_with_obsolete_fields", type: :rake do
+RSpec.describe "one_off:fix_transient_registrations_with_obsolete_fields", type: :task do
   let(:task) { Rake::Task["one_off:fix_transient_registrations_with_obsolete_fields"] }
 
   include_context "rake"

--- a/spec/lib/tasks/one_off/map_user_journey_types_to_transient_registration_classes_spec.rb
+++ b/spec/lib/tasks/one_off/map_user_journey_types_to_transient_registration_classes_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "one_off:map_user_journey_types_to_transient_registration_classes", type: :rake do
+RSpec.describe "one_off:map_user_journey_types_to_transient_registration_classes", type: :task do
   subject(:rake_task) { Rake::Task["one_off:map_user_journey_types_to_transient_registration_classes"] }
 
   include_context "rake"

--- a/spec/lib/tasks/one_off/rename_import_conviction_data_role_spec.rb
+++ b/spec/lib/tasks/one_off/rename_import_conviction_data_role_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "one_off:rename_import_conviction_data_role", type: :rake do
+RSpec.describe "one_off:rename_import_conviction_data_role", type: :task do
   include_context "rake"
 
   it "runs without error" do

--- a/spec/lib/tasks/summary_stats_for_date_range_spec.rb
+++ b/spec/lib/tasks/summary_stats_for_date_range_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "summary_stats:stats_for_date_range", type: :rake do
+RSpec.describe "summary_stats:stats_for_date_range", type: :task do
   include_context "rake"
 
   original_stdout = $stdout

--- a/spec/support/rake_env.rb
+++ b/spec/support/rake_env.rb
@@ -39,11 +39,11 @@ RSpec.configure do |config|
     Rake::Task.define_task(:environment)
   end
 
-  config.before(:each, type: :rake) do
+  config.before(:each, type: :task) do
     DatabaseCleaner.strategy = :deletion
   end
 
-  config.after(type: :rake) do
+  config.after(type: :task) do
     DatabaseCleaner.clean_with(:deletion)
   end
 end


### PR DESCRIPTION
This fixes an issue which was preventing certain registrations from appearing in the convictions queue.
https://eaflood.atlassian.net/browse/RUBY-3082