### PR TITLE
[RUBY-4108] Update user deactivated message to include NCCC email address

### DIFF
--- a/app/views/pages/deactivated.html.erb
+++ b/app/views/pages/deactivated.html.erb
@@ -2,6 +2,6 @@
 
 <div class="govuk-grid-row">
   <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
-  <p class="govuk-body"><%= t(".text") %></p>
+  <p class="govuk-body"><%= t(".text_html") %></p>
   <p class="govuk-body"><%= link_to t(".sign_out_link"), main_app.destroy_user_session_path %></p>
 </div>

--- a/config/locales/pages/deactivated.en.yml
+++ b/config/locales/pages/deactivated.en.yml
@@ -3,5 +3,5 @@ en:
     deactivated:
       title: "Your account has been deactivated"
       heading: "Your account has been deactivated"
-      text: "You cannot use the Waste Carriers Back Office unless your account is active. If you believe you should have access, contact an NCCC super user."
+      text_html: "You cannot use the Waste Carriers Back Office unless your account is active. If you believe you should have access, contact <a class=\"govuk-link\" href=\"mailto:nccc-carrierbroker@environment-agency.gov.uk\">nccc-carrierbroker@environment-agency.gov.uk</a>."
       sign_out_link: "Sign out"

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe "Pages" do
 
         expect(response).to have_http_status(:ok)
         expect(response).to render_template(:deactivated)
+        expect(response.body).to include("nccc-carrierbroker@environment-agency.gov.uk")
       end
     end
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-4108

Replace "contact an NCCC super user" on the deactivated account page with a mailto link to nccc-carrierbroker@environment-agency.gov.uk, so deactivated users know how to regain access.