### PR TITLE
[RUBY-3222] feat: Add rake task to fix communications_opted_in

### DIFF
--- a/lib/tasks/one_off/create_communications_opted_in_index.rake
+++ b/lib/tasks/one_off/create_communications_opted_in_index.rake
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+namespace :one_off do
+  desc "Create communications_opted_in index"
+  task create_communications_opted_in_index: :environment do
+    # create communications_opted_in index if it doesn't exist
+    if WasteCarriersEngine::Registration.collection.indexes.map { |i| i["key"].keys }
+                                        .flatten.include?("communications_opted_in")
+      puts "Index on communications_opted_in already exists"
+    else
+      create_communications_opted_in_index
+    end
+  end
+end
+
+def create_communications_opted_in_index
+  puts "Creating index on communications_opted_in" unless Rails.env.test?
+  time_start = Time.zone.now
+  WasteCarriersEngine::Registration.collection.indexes.create_one(communications_opted_in: 1)
+  time_end = Time.zone.now
+  puts "Finished creating index in #{time_end - time_start} seconds" unless Rails.env.test?
+end

--- a/lib/tasks/one_off/fix_communications_opted_in.rake
+++ b/lib/tasks/one_off/fix_communications_opted_in.rake
@@ -22,4 +22,3 @@ namespace :one_off do
     end
   end
 end
-

--- a/lib/tasks/one_off/fix_communications_opted_in.rake
+++ b/lib/tasks/one_off/fix_communications_opted_in.rake
@@ -3,6 +3,12 @@
 namespace :one_off do
   desc "Create registration unsubscribe_token index"
   task fix_communications_opted_in: :environment do
