### PR TITLE
[RUBY-4340] Communication history review fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,7 +64,7 @@ gem "defra_ruby_aws"
 # Use the waste carriers engine for the user journey
 gem "waste_carriers_engine",
     git: "https://github.com/DEFRA/waste-carriers-engine",
-    branch: "main"
+    branch: "RUBY-4340-add-subject-to-communication-records"
 
 # Use the Defra Ruby Features gem to allow users with the correct permissions to
 # manage feature toggle (create / update / delete) from the back-office.

--- a/Gemfile
+++ b/Gemfile
@@ -64,7 +64,7 @@ gem "defra_ruby_aws"
 # Use the waste carriers engine for the user journey
 gem "waste_carriers_engine",
     git: "https://github.com/DEFRA/waste-carriers-engine",
-    branch: "RUBY-4340-add-subject-to-communication-records"
+    branch: "main"
 
 # Use the Defra Ruby Features gem to allow users with the correct permissions to
 # manage feature toggle (create / update / delete) from the back-office.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: 706c4e40b7e507e02e474dcf8ee2f098a5e834ce
-  branch: main
+  revision: 8c5c5c4fe2b7e42992caf2664ff4396958a8d273
+  branch: RUBY-4340-add-subject-to-communication-records
   specs:
     waste_carriers_engine (0.0.1)
       aasm (~> 5.5.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DEFRA/waste-carriers-engine
-  revision: 8c5c5c4fe2b7e42992caf2664ff4396958a8d273
-  branch: RUBY-4340-add-subject-to-communication-records
+  revision: 62e65bb9a120534a401d70e291c00a6477988e5a
+  branch: main
   specs:
     waste_carriers_engine (0.0.1)
       aasm (~> 5.5.0)

--- a/app/helpers/communication_records_helper.rb
+++ b/app/helpers/communication_records_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module CommunicationRecordsHelper
-  NOTIFY_ALLOWED_TAGS = %w[p a ul ol li h1 h2 h3 h4 h5 h6 blockquote hr br].freeze
+  NOTIFY_ALLOWED_TAGS = %w[p a ul ol li h2 h3 h4 h5 h6 blockquote hr br].freeze
   NOTIFY_ALLOWED_ATTRS = %w[href class].freeze
 
   # Render a Notify message body (Notify markdown) as GOV.UK Frontend HTML.
@@ -12,6 +12,9 @@ module CommunicationRecordsHelper
     renderer = GovukMarkdown::Renderer.new({ headings_start_with: "s" }, { link_attributes: { class: "govuk-link" } })
     # lax_spacing: Notify omits the blank line before lists that Redcarpet needs
     html = Redcarpet::Markdown.new(renderer, tables: true, no_intra_emphasis: true, lax_spacing: true).render(markdown)
+
+    # Demote headings one level (h1 -> h2, h2 -> h3) so the page keeps a single h1
+    html = html.gsub(%r{<(/?)h2\b}, '<\1h3').gsub(%r{<(/?)h1\b}, '<\1h2')
 
     sanitize(html, tags: NOTIFY_ALLOWED_TAGS, attributes: NOTIFY_ALLOWED_ATTRS) # body carries personalisation
   end

--- a/app/views/communication_records/show.html.erb
+++ b/app/views/communication_records/show.html.erb
@@ -10,7 +10,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <dl class="govuk-summary-list govuk-summary-list--no-border">
+    <dl class="govuk-summary-list">
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key"><%= t(".comms_label") %></dt>
         <dd class="govuk-summary-list__value"><%= @communication_record.comms_label %></dd>
@@ -35,6 +35,12 @@
         <dt class="govuk-summary-list__key"><%= t(".delivery_status") %></dt>
         <dd class="govuk-summary-list__value"><%= @communication_record.delivery_status %></dd>
       </div>
+      <% if @communication_record.subject.present? %>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key"><%= t(".subject") %></dt>
+          <dd class="govuk-summary-list__value"><%= @communication_record.subject %></dd>
+        </div>
+      <% end %>
       <% if @communication_record.content.present? %>
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key"><%= t(".content") %></dt>

--- a/config/locales/communication_records.en.yml
+++ b/config/locales/communication_records.en.yml
@@ -16,4 +16,5 @@ en:
       sent_to: "Sent to"
       sent_at: "Sent on"
       delivery_status: "Delivery status"
+      subject: "Subject"
       content: "Content"

--- a/spec/factories/communication_record.rb
+++ b/spec/factories/communication_record.rb
@@ -11,6 +11,7 @@ FactoryBot.define do
       notification_type { "email" }
       comms_label       { "Upper tier waste carrier registration email V1" }
       sent_to           { "test@email.com" }
+      subject           { "Waste carrier registration CBDU1 completed" }
       content           { "Dear Jane Doe,\r\nPlease pay for your waste carrier registration." }
     end
 

--- a/spec/helpers/communication_records_helper_spec.rb
+++ b/spec/helpers/communication_records_helper_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CommunicationRecordsHelper do
+  describe "#notify_content_html" do
+    subject(:html) { helper.notify_content_html(content) }
+
+    context "with blank content" do
+      let(:content) { nil }
+
+      it { expect(html).to be_nil }
+    end
+
+    context "with Notify markdown content" do
+      let(:content) do
+        "Dear Jane Doe,\r\n\r\n" \
+          "#Please pay for your registration\r\n" \
+          "You need to include:\r\n" \
+          "*your registration number\r\n" \
+          "*the amount you paid\r\n\r\n" \
+          "[Renew online](https://example.gov.uk/renew)"
+      end
+
+      it "renders paragraphs with GOV.UK classes" do
+        expect(html).to include('<p class="govuk-body-m">Dear Jane Doe,</p>')
+      end
+
+      it "demotes headings so the page keeps a single h1" do
+        expect(html).to include('<h2 class="govuk-heading-s">Please pay for your registration</h2>')
+        expect(html).not_to include("<h1")
+      end
+
+      it "renders bullets without a space after the marker as a list" do
+        expect(html).to include('<ul class="govuk-list govuk-list--bullet">')
+        expect(html).to include("<li>your registration number</li>")
+      end
+
+      it "renders links with the govuk-link class" do
+        expect(html).to include('<a href="https://example.gov.uk/renew" class="govuk-link">Renew online</a>')
+      end
+    end
+
+    context "with HTML in the content" do
+      let(:content) { "Dear <script>alert(1)</script> <b>Jane</b>," }
+
+      it "strips markup that is not in the allowed list" do
+        expect(html).not_to include("<script")
+        expect(html).not_to include("<b>")
+        expect(html).to include("Jane")
+      end
+    end
+  end
+end

--- a/spec/requests/communication_records_spec.rb
+++ b/spec/requests/communication_records_spec.rb
@@ -121,6 +121,11 @@ RSpec.describe "Communication Records" do
         expect(response.body).to include(communication_record.delivery_status)
       end
 
+      it "includes the communication subject" do
+        expect(response.body).to include(">Subject</dt>")
+        expect(response.body).to include(communication_record.subject)
+      end
+
       it "includes the communication content" do
         expect(response.body).to include(">Content</dt>")
         expect(response.body).to include("Please pay for your waste carrier registration.")
@@ -129,7 +134,7 @@ RSpec.describe "Communication Records" do
 
     context "when the communication record has no persisted content" do
       let(:communication_record) do
-        create(:communication_record, :email, registration: registration, content: nil, delivery_status: nil)
+        create(:communication_record, :email, registration: registration, subject: nil, content: nil, delivery_status: nil)
       end
 
       before do
@@ -142,6 +147,10 @@ RSpec.describe "Communication Records" do
 
       it "does not include the content row" do
         expect(response.body).not_to include(">Content</dt>")
+      end
+
+      it "does not include the subject row" do
+        expect(response.body).not_to include(">Subject</dt>")
       end
     end
 

--- a/spec/services/notify/digital_renewal_sms_service_spec.rb
+++ b/spec/services/notify/digital_renewal_sms_service_spec.rb
@@ -14,7 +14,11 @@ RSpec.describe Notify::DigitalRenewalSmsService do
 
     let(:client) { instance_double(Notifications::Client) }
     let(:notifications_client_response_notification) do
-      instance_double(Notifications::Client::ResponseNotification, content: { "body" => "Text message content" })
+      instance_double(
+        Notifications::Client::ResponseNotification,
+        id: "740e5834-3a29-46b4-9a6f-16142fde533a",
+        content: { "body" => "Text message content" }
+      )
     end
 
     before do

--- a/spec/support/shared_examples/can_create_communication_record.rb
+++ b/spec/support/shared_examples/can_create_communication_record.rb
@@ -31,6 +31,7 @@ RSpec.shared_examples "can create a communication record" do |notification_type|
       expect(registration.communication_records.last[:comms_label]).to eq(expected_communication_record_attrs[:comms_label])
       expect(registration.communication_records.last[:sent_at]).to eq(expected_communication_record_attrs[:sent_at])
       expect(registration.communication_records.last[:sent_to]).to eq(expected_communication_record_attrs[:sent_to])
+      expect(registration.communication_records.last[:subject]).to eq(response.content["subject"])
       expect(registration.communication_records.last[:content]).to eq(response.content["body"])
       expect(registration.communication_records.last[:delivery_status]).to eq("sent")
     end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-4340

Review fixes for the communication history detail page:

- Add the message subject, captured from the Notify response
- Add lines between the data fields, following the WEX page format
- Fix the heading hierarchy in the rendered message content, so the page keeps a single h1

<img width="930" height="1006" alt="image" src="https://github.com/user-attachments/assets/3b4a22cc-4fef-46f6-9c9d-4053faa0d859" />
