### PR TITLE
Fix/ruby 4002 check refund status

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -107,7 +107,9 @@ group :development, :test do
   # Project uses RSpec as its test framework
   gem "rspec-rails"
   gem "rubocop-capybara", require: false
+  gem "rubocop-factory_bot", require: false
   gem "rubocop-rails", require: false
+  gem "rubocop-rake", require: false
   gem "rubocop-rspec", require: false
   gem "rubocop-rspec_rails", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -222,11 +222,7 @@ GEM
       sprockets-rails (~> 3.0)
     defra_ruby_storm (0.1.0)
       savon (~> 2.13.0)
-    defra_ruby_style (0.4.0)
-      rubocop (>= 1.0, < 2.0)
-      rubocop-factory_bot
-      rubocop-rake
-      rubocop-rspec
+    defra_ruby_style (0.4.1)
     defra_ruby_template (5.11.0)
     defra_ruby_validators (3.0.0)
       activemodel
@@ -326,7 +322,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    json (2.12.2)
+    json (2.15.0)
     jwt (2.10.2)
       base64
     kaminari (1.2.2)
@@ -406,7 +402,7 @@ GEM
     orm_adapter (0.5.0)
     os_map_ref (0.5.0)
     parallel (1.27.0)
-    parser (3.3.8.0)
+    parser (3.3.9.0)
       ast (~> 2.4.1)
       racc
     passenger (6.1.0)
@@ -417,7 +413,7 @@ GEM
     pp (0.6.2)
       prettyprint
     prettyprint (0.2.0)
-    prism (1.4.0)
+    prism (1.5.1)
     protocol-hpack (1.5.1)
     protocol-http (0.50.1)
     protocol-http1 (0.34.0)
@@ -483,7 +479,7 @@ GEM
     rdoc (6.14.2)
       erb
       psych (>= 4.0.0)
-    regexp_parser (2.10.0)
+    regexp_parser (2.11.3)
     reline (0.6.2)
       io-console (~> 0.5)
     responders (3.1.1)
@@ -514,7 +510,7 @@ GEM
     rspec-retry (0.6.2)
       rspec-core (> 3.3)
     rspec-support (3.13.4)
-    rubocop (1.76.2)
+    rubocop (1.81.0)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -522,10 +518,10 @@ GEM
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 2.9.3, < 3.0)
-      rubocop-ast (>= 1.45.1, < 2.0)
+      rubocop-ast (>= 1.47.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.45.1)
+    rubocop-ast (1.47.1)
       parser (>= 3.3.7.2)
       prism (~> 1.4)
     rubocop-capybara (2.22.1)
@@ -534,7 +530,7 @@ GEM
     rubocop-factory_bot (2.27.1)
       lint_roller (~> 1.1)
       rubocop (~> 1.72, >= 1.72.1)
-    rubocop-rails (2.32.0)
+    rubocop-rails (2.33.3)
       activesupport (>= 4.2.0)
       lint_roller (~> 1.1)
       rack (>= 1.1)
@@ -543,7 +539,7 @@ GEM
     rubocop-rake (0.7.1)
       lint_roller (~> 1.1)
       rubocop (>= 1.72.1)
-    rubocop-rspec (3.6.0)
+    rubocop-rspec (3.7.0)
       lint_roller (~> 1.1)
       rubocop (~> 1.72, >= 1.72.1)
     rubocop-rspec_rails (2.31.0)
@@ -608,9 +604,9 @@ GEM
       execjs (>= 0.3.0, < 3)
     uk_postcode (2.1.8)
     unaccent (0.4.0)
-    unicode-display_width (3.1.4)
-      unicode-emoji (~> 4.0, >= 4.0.4)
-    unicode-emoji (4.0.4)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.1.0)
     uri (1.0.3)
     useragent (0.16.11)
     validates_email_format_of (1.8.2)
@@ -683,7 +679,9 @@ DEPENDENCIES
   rspec-rails
   rspec-retry
   rubocop-capybara
+  rubocop-factory_bot
   rubocop-rails
