### PR TITLE
RUBY-3493 : add logging to permanent scheduled jobs

### DIFF
--- a/app/models/stdout_logger.rb
+++ b/app/models/stdout_logger.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class StdoutLogger
+  def self.log(msg)
+    # Avoid cluttering up the test logs
+    puts msg unless Rails.env.test? # rubocop:disable Rails/Output
+  end
+end

--- a/app/services/expired_registrations_service.rb
+++ b/app/services/expired_registrations_service.rb
@@ -2,7 +2,11 @@
 
 class ExpiredRegistrationsService < WasteCarriersEngine::BaseService
   def run
-    all_expired_registrations.each(&:expire!)
+    expired_registrations = all_expired_registrations
+    expired_registrations_counter = expired_registrations.size
+    expired_registrations.each(&:expire!)
+
+    expired_registrations_counter
   end
 
   private

--- a/app/services/renewal_reminder_service_base.rb
+++ b/app/services/renewal_reminder_service_base.rb
@@ -8,6 +8,8 @@ class RenewalReminderServiceBase < WasteCarriersEngine::BaseService
       Airbrake.notify e, registration: registration.reg_identifier
       Rails.logger.error "Failed to send first renewal email for registration #{registration.reg_identifier}"
     end
+
+    expiring_registrations.size
   end
 
   private

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -89,7 +89,7 @@ every :tuesday, at: ENV["EXPORT_COPY_CARD_ORDERS_RUN_TIME"] || "02:15", roles: [
 end
 
 every :day, at: ENV["EASTING_NORTHING_LOOKUP"] || "01:05", roles: [:db] do
-  rake_and_format "lookups:update:missing_easting_northing"
+  rake_and_format "lookups:update:missing_easting_northings"
 end
 
 every :day, at: ENV["AREA_LOOKUP"] || "03:30", roles: [:db] do

--- a/lib/tasks/email.rake
+++ b/lib/tasks/email.rake
@@ -7,7 +7,8 @@ namespace :email do
       task send: :environment do
         return unless WasteCarriersEngine::FeatureToggle.active?(:renewal_reminders)
 
-        FirstRenewalReminderService.run
+        registrations_count = FirstRenewalReminderService.run
+        StdoutLogger.log "Sent #{registrations_count} first renewal reminder(s)"
       end
     end
 
@@ -16,7 +17,8 @@ namespace :email do
       task send: :environment do
         return unless WasteCarriersEngine::FeatureToggle.active?(:renewal_reminders)
 
-        SecondRenewalReminderService.run
+        registrations_count = SecondRenewalReminderService.run
+        StdoutLogger.log "Sent #{registrations_count} second renewal reminder(s)"
       end
     end
   end

--- a/lib/tasks/expire_registration.rake
+++ b/lib/tasks/expire_registration.rake
@@ -3,6 +3,7 @@
 namespace :expire_registration do
   desc "Set the status of expired registations to expired"
   task run: :environment do
-    ExpiredRegistrationsService.run
+    expired_registrations_count = ExpiredRegistrationsService.run
+    StdoutLogger.log "#{expired_registrations_count} expired registration(s) have been set to expired"
   end
 end

--- a/lib/tasks/notify.rake
+++ b/lib/tasks/notify.rake
@@ -12,6 +12,7 @@ namespace :notify do
                                                        .from_now
 
       registrations = Notify::BulkDigitalRenewalNotificationService.run(expires_on)
+      StdoutLogger.log "Sent #{registrations.count} digital renewal notification(s)"
 
       if registrations.any?
         Rails.logger.info(
@@ -33,6 +34,7 @@ namespace :notify do
                                                        .from_now
 
       registrations = Notify::BulkAdRenewalLettersService.run(expires_on)
+      StdoutLogger.log "Sent #{registrations.count} AD renewal letter(s)"
 
       if registrations.any?
         Rails.logger.info "Notify AD renewal letters sent for #{registrations.map(&:reg_identifier).join(', ')}"

--- a/lib/tasks/trim.rake
+++ b/lib/tasks/trim.rake
@@ -7,9 +7,11 @@ namespace :db do
       cutoff_time = 30.days.ago
 
       # Assuming that the session data is stored in a Mongoid document named 'Session'
-      MongoidStore::Session.where(:updated_at.lt => cutoff_time).delete_all
+      old_sessions = MongoidStore::Session.where(:updated_at.lt => cutoff_time)
+      old_sessions_count = old_sessions.size
+      old_sessions.delete_all
 
-      puts "Sessions older than #{cutoff_time} have been removed." unless Rails.env.test?
+      puts "#{old_sessions_count} session(s) older than #{cutoff_time} have been removed." unless Rails.env.test?
     end
   end
 end

--- a/spec/lib/tasks/email_spec.rb
+++ b/spec/lib/tasks/email_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe "Email task", type: :task do
   describe "email:renew_reminder:first:send" do
     before do
       allow(FirstRenewalReminderService).to receive(:run).and_return(registrations_count)
+      subject.reenable
     end
 
     it "runs without error" do
@@ -29,6 +30,7 @@ RSpec.describe "Email task", type: :task do
   describe "email:renew_reminder:second:send" do
     before do
       allow(SecondRenewalReminderService).to receive(:run).and_return(registrations_count)
+      subject.reenable
     end
 
     it "runs without error" do

--- a/spec/lib/tasks/email_spec.rb
+++ b/spec/lib/tasks/email_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Email task", type: :task do
+  include_context "rake"
+
+  let(:registrations_count) { 1 }
+
+  before do
+    allow(WasteCarriersEngine::FeatureToggle).to receive(:active?).with(:renewal_reminders).and_return(true)
+  end
+
+  describe "email:renew_reminder:first:send" do
+    before do
+      allow(FirstRenewalReminderService).to receive(:run).and_return(registrations_count)
+    end
+
+    it "runs without error" do
+      expect { subject.invoke }.not_to raise_error
+    end
+
+    it "logs the number of emails sent" do
+      expect(StdoutLogger).to receive(:log).with("Sent #{registrations_count} first renewal reminder(s)")
+      subject.invoke
+    end
+  end
+
+  describe "email:renew_reminder:second:send" do
+    before do
+      allow(SecondRenewalReminderService).to receive(:run).and_return(registrations_count)
+    end
+
+    it "runs without error" do
+      expect { subject.invoke }.not_to raise_error
+    end
+
+    it "logs the number of emails sent" do
+      expect(StdoutLogger).to receive(:log).with("Sent #{registrations_count} second renewal reminder(s)")
+      subject.invoke
+    end
+  end
+end

--- a/spec/models/stdout_logger_spec.rb
+++ b/spec/models/stdout_logger_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe StdoutLogger do
+  describe ".log" do
+    let(:message) { "Test message" }
+
+    context "when in test environment" do
+      before do
+        allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("test"))
+      end
+
+      it "does not log the message" do
+        expect { described_class.log(message) }.not_to output.to_stdout
+      end
+    end
+
+    context "when not in test environment" do
+      before do
+        allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("development"))
+      end
+
+      it "logs the message" do
+        expect { described_class.log(message) }.to output("#{message}\n").to_stdout
+      end
+    end
+  end
+end