+    # create communications_opted_in index if it doesn't exist
+    unless WasteCarriersEngine::Registration.collection.indexes.map { |i| i["key"].keys }
+                                            .flatten.include?("communications_opted_in")
+      create_communications_opted_in_index
+    end
+
     regs_with_unset_opted_in = WasteCarriersEngine::Registration.where(
       communications_opted_in: nil,
       expires_on: { "$gte": 40.days.ago.beginning_of_day }
@@ -10,15 +16,23 @@ namespace :one_off do
 
     if regs_with_unset_opted_in.count.positive?
       puts "Updating #{regs_with_unset_opted_in.count} registration(s)" unless Rails.env.test?
-      time_start = Time.now
+      time_start = Time.zone.now
       WasteCarriersEngine::Registration.collection.update_many(
         { communications_opted_in: nil, expires_on: { "$gte": 40.days.ago.beginning_of_day } },
         { "$set": { communications_opted_in: true } }
       )
-      time_end = Time.now
+      time_end = Time.zone.now
       puts "Finished updating registrations in #{time_end - time_start} seconds" unless Rails.env.test?
     else
       puts "No registrations with unset communications_opted_in found." unless Rails.env.test?
     end
   end
+end
+
+def create_communications_opted_in_index
+  puts "Creating index on communications_opted_in" unless Rails.env.test?
+  time_start = Time.zone.now
+  WasteCarriersEngine::Registration.collection.indexes.create_one(communications_opted_in: 1)
+  time_end = Time.zone.now
+  puts "Finished creating index in #{time_end - time_start} seconds" unless Rails.env.test?
 end

--- a/lib/tasks/one_off/fix_communications_opted_in.rake
+++ b/lib/tasks/one_off/fix_communications_opted_in.rake
@@ -3,12 +3,15 @@
 namespace :one_off do
   desc "Create registration unsubscribe_token index"
   task fix_communications_opted_in: :environment do
-    regs_with_unset_opted_in = WasteCarriersEngine::Registration.where(communications_opted_in: nil)
+    regs_with_unset_opted_in = WasteCarriersEngine::Registration.where(
+      communications_opted_in: nil,
+      expires_on: { "$gte": 40.days.ago.beginning_of_day }
+    )
 
     if regs_with_unset_opted_in.count.positive?
       puts "Updating #{regs_with_unset_opted_in.count} registration(s)" unless Rails.env.test?
       WasteCarriersEngine::Registration.collection.update_many(
-        { communications_opted_in: nil },
+        { communications_opted_in: nil, expires_on: { "$gte": 40.days.ago.beginning_of_day } },
         { "$set": { communications_opted_in: true } }
       )
     else

--- a/lib/tasks/one_off/fix_communications_opted_in.rake
+++ b/lib/tasks/one_off/fix_communications_opted_in.rake
@@ -1,14 +1,8 @@
 # frozen_string_literal: true
 
 namespace :one_off do
-  desc "Create registration unsubscribe_token index"
+  desc "Set communications_opted_in for all registrations where expires_on is within the last 40 months"
   task fix_communications_opted_in: :environment do
-    # create communications_opted_in index if it doesn't exist
-    # unless WasteCarriersEngine::Registration.collection.indexes.map { |i| i["key"].keys }
-    #                                         .flatten.include?("communications_opted_in")
-    #   create_communications_opted_in_index
-    # end
-
     regs_with_unset_opted_in = WasteCarriersEngine::Registration.where(
       communications_opted_in: nil,
       expires_on: { "$gte": 40.months.ago.beginning_of_day }
@@ -29,10 +23,3 @@ namespace :one_off do
   end
 end
 
-def create_communications_opted_in_index
-  puts "Creating index on communications_opted_in" unless Rails.env.test?
-  time_start = Time.zone.now
-  WasteCarriersEngine::Registration.collection.indexes.create_one(communications_opted_in: 1)
-  time_end = Time.zone.now
-  puts "Finished creating index in #{time_end - time_start} seconds" unless Rails.env.test?
-end

--- a/lib/tasks/one_off/fix_communications_opted_in.rake
+++ b/lib/tasks/one_off/fix_communications_opted_in.rake
@@ -10,10 +10,13 @@ namespace :one_off do
 
     if regs_with_unset_opted_in.count.positive?
       puts "Updating #{regs_with_unset_opted_in.count} registration(s)" unless Rails.env.test?
+      time_start = Time.now
       WasteCarriersEngine::Registration.collection.update_many(
         { communications_opted_in: nil, expires_on: { "$gte": 40.days.ago.beginning_of_day } },
         { "$set": { communications_opted_in: true } }
       )
+      time_end = Time.now
+      puts "Finished updating registrations in #{time_end - time_start} seconds" unless Rails.env.test?
     else
       puts "No registrations with unset communications_opted_in found." unless Rails.env.test?
     end

--- a/lib/tasks/one_off/fix_communications_opted_in.rake
+++ b/lib/tasks/one_off/fix_communications_opted_in.rake
@@ -3,7 +3,7 @@
 namespace :one_off do
   desc "Create registration unsubscribe_token index"
   task fix_communications_opted_in: :environment do
-    regs_with_unset_opted_in = WasteCarriersEngine::Registration.active.upper_tier.where(communications_opted_in: nil)
+    regs_with_unset_opted_in = WasteCarriersEngine::Registration.where(communications_opted_in: nil)
 
     if regs_with_unset_opted_in.count.positive?
       puts "Updating #{regs_with_unset_opted_in.count} registration(s)" unless Rails.env.test?

--- a/lib/tasks/one_off/fix_communications_opted_in.rake
+++ b/lib/tasks/one_off/fix_communications_opted_in.rake
@@ -8,11 +8,11 @@ namespace :one_off do
     if regs_with_unset_opted_in.count.positive?
       puts "Updating #{regs_with_unset_opted_in.count} registration(s)" unless Rails.env.test?
       WasteCarriersEngine::Registration.collection.update_many(
-        { tier: "UPPER", "metaData.status": "ACTIVE", communications_opted_in: nil },
+        { communications_opted_in: nil },
         { "$set": { communications_opted_in: true } }
       )
     else
-      puts "No active upper tier registrations with unset communications_opted_in found." unless Rails.env.test?
+      puts "No registrations with unset communications_opted_in found." unless Rails.env.test?
     end
   end
 end

--- a/lib/tasks/one_off/fix_communications_opted_in.rake
+++ b/lib/tasks/one_off/fix_communications_opted_in.rake
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+namespace :one_off do
+  desc "Create registration unsubscribe_token index"
+  task fix_communications_opted_in: :environment do
+    regs_with_unset_opted_in = WasteCarriersEngine::Registration.active.upper_tier.where(communications_opted_in: nil)
+
+    if regs_with_unset_opted_in.count.positive?
+      puts "Updating #{regs_with_unset_opted_in.count} registration(s)" unless Rails.env.test?
+      WasteCarriersEngine::Registration.collection.update_many(
+        { tier: "UPPER", "metaData.status": "ACTIVE", communications_opted_in: nil },
+        { "$set": { communications_opted_in: true } }
+      )
+    else
+      puts "No active upper tier registrations with unset communications_opted_in found." unless Rails.env.test?
+    end
+  end
+end

--- a/lib/tasks/one_off/fix_communications_opted_in.rake
+++ b/lib/tasks/one_off/fix_communications_opted_in.rake
@@ -11,14 +11,14 @@ namespace :one_off do
 
     regs_with_unset_opted_in = WasteCarriersEngine::Registration.where(
       communications_opted_in: nil,
-      expires_on: { "$gte": 40.days.ago.beginning_of_day }
+      expires_on: { "$gte": 40.months.ago.beginning_of_day }
     )
 
     if regs_with_unset_opted_in.count.positive?
       puts "Updating #{regs_with_unset_opted_in.count} registration(s)" unless Rails.env.test?
       time_start = Time.zone.now
       WasteCarriersEngine::Registration.collection.update_many(
-        { communications_opted_in: nil, expires_on: { "$gte": 40.days.ago.beginning_of_day } },
+        { communications_opted_in: nil, expires_on: { "$gte": 40.months.ago.beginning_of_day } },
         { "$set": { communications_opted_in: true } }
       )
       time_end = Time.zone.now

--- a/lib/tasks/one_off/fix_communications_opted_in.rake
+++ b/lib/tasks/one_off/fix_communications_opted_in.rake
@@ -4,10 +4,10 @@ namespace :one_off do
   desc "Create registration unsubscribe_token index"
   task fix_communications_opted_in: :environment do
     # create communications_opted_in index if it doesn't exist
-    unless WasteCarriersEngine::Registration.collection.indexes.map { |i| i["key"].keys }
-                                            .flatten.include?("communications_opted_in")
-      create_communications_opted_in_index
-    end
+    # unless WasteCarriersEngine::Registration.collection.indexes.map { |i| i["key"].keys }
+    #                                         .flatten.include?("communications_opted_in")
+    #   create_communications_opted_in_index
+    # end
 
     regs_with_unset_opted_in = WasteCarriersEngine::Registration.where(
       communications_opted_in: nil,

--- a/spec/lib/tasks/one_off/create_communications_opted_in_index_spec.rb
+++ b/spec/lib/tasks/one_off/create_communications_opted_in_index_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "one_off:create_communications_opted_in_index", type: :task do
+  include_context "rake"
+
+  it "runs without error" do
+    expect { subject.invoke }.not_to raise_error
+  end
+end

--- a/spec/lib/tasks/one_off/fix_communications_opted_in_spec.rb
+++ b/spec/lib/tasks/one_off/fix_communications_opted_in_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "one_off:fix_communications_opted_in", type: :task do
+  let(:task) { Rake::Task["one_off:fix_communications_opted_in"] }
+
+  include_context "rake"
+
+  before do
+    task.reenable
+  end
+
+  it "runs without error" do
+    expect { task.invoke }.not_to raise_error
+  end
+
+  context "when a registration has no communications_opted_in field set" do
+    let!(:upper_tier_registration) { create(:registration, tier: "UPPER") }
+    let!(:lower_tier_registration) { create(:registration, tier: "LOWER") }
+    let!(:inactive_registration) { create(:registration, tier: "UPPER", metaData: { status: "PENDING" }) }
+
+    before do
+      WasteCarriersEngine::Registration.collection.update_many({}, { "$unset": { communications_opted_in: 1 } })
+    end
+
+    it "set communications_opted_in to true for active upper tier registrations" do
+      expect(WasteCarriersEngine::Registration.collection.find({ regIdentifier: upper_tier_registration.regIdentifier, communications_opted_in: true }).count).to be_zero
+      task.invoke
+      expect(WasteCarriersEngine::Registration.collection.find({ regIdentifier: upper_tier_registration.regIdentifier, communications_opted_in: true }).count).to be_positive
+    end
+
+    it "does not modify the lower tier registrations" do
+      expect { task.invoke }.not_to change(lower_tier_registration, :communications_opted_in)
+    end
+
+    it "does not modify the inactive registrations" do
+      expect { task.invoke }.not_to change(inactive_registration, :communications_opted_in)
+    end
+  end
+
+  context "when a registration has communications_opted_in field set already" do
+    let(:registration) { create(:registration, communications_opted_in: false) }
+
+    it "does not modify the registration" do
+      expect { task.invoke }.not_to change(registration, :communications_opted_in)
+    end
+  end
+end

--- a/spec/lib/tasks/one_off/fix_communications_opted_in_spec.rb
+++ b/spec/lib/tasks/one_off/fix_communications_opted_in_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "one_off:fix_communications_opted_in", type: :task do
   end
 
   context "when a registration has no communications_opted_in field set" do
-    let!(:registration) { create(:registration) }
+    let!(:registration) { create(:registration, expires_on: 2.days.from_now) }
 
     before do
       WasteCarriersEngine::Registration.collection.update_one(
@@ -33,7 +33,7 @@ RSpec.describe "one_off:fix_communications_opted_in", type: :task do
   end
 
   context "when a registration has communications_opted_in field set already" do
-    let(:registration) { create(:registration, communications_opted_in: false) }
+    let(:registration) { create(:registration, communications_opted_in: false, expires_on: 2.days.from_now) }
 
     it "does not modify the registration" do
       expect { task.invoke }.not_to change(registration, :communications_opted_in)


### PR DESCRIPTION
This commit adds a new rake task `fix_communications_opted_in` to the `one_off` namespace. The task updates registrations in the `WasteCarriersEngine` module that have the `communications_opted_in` unset and sets it to `true`. This ensures that all registrations have the `communications_opted_in` field properly set.

https://eaflood.atlassian.net/browse/RUBY-3222