+  rubocop-rake
   rubocop-rspec
   rubocop-rspec_rails
   rubyzip

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -13,9 +13,9 @@ class DashboardsController < ApplicationController
     @result_count = 0
     @results = []
 
-    if [params[:search_fullname], params[:search_email], params[:search_reg_identifier]].select do |s|
+    if [params[:search_fullname], params[:search_email], params[:search_reg_identifier]].many? do |s|
          s == "1"
-       end.count > 1
+       end
       flash.now[:error] = I18n.t(".dashboards.index.search.search_type_error")
     else
       @search_type = search_type(params)

--- a/app/controllers/refunds_controller.rb
+++ b/app/controllers/refunds_controller.rb
@@ -45,11 +45,10 @@ class RefundsController < ApplicationController
   end
 
   def update
-    refund_id = fetch_payment_by_id(params[:order_key]).govpay_id
+    refund = fetch_payment_by_id(params[:order_key])
     updated = WasteCarriersEngine::GovpayUpdateRefundStatusService.run(
-      registration: @resource,
-      refund_id:,
-      new_status: GovpayRefundDetailsService.run(refund_id:)["status"]
+      refund:,
+      new_status: GovpayRefundDetailsService.run(refund_id: refund.govpay_id)["status"]
     )
 
     if updated

--- a/app/controllers/resend_confirmation_email_controller.rb
+++ b/app/controllers/resend_confirmation_email_controller.rb
@@ -31,8 +31,8 @@ class ResendConfirmationEmailController < ApplicationController
   end
 
   def registration
-    return @_registration if defined?(@_registration)
+    return @registration if defined?(@registration)
 
-    @_registration = WasteCarriersEngine::Registration.find_by(reg_identifier: params[:reg_identifier])
+    @registration = WasteCarriersEngine::Registration.find_by(reg_identifier: params[:reg_identifier])
   end
 end

--- a/app/controllers/resend_confirmation_email_controller.rb
+++ b/app/controllers/resend_confirmation_email_controller.rb
@@ -31,6 +31,8 @@ class ResendConfirmationEmailController < ApplicationController
   end
 
   def registration
-    @_registration ||= WasteCarriersEngine::Registration.find_by(reg_identifier: params[:reg_identifier])
+    return @_registration if defined?(@_registration)
+
+    @_registration = WasteCarriersEngine::Registration.find_by(reg_identifier: params[:reg_identifier])
   end
 end

--- a/app/controllers/resend_renewal_email_controller.rb
+++ b/app/controllers/resend_renewal_email_controller.rb
@@ -31,8 +31,8 @@ class ResendRenewalEmailController < ApplicationController
   end
 
   def registration
-    return @_registration if defined?(@_registration)
+    return @registration if defined?(@registration)
 
-    @_registration = WasteCarriersEngine::Registration.find_by(reg_identifier: params[:reg_identifier])
+    @registration = WasteCarriersEngine::Registration.find_by(reg_identifier: params[:reg_identifier])
   end
 end

--- a/app/controllers/resend_renewal_email_controller.rb
+++ b/app/controllers/resend_renewal_email_controller.rb
@@ -31,6 +31,8 @@ class ResendRenewalEmailController < ApplicationController
   end
 
   def registration
-    @_registration ||= WasteCarriersEngine::Registration.find_by(reg_identifier: params[:reg_identifier])
+    return @_registration if defined?(@_registration)
+
+    @_registration = WasteCarriersEngine::Registration.find_by(reg_identifier: params[:reg_identifier])
   end
 end

--- a/app/controllers/resource_forms_controller.rb
+++ b/app/controllers/resource_forms_controller.rb
@@ -8,6 +8,7 @@ class ResourceFormsController < ApplicationController
   include CanCompleteIfPossible
 
   extend ActiveModel::Callbacks
+
   define_model_callbacks :renew_or_complete
 
   prepend_before_action :authenticate_user!

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -155,7 +155,7 @@ module ActionLinksHelper
     return false unless display_renewing_registration_links?(resource)
     return false unless can?(:edit, WasteCarriersEngine::Registration)
 
