### PR TITLE
Fix/ruby 3139 reverse manual payments

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: 576d9e9d586cc4d27a616b38df896e615ccfd82a
+  revision: 53331092bae8fe3c3daaa477cea9a26332b8af73
   branch: main
   specs:
     waste_carriers_engine (0.0.1)
@@ -569,7 +569,7 @@ GEM
       whenever
     wicked_pdf (2.6.3)
       activesupport
-    zeitwerk (2.6.13)
+    zeitwerk (2.6.14)
 
 PLATFORMS
   ruby

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -101,7 +101,7 @@ class Ability
     can :record_missed_card_payment, :all
     can :view_payments, :all
     can :reverse, WasteCarriersEngine::Payment, &:govpay?
-    can :reverse, WasteCarriersEngine::Payment, &:missed_card?
+    can :reverse, WasteCarriersEngine::Payment, &:worldpay_missed?
   end
 
   def permissions_for_agency_super_user

--- a/spec/factories/payment.rb
+++ b/spec/factories/payment.rb
@@ -30,10 +30,6 @@ FactoryBot.define do
       payment_type { WasteCarriersEngine::Payment::WORLDPAY_MISSED }
     end
 
-    trait :missed_card do
-      payment_type { WasteCarriersEngine::Payment::MISSED_CARD }
-    end
-
     trait :govpay do
       payment_type { WasteCarriersEngine::Payment::GOVPAY }
       govpay_id { SecureRandom.hex(24) }

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -294,7 +294,7 @@ RSpec.describe Ability do
       end
 
       it_behaves_like "allows only the permitted roles", false, :reverse,
-                      WasteCarriersEngine::Payment.new(payment_type: WasteCarriersEngine::Payment::MISSED_CARD)
+                      WasteCarriersEngine::Payment.new(payment_type: WasteCarriersEngine::Payment::WORLDPAY_MISSED)
     end
   end
 


### PR DESCRIPTION
Switch from the unused MISSED_PAYMENT payment type to WORLDPAY_MISSED for the new reversal access change.
https://eaflood.atlassian.net/browse/RUBY-3139