### PR TITLE
Prevent individual object mapping errors from halting serializers

### DIFF
--- a/app/models/reports/base_serializer.rb
+++ b/app/models/reports/base_serializer.rb
@@ -19,6 +19,16 @@ module Reports
     def each_data
       scope.each do |object|
         yield parse_object(object)
+      rescue StandardError => e
+        # Handle parsing errors here so that the serializer can continue with the next object.
+        message = if object.respond_to?(:reg_identifier)
+                    "Error mapping object with reg_identifier \"#{object.reg_identifier}\" to CSV: #{e}"
+                  else
+                    "Error writing CSV file to #{@path}: #{e}"
+                  end
+
+        Rails.logger.error message
+        Airbrake.notify(e, message:, csv_file_path: @path)
       end
     end
   end

--- a/app/models/reports/epr_serializer.rb
+++ b/app/models/reports/epr_serializer.rb
@@ -40,7 +40,7 @@ module Reports
                       .active_and_expired
                       .lower_tier_or_unexpired
 
-      # Save these for de-duplication purposes
+      # Save these for de-duplication purposes in the EprRenewalSerializer subclass
       @registration_ids = registrations.pluck(:reg_identifier).to_set
 
       registrations

--- a/spec/models/reports/base_serializer_spec.rb
+++ b/spec/models/reports/base_serializer_spec.rb
@@ -5,31 +5,92 @@ require "rails_helper"
 module Reports
   RSpec.describe BaseSerializer do
 
-    let(:test_class) do
-      Class.new(described_class) do
+    describe "#to_csv" do
 
-        const_set(:ATTRIBUTES, { reg_identifier: "reg_identifier" })
+      context "when the serializer is for registrations" do
+        let(:test_class) do
+          Class.new(described_class) do
 
-        def scope
-          ::WasteCarriersEngine::Registration.all # Will not actually be called, just stubbed
+            const_set(:ATTRIBUTES, { tier: "tier" })
+
+            def scope
+              ::WasteCarriersEngine::Registration.all # Will not actually be called, just stubbed
+            end
+
+            def parse_object(registration)
+              [registration.tier]
+            end
+          end
+        end
+        let(:registration) { build(:registration) }
+
+        subject { test_class.new }
+
+        before do
+          allow(WasteCarriersEngine::Registration).to receive(:all).and_return([registration])
+          allow(Rails.logger).to receive(:error)
+          allow(Airbrake).to receive(:notify)
         end
 
-        def parse_object(registration)
-          [registration.reg_identifier]
+        context "with a valid object" do
+          before { allow(registration).to receive(:tier).and_return("UPPER") }
+
+          it "returns a csv version of the given data based on attributes" do
+            expect(subject.to_csv).to eq("\"tier\"\n\"UPPER\"\n")
+          end
+        end
+
+        context "with an invalid object" do
+          before { allow(registration).to receive(:tier).and_raise(StandardError) }
+
+          it "logs an error including the registration's reg_identifier" do
+            subject.to_csv
+            expect(Rails.logger).to have_received(:error).with(/.*#{registration.reg_identifier}.*/)
+          end
         end
       end
-    end
 
-    subject { test_class.new }
+      context "when the serializer is for non-registration objects" do
+        let(:test_class) do
+          Class.new(described_class) do
 
-    describe "#to_csv" do
-      it "returns a csv version of the given data based on attributes" do
-        registration = double(:registration)
+            const_set(:ATTRIBUTES, { postcode: "postcode" })
 
-        allow(registration).to receive(:reg_identifier).and_return("CBDU0000")
-        allow(WasteCarriersEngine::Registration).to receive(:all).and_return([registration])
+            def scope
+              ::WasteCarriersEngine::Address.all # Will not actually be called, just stubbed
+            end
 
-        expect(subject.to_csv).to eq("\"reg_identifier\"\n\"CBDU0000\"\n")
+            def parse_object(address)
+              [address.postcode]
+            end
+          end
+        end
+        let(:address) { build(:address) }
+
+        subject { test_class.new }
+
+        before do
+          allow(WasteCarriersEngine::Address).to receive(:all).and_return([address])
+          allow(Rails.logger).to receive(:error)
+          allow(Airbrake).to receive(:notify)
+        end
+
+        context "with a valid object" do
+          before { allow(address).to receive(:postcode).and_return("BS1 5AH") }
+
+          it "returns a csv version of the given data based on attributes" do
+            expect(subject.to_csv).to eq("\"postcode\"\n\"BS1 5AH\"\n")
+          end
+        end
+
+        context "with an invalid object" do
+          before { allow(address).to receive(:postcode).and_raise(StandardError) }
+
+          it "logs an error" do
+            subject.to_csv
+            expect(Rails.logger).to have_received(:error)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
This change is to address an issue where a single object mapping error would halt the entire serialization run. Mapping errors will now be handled at the object level and the serializer will be able to continue with the next object.
https://eaflood.atlassian.net/browse/RUBY-3489
