### PR TITLE
Release/v1.36.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,25 @@
 
 ## [Unreleased](https://github.com/defra/waste-carriers-back-office/tree/HEAD)
 
-[Full Changelog](https://github.com/defra/waste-carriers-back-office/compare/v1.36.1...HEAD)
+[Full Changelog](https://github.com/defra/waste-carriers-back-office/compare/v1.36.2...HEAD)
 
 **Merged pull requests:**
 
+- Bump waste\_carriers\_engine from `9e7db7a` to `0bb3c95` [\#2334](https://github.com/DEFRA/waste-carriers-back-office/pull/2334) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Feature/ruby 4335 wcr security enable bundler cooldown give new gems a few days to be vetted [\#2333](https://github.com/DEFRA/waste-carriers-back-office/pull/2333) ([brujeo](https://github.com/brujeo))
+- Bump waste\_carriers\_engine from `3f7611e` to `9e7db7a` [\#2326](https://github.com/DEFRA/waste-carriers-back-office/pull/2326) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump net-imap from 0.6.4 to 0.6.4.1 [\#2320](https://github.com/DEFRA/waste-carriers-back-office/pull/2320) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump spring from 4.5.0 to 4.6.0 [\#2318](https://github.com/DEFRA/waste-carriers-back-office/pull/2318) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump waste\_carriers\_engine from `33cc560` to `3f7611e` [\#2316](https://github.com/DEFRA/waste-carriers-back-office/pull/2316) ([dependabot[bot]](https://github.com/apps/dependabot))
+- RUBY-4265 Update Ruby to 3.4.6 [\#2313](https://github.com/DEFRA/waste-carriers-back-office/pull/2313) ([jjromeo](https://github.com/jjromeo))
+
+## [v1.36.2](https://github.com/defra/waste-carriers-back-office/tree/v1.36.2) (2026-05-09)
+
+[Full Changelog](https://github.com/defra/waste-carriers-back-office/compare/v1.36.1...v1.36.2)
+
+**Merged pull requests:**
+
+- Release/v1.36.2 [\#2308](https://github.com/DEFRA/waste-carriers-back-office/pull/2308) ([brujeo](https://github.com/brujeo))
 - Bump waste\_carriers\_engine from `1bb166d` to `33cc560` [\#2307](https://github.com/DEFRA/waste-carriers-back-office/pull/2307) ([dependabot[bot]](https://github.com/apps/dependabot))
 - Bump devise from 5.0.3 to 5.0.4 [\#2306](https://github.com/DEFRA/waste-carriers-back-office/pull/2306) ([dependabot[bot]](https://github.com/apps/dependabot))
 - Bump nokogiri from 1.19.2 to 1.19.3 [\#2305](https://github.com/DEFRA/waste-carriers-back-office/pull/2305) ([dependabot[bot]](https://github.com/apps/dependabot))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -310,7 +310,7 @@ GEM
       domain_name (~> 0.5)
     httpi (3.0.1)
       rack
-    i18n (1.15.1)
+    i18n (1.15.2)
       concurrent-ruby (~> 1.0)
     io-console (0.8.2)
     io-endpoint (0.17.2)
@@ -329,7 +329,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    json (2.20.0)
+    json (2.19.9)
     jwt (2.10.3)
       base64
     kaminari (1.2.2)
@@ -420,7 +420,7 @@ GEM
       rackup (>= 1.0.1)
       rake (>= 12.3.3)
     phonelib (0.10.22)
-    pp (0.6.3)
+    pp (0.6.4)
       prettyprint
     prettyprint (0.2.0)
     prism (1.9.0)
@@ -545,7 +545,7 @@ GEM
     rubocop-factory_bot (2.28.0)
       lint_roller (~> 1.1)
       rubocop (~> 1.72, >= 1.72.1)
-    rubocop-rails (2.35.4)
+    rubocop-rails (2.35.5)
       activesupport (>= 4.2.0)
       lint_roller (~> 1.1)
       rack (>= 1.1)


### PR DESCRIPTION
- Update CHANGELOG.md

- Bump gem dependencies
    
    Updated gems:
      - i18n: 1.15.1 -> 1.15.2
      - json: 2.20.0 -> 2.19.9
      - pp: 0.6.3 -> 0.6.4
      - rubocop-rails: 2.35.4 -> 2.35.5