### PR TITLE
Release/v1.36.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,23 @@
 
 ## [Unreleased](https://github.com/defra/waste-carriers-back-office/tree/HEAD)
 
-[Full Changelog](https://github.com/defra/waste-carriers-back-office/compare/v1.36.2...HEAD)
+[Full Changelog](https://github.com/defra/waste-carriers-back-office/compare/v1.36.3...HEAD)
+
+**Fixed bugs:**
+
+- \[RUBY-4304\] Fix issue with copy-card orders not being in export [\#2332](https://github.com/DEFRA/waste-carriers-back-office/pull/2332) ([jjromeo](https://github.com/jjromeo))
 
 **Merged pull requests:**
 
+- Feature/ruby 4356 wcr remove deregistration functionality [\#2340](https://github.com/DEFRA/waste-carriers-back-office/pull/2340) ([brujeo](https://github.com/brujeo))
+
+## [v1.36.3](https://github.com/defra/waste-carriers-back-office/tree/v1.36.3) (2026-06-29)
+
+[Full Changelog](https://github.com/defra/waste-carriers-back-office/compare/v1.36.2...v1.36.3)
+
+**Merged pull requests:**
+
+- Release/v1.36.3 [\#2335](https://github.com/DEFRA/waste-carriers-back-office/pull/2335) ([brujeo](https://github.com/brujeo))
 - Bump waste\_carriers\_engine from `9e7db7a` to `0bb3c95` [\#2334](https://github.com/DEFRA/waste-carriers-back-office/pull/2334) ([dependabot[bot]](https://github.com/apps/dependabot))
 - Feature/ruby 4335 wcr security enable bundler cooldown give new gems a few days to be vetted [\#2333](https://github.com/DEFRA/waste-carriers-back-office/pull/2333) ([brujeo](https://github.com/brujeo))
 - Bump waste\_carriers\_engine from `3f7611e` to `9e7db7a` [\#2326](https://github.com/DEFRA/waste-carriers-back-office/pull/2326) ([dependabot[bot]](https://github.com/apps/dependabot))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,7 +114,7 @@ GEM
       gyoku (>= 0.4.0)
       nokogiri
     ast (2.4.3)
-    async (2.39.0)
+    async (2.41.0)
       console (~> 1.29)
       fiber-annotation
       io-event (~> 1.11)
@@ -139,7 +139,7 @@ GEM
     aws-eventstream (1.4.0)
     aws-healthcheck (2.0.0)
       railties (>= 3.0)
-    aws-partitions (1.1261.0)
+    aws-partitions (1.1262.0)
     aws-sdk-core (3.252.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
@@ -314,7 +314,7 @@ GEM
       concurrent-ruby (~> 1.0)
     io-console (0.8.2)
     io-endpoint (0.17.2)
-    io-event (1.16.2)
+    io-event (1.18.0)
     io-stream (0.13.1)
     irb (1.18.0)
       pp (>= 0.6.0)
@@ -329,7 +329,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    json (2.19.9)
+    json (2.20.0)
     jwt (2.10.3)
       base64
     kaminari (1.2.2)
@@ -353,7 +353,7 @@ GEM
     loofah (2.25.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    mail (2.9.1)
+    mail (2.9.0)
       logger
       mini_mime (>= 0.1.1)
       net-imap
@@ -366,7 +366,7 @@ GEM
     mime-types (3.7.0)
       logger
       mime-types-data (~> 3.2025, >= 3.2025.0507)
-    mime-types-data (3.2026.0701)
+    mime-types-data (3.2026.0414)
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
     minitest (5.27.0)
@@ -414,7 +414,7 @@ GEM
     parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
-    passenger (6.1.5)
+    passenger (6.1.6)
       logger (>= 1.7.0)
       rack (>= 1.6.13)
       rackup (>= 1.0.1)
@@ -541,7 +541,7 @@ GEM
     rubocop-ast (1.49.1)
       parser (>= 3.3.7.2)
       prism (~> 1.7)
-    rubocop-capybara (2.23.0)
+    rubocop-capybara (3.0.0)
       lint_roller (~> 1.1)
       rubocop (~> 1.81)
     rubocop-factory_bot (2.28.0)
@@ -566,7 +566,7 @@ GEM
       rubocop-rspec (~> 3.5)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
-    rubyzip (3.4.0)
+    rubyzip (3.4.1)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.4.0)
@@ -599,7 +599,7 @@ GEM
     simplecov-html (0.13.2)
     simplecov_json_formatter (0.1.4)
     simpleidn (0.2.3)
-    spring (4.6.0)
+    spring (4.7.0)
     sprockets (4.2.2)
       concurrent-ruby (~> 1.0)
       logger


### PR DESCRIPTION
- Update CHANGELOG.md for v1.36.4
- Updated gems:
      - async: 2.39.0 -> 2.41.0
      - aws-partitions: 1.1261.0 -> 1.1262.0
      - io-event: 1.16.2 -> 1.18.0
      - json: 2.19.9 -> 2.20.0
      - mail: 2.9.1 -> 2.9.0
      - mime-types-data: 3.2026.0701 -> 3.2026.0414
      - passenger: 6.1.5 -> 6.1.6
      - rubocop-capybara: 2.23.0 -> 3.0.0
      - rubyzip: 3.4.0 -> 3.4.1
      - spring: 4.6.0 -> 4.7.0