-    WasteCarriersEngine::RenewingRegistration.where(reg_identifier: resource.reg_identifier).count.positive?
+    WasteCarriersEngine::RenewingRegistration.where(reg_identifier: resource.reg_identifier).any?
   end
 
   def display_refresh_registered_company_name_link_for?(resource)

--- a/app/models/ceased_or_revoked_registration.rb
+++ b/app/models/ceased_or_revoked_registration.rb
@@ -8,6 +8,8 @@ class CeasedOrRevokedRegistration < WasteCarriersEngine::TransientRegistration
   delegate :company_name, :registration_type, :tier, :contact_address, to: :registration
 
   def registration
-    @_registration ||= WasteCarriersEngine::Registration.find_by(reg_identifier: reg_identifier)
+    return @_registration if defined?(@_registration)
+
+    @_registration = WasteCarriersEngine::Registration.find_by(reg_identifier: reg_identifier)
   end
 end

--- a/app/models/ceased_or_revoked_registration.rb
+++ b/app/models/ceased_or_revoked_registration.rb
@@ -8,8 +8,8 @@ class CeasedOrRevokedRegistration < WasteCarriersEngine::TransientRegistration
   delegate :company_name, :registration_type, :tier, :contact_address, to: :registration
 
   def registration
-    return @_registration if defined?(@_registration)
+    return @registration if defined?(@registration)
 
-    @_registration = WasteCarriersEngine::Registration.find_by(reg_identifier: reg_identifier)
+    @registration = WasteCarriersEngine::Registration.find_by(reg_identifier: reg_identifier)
   end
 end

--- a/app/models/concerns/can_behave_like_user.rb
+++ b/app/models/concerns/can_behave_like_user.rb
@@ -2,6 +2,7 @@
 
 module CanBehaveLikeUser
   extend ActiveSupport::Concern
+
   SUBSTITUTIONS = {
     "0" => "o", "1" => "i", "3" => "e", "4" => "a", "5" => "s", "7" => "t",
     "8" => "b", "9" => "g", "2" => "z", "6" => "b", "@" => "a", "$" => "s",

--- a/app/models/edit_registration.rb
+++ b/app/models/edit_registration.rb
@@ -34,9 +34,9 @@ class EditRegistration < WasteCarriersEngine::TransientRegistration
   }.freeze
 
   def registration
-    return @_registration if defined?(@_registration)
+    return @registration if defined?(@registration)
 
-    @_registration = WasteCarriersEngine::Registration.find_by(reg_identifier: reg_identifier)
+    @registration = WasteCarriersEngine::Registration.find_by(reg_identifier: reg_identifier)
   end
 
   def prepare_for_payment(mode, user)

--- a/app/models/edit_registration.rb
+++ b/app/models/edit_registration.rb
@@ -34,7 +34,9 @@ class EditRegistration < WasteCarriersEngine::TransientRegistration
   }.freeze
 
   def registration
-    @_registration ||= WasteCarriersEngine::Registration.find_by(reg_identifier: reg_identifier)
+    return @_registration if defined?(@_registration)
+
+    @_registration = WasteCarriersEngine::Registration.find_by(reg_identifier: reg_identifier)
   end
 
   def prepare_for_payment(mode, user)

--- a/app/models/order_copy_cards_registration.rb
+++ b/app/models/order_copy_cards_registration.rb
@@ -12,7 +12,9 @@ class OrderCopyCardsRegistration < WasteCarriersEngine::TransientRegistration
   instance_delegate %i[contact_address contact_email registered_address] => :registration
 
   def registration
-    @_registration ||= WasteCarriersEngine::Registration.find_by(reg_identifier: reg_identifier)
+    return @_registration if defined?(@_registration)
+
+    @_registration = WasteCarriersEngine::Registration.find_by(reg_identifier: reg_identifier)
   end
 
   def prepare_for_payment(mode, user)

--- a/app/models/order_copy_cards_registration.rb
+++ b/app/models/order_copy_cards_registration.rb
@@ -12,9 +12,9 @@ class OrderCopyCardsRegistration < WasteCarriersEngine::TransientRegistration
   instance_delegate %i[contact_address contact_email registered_address] => :registration
 
   def registration
