### PR TITLE
Fix/ruby 3411

### DIFF
--- a/app/services/address/update_easting_northing_service.rb
+++ b/app/services/address/update_easting_northing_service.rb
@@ -6,8 +6,8 @@ module Address
 
     delegate :postcode, to: :address
 
-    def run(registration_id:)
-      @registration = WasteCarriersEngine::Registration.find(registration_id)
+    def run(reg_identifier:)
+      @registration = WasteCarriersEngine::Registration.find_by(reg_identifier:)
       @address = @registration.registered_address
 
       return if address.easting.present? && address.northing.present?

--- a/lib/tasks/lookups.rake
+++ b/lib/tasks/lookups.rake
@@ -31,6 +31,8 @@ def run_service(address_match_clause, service)
     scope_pipeline(address_limit, address_match_clause)
   ).pluck(:_id)
 
+  puts "Updating #{registrations_scope.count} registrations" unless Rails.env.test?
+
   throttle = MINUTE_IN_SECONDS / MAX_REQUESTS_PER_MINUTE
 
   TimedServiceRunner.run(

--- a/spec/services/address/update_easting_northing_service_spec.rb
+++ b/spec/services/address/update_easting_northing_service_spec.rb
@@ -12,7 +12,7 @@ module Address
       let(:valid_easting) { os_places_data["easting"] }
       let(:valid_northing) { os_places_data["northing"] }
 
-      subject(:run_service) { described_class.run(registration_id: registration.id) }
+      subject(:run_service) { described_class.run(reg_identifier: registration.reg_identifier) }
 
       before do
         allow(WasteCarriersEngine::AddressLookupService).to receive(:run).and_return(


### PR DESCRIPTION
This fixes the EA area lookup service input parameter which was registration DB id instead of reg_identifier.
https://eaflood.atlassian.net/browse/RUBY-3408