### PR TITLE
[RUBY-3223] Update Gemfile and asset configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,24 @@
 
 ## [Unreleased](https://github.com/defra/waste-carriers-back-office/tree/HEAD)
 
-[Full Changelog](https://github.com/defra/waste-carriers-back-office/compare/v1.25.1...HEAD)
+[Full Changelog](https://github.com/defra/waste-carriers-back-office/compare/v1.26.0...HEAD)
+
+**Implemented enhancements:**
+
+- Feature/ruby 2859 wcr ensure that scheduled job start and completion events are being recorded in logs [\#1965](https://github.com/DEFRA/waste-carriers-back-office/pull/1965) ([brujeo](https://github.com/brujeo))
+
+**Fixed bugs:**
+
+- \[RUBY-3222\] feat: Add rake task to fix communications\_opted\_in [\#1970](https://github.com/DEFRA/waste-carriers-back-office/pull/1970) ([brujeo](https://github.com/brujeo))
+- Fix/ruby 2919 govpay mocks config [\#1957](https://github.com/DEFRA/waste-carriers-back-office/pull/1957) ([PaulDoyle-DEFRA](https://github.com/PaulDoyle-DEFRA))
+
+**Merged pull requests:**
+
+- Bump faker from 3.3.1 to 3.4.1 [\#1956](https://github.com/DEFRA/waste-carriers-back-office/pull/1956) ([dependabot[bot]](https://github.com/apps/dependabot))
+
+## [v1.26.0](https://github.com/defra/waste-carriers-back-office/tree/v1.26.0) (2024-05-28)
+
+[Full Changelog](https://github.com/defra/waste-carriers-back-office/compare/v1.25.1...v1.26.0)
 
 **Implemented enhancements:**
 
@@ -20,6 +37,7 @@
 
 **Merged pull requests:**
 
+- Version 1.26.0 [\#1954](https://github.com/DEFRA/waste-carriers-back-office/pull/1954) ([PaulDoyle-DEFRA](https://github.com/PaulDoyle-DEFRA))
 - bump mocks gem [\#1950](https://github.com/DEFRA/waste-carriers-back-office/pull/1950) ([PaulDoyle-DEFRA](https://github.com/PaulDoyle-DEFRA))
 - Bump waste\_carriers\_engine from `395c808` to `a7700e0` [\#1949](https://github.com/DEFRA/waste-carriers-back-office/pull/1949) ([dependabot[bot]](https://github.com/apps/dependabot))
 - Bump defra\_ruby\_mocks from 4.1.0 to 4.2.0 [\#1948](https://github.com/DEFRA/waste-carriers-back-office/pull/1948) ([dependabot[bot]](https://github.com/apps/dependabot))

--- a/lib/tasks/one_off/create_communications_opted_in_index.rake
+++ b/lib/tasks/one_off/create_communications_opted_in_index.rake
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+namespace :one_off do
+  desc "Create communications_opted_in index"
+  task create_communications_opted_in_index: :environment do
+    # create communications_opted_in index if it doesn't exist
+    if WasteCarriersEngine::Registration.collection.indexes.map { |i| i["key"].keys }
+                                        .flatten.include?("communications_opted_in")
+      puts "Index on communications_opted_in already exists"
+    else
+      create_communications_opted_in_index
+    end
+  end
+end
+
+def create_communications_opted_in_index
+  puts "Creating index on communications_opted_in" unless Rails.env.test?
+  time_start = Time.zone.now
+  WasteCarriersEngine::Registration.collection.indexes.create_one(communications_opted_in: 1)
+  time_end = Time.zone.now
+  puts "Finished creating index in #{time_end - time_start} seconds" unless Rails.env.test?
+end

--- a/lib/tasks/one_off/fix_communications_opted_in.rake
+++ b/lib/tasks/one_off/fix_communications_opted_in.rake
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+namespace :one_off do
+  desc "Set communications_opted_in for all registrations where expires_on is within the last 40 months"
+  task fix_communications_opted_in: :environment do
+    regs_with_unset_opted_in = WasteCarriersEngine::Registration.where(
+      communications_opted_in: nil,
+      expires_on: { "$gte": 40.months.ago.beginning_of_day }
+    )
+
+    if regs_with_unset_opted_in.count.positive?
+      puts "Updating #{regs_with_unset_opted_in.count} registration(s)" unless Rails.env.test?
+      time_start = Time.zone.now
+      WasteCarriersEngine::Registration.collection.update_many(
+        { communications_opted_in: nil, expires_on: { "$gte": 40.months.ago.beginning_of_day } },
+        { "$set": { communications_opted_in: true } }
+      )
+      time_end = Time.zone.now
+      puts "Finished updating registrations in #{time_end - time_start} seconds" unless Rails.env.test?
+    else
+      puts "No registrations with unset communications_opted_in found." unless Rails.env.test?
+    end
+  end
+end

--- a/spec/lib/tasks/one_off/create_communications_opted_in_index_spec.rb
+++ b/spec/lib/tasks/one_off/create_communications_opted_in_index_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "one_off:create_communications_opted_in_index", type: :task do
+  include_context "rake"
+
+  it "runs without error" do
+    expect { subject.invoke }.not_to raise_error
+  end
+end

--- a/spec/lib/tasks/one_off/fix_communications_opted_in_spec.rb
+++ b/spec/lib/tasks/one_off/fix_communications_opted_in_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "one_off:fix_communications_opted_in", type: :task do
+  let(:task) { Rake::Task["one_off:fix_communications_opted_in"] }
+
+  include_context "rake"
+
+  before do
+    task.reenable
+  end
+
+  it "runs without error" do
+    expect { task.invoke }.not_to raise_error
+  end
+
+  context "when a registration has no communications_opted_in field set" do
+    let!(:registration) { create(:registration, expires_on: 2.days.from_now) }
+
+    before do
+      WasteCarriersEngine::Registration.collection.update_one(
+        { regIdentifier: registration.regIdentifier },
+        { "$unset": { communications_opted_in: 1 } }
+      )
+    end
+
+    it "set communications_opted_in to true" do
+      expect(WasteCarriersEngine::Registration.collection.find({ regIdentifier: registration.regIdentifier, communications_opted_in: true }).count).to be_zero
+      task.invoke
+      expect(WasteCarriersEngine::Registration.collection.find({ regIdentifier: registration.regIdentifier, communications_opted_in: true }).count).to be_positive
+    end
+  end
+
+  context "when a registration has communications_opted_in field set already" do
+    let(:registration) { create(:registration, communications_opted_in: false, expires_on: 2.days.from_now) }
+
+    it "does not modify the registration" do
+      expect { task.invoke }.not_to change(registration, :communications_opted_in)
+    end
+  end
+end


### PR DESCRIPTION
- Change `defra_ruby_template` to use a specific Git branch.
- Update `waste_carriers_engine` to use a local path.
- Adjust asset paths in `config/application.rb`.
- Remove `defra_ruby_template` require from `application.js`.
- Update dependencies in `Gemfile.lock`.

[RUBY-3083] Update Gemfile and application layout

- Change branch in Gemfile and Gemfile.lock for `defra_ruby_template` to `RUBY-3083-wcr-wex-frae-bo-show-password-hint-functionality-does-not-work`
- Update class name in application layout link to `govuk-header__service-name`


[RUBY-3083]: https://eaflood.atlassian.net/browse/RUBY-3083?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