-    return @_registration if defined?(@_registration)
+    return @registration if defined?(@registration)
 
-    @_registration = WasteCarriersEngine::Registration.find_by(reg_identifier: reg_identifier)
+    @registration = WasteCarriersEngine::Registration.find_by(reg_identifier: reg_identifier)
   end
 
   def prepare_for_payment(mode, user)

--- a/app/presenters/base_conviction_presenter.rb
+++ b/app/presenters/base_conviction_presenter.rb
@@ -71,6 +71,6 @@ class BaseConvictionPresenter < WasteCarriersEngine::BasePresenter
 
     # Check to see if any conviction_search_results are present
     conviction_search_results = key_people.map(&:conviction_search_result).compact
-    conviction_search_results.count.zero?
+    conviction_search_results.none?
   end
 end

--- a/app/services/process_refund_service.rb
+++ b/app/services/process_refund_service.rb
@@ -66,12 +66,6 @@ class ProcessRefundService < WasteCarriersEngine::BaseService
     refund.order_key = "#{payment.order_key}_PENDING"
   end
 
-  def order
-    return @_order if defined?(@_order)
-
-    @_order = finance_details.orders.find_by(order_code: payment.order_key)
-  end
-
   def card_payment?
     payment.govpay?
   end

--- a/app/services/process_refund_service.rb
+++ b/app/services/process_refund_service.rb
@@ -67,7 +67,9 @@ class ProcessRefundService < WasteCarriersEngine::BaseService
   end
 
   def order
-    @_order ||= finance_details.orders.find_by(order_code: payment.order_key)
+    return @_order if defined?(@_order)
+
+    @_order = finance_details.orders.find_by(order_code: payment.order_key)
   end
 
   def card_payment?

--- a/app/services/reports/generate_boxi_files_service.rb
+++ b/app/services/reports/generate_boxi_files_service.rb
@@ -59,11 +59,11 @@ module Reports
     end
 
     def registrations
-      @_registrations ||= WasteCarriersEngine::Registration.all
+      @registrations ||= WasteCarriersEngine::Registration.all
     end
 
     def registration_serializers
-      @_registration_serializers ||= REGISTRATION_SERIALIZERS.map do |serializer_class|
+      @registration_serializers ||= REGISTRATION_SERIALIZERS.map do |serializer_class|
         serializer_class.new(dir_path)
       end
     end

--- a/app/services/status_tag_service.rb
+++ b/app/services/status_tag_service.rb
@@ -79,6 +79,6 @@ class StatusTagService < WasteCarriersEngine::BaseService
   end
 
   def registration_or_submitted_renewal?
-    @_registration_or_submitted_renewal ||= submitted_renewal? || !transient?
+    @registration_or_submitted_renewal ||= submitted_renewal? || !transient?
   end
 end

--- a/lib/tasks/one_off/fix_communications_opted_in.rake
+++ b/lib/tasks/one_off/fix_communications_opted_in.rake
@@ -8,7 +8,7 @@ namespace :one_off do
       expires_on: { "$gte": 40.months.ago.beginning_of_day }
     )
 
-    if regs_with_unset_opted_in.count.positive?
+    if regs_with_unset_opted_in.any?
       puts "Updating #{regs_with_unset_opted_in.count} registration(s)" unless Rails.env.test?
       time_start = Time.zone.now
       WasteCarriersEngine::Registration.collection.update_many(

--- a/spec/requests/refunds_spec.rb
+++ b/spec/requests/refunds_spec.rb
@@ -150,6 +150,10 @@ RSpec.describe "Refunds" do
         patch resource_refund_path(registration, refund.govpay_id)
       end
 
+      it "returns a HTTP :found response" do
+        expect(response).to have_http_status(:found)
+      end
+
       it "calls the refund update service" do
         expect(WasteCarriersEngine::GovpayUpdateRefundStatusService).to have_received(:run)
       end


### PR DESCRIPTION
This change updates refunds_controller to use the recently updated WasteCarriersEngine::GovpayUpdateRefundStatusService parameter structure.
https://eaflood.atlassian.net/browse/RUBY-4002