### PR TITLE
[RUBY-4304] Fix issue with copy-card orders not being in export

### DIFF
--- a/app/services/order_copy_cards_completion_service.rb
+++ b/app/services/order_copy_cards_completion_service.rb
@@ -29,7 +29,7 @@ class OrderCopyCardsCompletionService < WasteCarriersEngine::BaseService
     registration.save!
 
     # Log the order items only if payment is complete.
-    if @transient_registration.unpaid_balance?
+    if registration.unpaid_balance?
       # Orders paid using alternate payment methods are not currently
       # included in the card order export. Just log these.
       Rails.logger.warn("Copy card order payment incomplete " \
@@ -44,7 +44,7 @@ class OrderCopyCardsCompletionService < WasteCarriersEngine::BaseService
   end
 
   def send_confirmation_email
-    if @transient_registration.unpaid_balance?
+    if registration.unpaid_balance?
       Notify::CopyCardsAwaitingPaymentEmailService
         .run(registration: registration, order: cached_copy_cards_order)
     else

--- a/spec/services/order_copy_cards_completion_service_spec.rb
+++ b/spec/services/order_copy_cards_completion_service_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe OrderCopyCardsCompletionService do
     # Ensure registration activation date is prior to the card order date
     before do
       allow(registration).to receive(:save!)
-      allow(registration.finance_details).to receive(:update_balance)
+      allow(registration.finance_details).to receive(:update_balance).and_call_original
       allow(transient_registration).to receive(:delete)
 
       registration.metaData.dateActivated = 1.month.ago
@@ -89,6 +89,23 @@ RSpec.describe OrderCopyCardsCompletionService do
 
       it "does not create an order item log" do
         expect { described_class.run(transient_registration) }.not_to change(WasteCarriersEngine::OrderItemLog, :count).from(0)
+      end
+    end
+
+    context "when the payment has already been recorded against the registration" do
+      before do
+        registration.finance_details.payments << build(:payment, :cheque, amount: Rails.configuration.card_charge)
+      end
+
+      it_behaves_like "completes the order", Notify::CopyCardsOrderCompletedEmailService
+
+      it "creates an order item log for the copy cards order" do
+        copy_card_order_item = transient_finance_details.orders.first.order_items.first
+
+        expect { described_class.run(transient_registration) }
+          .to change {
+            WasteCarriersEngine::OrderItemLog.where(order_item_id: copy_card_order_item.id).count
+          }.from(0).to(1)
       end
     end
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-4304

This fixes an edge case where a manual payment is recorded before the copy-card order is fully completed.

In that scenario, the data is temporarily split:
  - the payment is on the real registration
  - the copy-card order is still on the transient copy-card registration
  - 

  When the copy-card order is completed, the transient order is merged into the real registration. The old code checked whether the transient registration was paid before creating a log, but that could still look unpaid because the payment was on the real registration. As a result, no OrderItemLog was created, so the paid copy-card order was missing from the export.

  The fix checks the real registration balance after the merge. At that point the real registration has both the payment and the copy-card order, so the export log is created correctly.

A spec has been added for this edge case