--- a/spec/schedule_spec.rb
+++ b/spec/schedule_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe "Whenever::Test::Shedule" do
   end
 
   it "picks up the daily missing easting/northing task run frequency and time" do
-    job_details = schedule.jobs[:rake_and_format].find { |h| h[:task] == "lookups:update:missing_easting_northing" }
+    job_details = schedule.jobs[:rake_and_format].find { |h| h[:task] == "lookups:update:missing_easting_northings" }
 
     expect(job_details[:every][0]).to eq(:day)
     expect(job_details[:every][1][:at]).to eq("01:05")

--- a/spec/services/expired_registrations_service_spec.rb
+++ b/spec/services/expired_registrations_service_spec.rb
@@ -23,5 +23,12 @@ RSpec.describe ExpiredRegistrationsService do
       expect(active_registration).not_to be_expired
       expect(lower_tier_registration).not_to be_expired
     end
+
+    it "returns the number of registrations that were expired" do
+      create(:registration, :active, expires_on: Time.zone.now.beginning_of_day + 4.hours)
+      create(:registration, :active, expires_on: Time.zone.now.end_of_day + 4.hours)
+
+      expect(described_class.run).to eq(1)
+    end
   end
 end

--- a/spec/services/renewal_reminder_service_base_spec.rb
+++ b/spec/services/renewal_reminder_service_base_spec.rb
@@ -45,6 +45,13 @@ RSpec.describe RenewalReminderServiceBase do
       end
     end
 
+    it "returns the number of registrations that were sent emails" do
+      create(:registration, expires_on: 3.days.from_now)
+      create(:registration, expires_on: 5.days.from_now)
+
+      expect(test_class.run).to eq(1)
+    end
+
     context "when an error occurs" do
       before do
         create(:registration, expires_on: 3.days.from_now)


### PR DESCRIPTION
Adjust permanent scheduled jobs to ensure they output the number of records affected, e.g. number of renewal reminders sent, etc
https://eaflood.atlassian.net/browse/RUBY-3493

 - created StdoutLogger class
 - refactored several services to return the number of records affected
 - refactored rake jobs to log number of affected records using StdoutLogger
 - fixed typo in rake task name in schedule config